### PR TITLE
Add doc comments

### DIFF
--- a/internal/api/test_plan.go
+++ b/internal/api/test_plan.go
@@ -20,15 +20,18 @@ type Tests struct {
 	Format string     `json:"format"`
 }
 
+// Task represents the task for the given node.
 type Task struct {
 	NodeNumber int   `json:"node_number"`
 	Tests      Tests `json:"tests"`
 }
 
+// TestPlan represents the entire test plan.
 type TestPlan struct {
 	Tasks map[string]Task `json:"tasks"`
 }
 
+// TestPlanParams represents the config params sent when fetching a test plan.
 type TestPlanParams struct {
 	SuiteToken  string `json:"suite_token"`
 	Mode        string `json:"mode"`

--- a/internal/runner/file.go
+++ b/internal/runner/file.go
@@ -6,7 +6,7 @@ import (
 )
 
 // readJsonFile reads a json file and unmarshals it into v.
-// v must be a pointer to a struct
+// v must be a pointer to a struct.
 //
 // https://golang.org/pkg/encoding/json/#Unmarshal
 func readJsonFile(filename string, v any) error {

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -13,9 +13,15 @@ import (
 	"github.com/buildkite/test-splitter/internal/api"
 )
 
+// In future, Rspec will implement an interface that defines
+// behaviour common to all test runners.
+// For now, Rspec provides rspec specific behaviour to execute
+// and report on tests in the Rspec framework.
 type Rspec struct {
 }
 
+// GetFiles returns an array of file names, for files in
+// the "spec" directory that end in "spec.rb".
 func (Rspec) GetFiles() []string {
 	var files []string
 
@@ -40,6 +46,7 @@ func (Rspec) GetFiles() []string {
 	return files
 }
 
+// Run executes the given testCases via bin/rspec.
 func (Rspec) Run(testCases []string) error {
 	args := []string{"--options", ".rspec.ci"}
 
@@ -54,6 +61,7 @@ func (Rspec) Run(testCases []string) error {
 	return cmd.Run()
 }
 
+// RspecExample defines metadata for an rspec example (test).
 type RspecExample struct {
 	Id              string  `json:"id"`
 	Description     string  `json:"description"`
@@ -64,12 +72,18 @@ type RspecExample struct {
 	RunTime         float64 `json:"run_time"`
 }
 
+// RspecReport defines metadata for an rspec generated test report.
 type RspecReport struct {
 	Version  string         `json:"version"`
 	Seed     int            `json:"seed"`
 	Examples []RspecExample `json:"examples"`
 }
 
+// Report produces a report that surfaces estimated and actual
+// performance data for Rspec tests files.
+//
+// This is helpful for us in development, not sure if we will
+// continue to maintain this functionality.
 func (Rspec) Report(testCases []api.TestCase) {
 	// get all rspec json files
 	reportFiles, err := filepath.Glob("tmp/rspec-*.json")


### PR DESCRIPTION
Adding doc comments for the remaining top level exported identifiers. Comment only change 
