### PR TITLE
Return err from getFiles

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -22,7 +21,7 @@ type Rspec struct {
 
 // GetFiles returns an array of file names, for files in
 // the "spec" directory that end in "spec.rb".
-func (Rspec) GetFiles() []string {
+func (Rspec) GetFiles() ([]string, error) {
 	var files []string
 
 	// Use filepath.Walk to traverse the directory recursively
@@ -40,10 +39,10 @@ func (Rspec) GetFiles() []string {
 
 	// Handle potential error from filepath.Walk
 	if err != nil {
-		log.Fatal("Error when getting files: ", err)
+		return nil, err
 	}
 
-	return files
+	return files, nil
 }
 
 // Run executes the given testCases via bin/rspec.

--- a/main.go
+++ b/main.go
@@ -27,7 +27,10 @@ func main() {
 
 	// get files
 	fmt.Println("--- :test-analytics: Gathering test plan context and creating test plan request 🐿️")
-	files := testRunner.GetFiles()
+	files, err := testRunner.GetFiles()
+	if err != nil {
+		log.Fatalf("Couldn't get files: %v", err)
+	}
 	fmt.Printf("Found %d files\n", len(files))
 
 	// fetch env vars


### PR DESCRIPTION
Return err from GetFiles so that error handling can be handled in the layer above. Haven't added a test for this as currently the functionality depends on two hard coded strings - lmk if you think we should add one!