### PR TITLE
[TAT 96] Enable e2e for all branches 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,6 @@ steps:
   - trigger: buildkite-splitter
     key: e2e-tests
     label: ":bonezone: End-to-end Tests"
-    if: build.message =~ /\[e2e\]/i || build.branch == "main"
     depends_on: 
       - build-binary
     build:


### PR DESCRIPTION
### Description

The goal of this PR is to enable e2e test for all branches.

**Out of scope:**
We are not introducing the ability to bypass failure pipeline step/build 
More details: https://3.basecamp.com/3453178/buckets/33707278/messages/7225128272

### Context
https://linear.app/buildkite/issue/TAT-96/splitter-builds-are-broken-investigate

### Changes

Remove branch check and commit message check for running e2e
