### PR TITLE
PIE-2311 Remove int type casting around time.duration

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -149,12 +149,12 @@ func (r Rspec) Report(w io.Writer, testCases []api.TestCase) error {
 
 	// print each row
 	for _, testCase := range testCases {
-		estimatedDuration := 0
-		if testCase.EstimatedDuration != nil {
-			// Estimated duration from API is an integer in microsecond
-			estimatedDuration = *testCase.EstimatedDuration * int(time.Microsecond)
-		}
 
+		var estimatedDuration time.Duration
+
+		if testCase.EstimatedDuration != nil {
+			estimatedDuration = time.Duration(*testCase.EstimatedDuration) * time.Microsecond
+		}
 		// Actual duration from rspec report is in second
 		actualDuration := executionByFile[testCase.Path] * float64(time.Second)
 
@@ -163,7 +163,7 @@ func (r Rspec) Report(w io.Writer, testCases []api.TestCase) error {
 		fmt.Fprintf(w,
 			"%-*s | %*s | %*s | %*s |\n",
 			fileNameWidth, testCase.Path,
-			estimatedDurationWidth, time.Duration(estimatedDuration).Truncate(time.Millisecond).String(),
+			estimatedDurationWidth, estimatedDuration.Truncate(time.Millisecond).String(),
 			actualDurationWidth, time.Duration(actualDuration).Truncate(time.Millisecond).String(),
 			predictionErrorWidth, fmt.Sprintf("%.2f%%", predictionError),
 		)


### PR DESCRIPTION
**Description**
In the `Report` func, we cast `time.Duration` (time.Microsecond) values to `int`, however, we prefer to work in `time.Duration` as they're integers under the hood. 

Suggested changes on linear ticket:

> So (after checking `EstimatedDuration != nil`) I would write `time.Duration(*testCase.EstimatedDuration) * time.Microsecond` instead of  `*testCase.EstimatedDuration * int(time.Microsecond)` - this avoids a cast to `time.Duration` later on, and if you need to (say) do some debug logging of `estimatedDuration` in the middle, it will format as a duration automatically.

**Context**
https://linear.app/buildkite/issue/PIE-2311/remove-casting-to-int-around-timeduration

**Testing**
The splitter client pipeline passed https://buildkite.com/buildkite/test-splitter-client/builds/94

I didn't add more tests for the `Report` func as we don't think we are going to keep this for long time. Let me know if we believe we need to have more test coverage on it.
