### PR TITLE
Terminate the client with the same exit code returned by the sub process (Rspec)

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,13 +96,11 @@ func main() {
 	for _, testCase := range thisNodeTask.Tests.Cases {
 		runnableTests = append(runnableTests, testCase.Path)
 	}
-	err = testRunner.Run(runnableTests)
-
-	if err != nil {
+	if err := testRunner.Run(runnableTests); err != nil {
 		if exitError := new(exec.ExitError); errors.As(err, &exitError) {
-			errorCode := exitError.ExitCode()
-			log.Printf("Rspec exits with error %d", errorCode)
-			os.Exit(errorCode)
+			exitCode := exitError.ExitCode()
+			log.Printf("Rspec exited with error %d", exitCode)
+			os.Exit(exitCode)
 		}
 		log.Fatalf("Couldn't run tests: %v", err)
 	}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
The test client spawns a sub process to run Rspec command. In the main function, when we receive an error from the sub process, we call `log.Fatal` that will terminate the client with exit code 1 to make sure that Rspec failure in the sub process also fails the job in the CI. However, the sub process can exit with any error code (other than 1). We need to update the implementation of the client to exit and return the same exit code that the sub process returned when there is an error.
