### PR TITLE
[Sketch] Support other testing frameworks

### DIFF
--- a/internal/runner/go.go
+++ b/internal/runner/go.go
@@ -1,0 +1,17 @@
+package runner
+
+import "github.com/buildkite/test-splitter/internal/api"
+
+type GoTests struct{}
+
+func (GoTests) FindFiles() ([]string, error) {
+	return nil, nil
+}
+
+func (GoTests) Run(testCases []string) error {
+	return nil
+}
+
+func (GoTests) Report([]api.TestCase) {
+
+}


### PR DESCRIPTION
### Description

Code I started writing in today's meeting, for future reference (not necessarily intended to be exactly how it should be done)

### Context

* We need to handle other testing frameworks. 
* We need a strategy for passing huge lists of test cases/files to test-running commands (such as rspec) or at least be able to handle that particular error from `Run`.

### Changes

* Introduce an interface with the three runner methods called by `main`
* Introduce a flag to switch between runner types
* Add a check for `syscall.E2BIG` errors from `cmd.Run` (good) and recursively split the test cases in half (maybe not so good)

### Testing

Not tested at all - some of the code isn't bad, but it's intended as a demo.