### PR TITLE
PIE-2371 Use fallback mode in client when exceeding retry limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,9 +72,7 @@ func main() {
 		Format: "files",
 	}
 
-	var testPlan plan.TestPlan
-
-	testPlan, err = api.FetchTestPlan(fetchCtx, splitterPath, api.TestPlanParams{
+	testPlan, err := api.FetchTestPlan(fetchCtx, splitterPath, api.TestPlanParams{
 		SuiteToken:  suiteToken,
 		Mode:        mode,
 		Identifier:  identifier,


### PR DESCRIPTION
### Description

This PR is for using fallback mode in client when exceeding retry limit

### Context
https://linear.app/buildkite/issue/PIE-2371/use-fallback-mode-in-client-when-exceeding-retry-limit

### Changes

Use fallback mode in client when exceeding retry limit
### Testing

Verify the change with e2e tests ->`splitter pipeline`

I'm aware that there's no tests around this change. I'm thinking about extracting out the test plan fetching + fallback logic in the main function to make things easy to test. Keen to hear your thoughts.

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
