### PR TITLE
Add functionality to pass in files via cmd line

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,12 +5,14 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildkite/test-splitter/internal/api"
@@ -23,10 +25,20 @@ func main() {
 	// TODO: detect test runner and use appropriate runner
 	testRunner := runner.Rspec{}
 
-	// get files
-	files, err := testRunner.GetFiles()
-	if err != nil {
-		log.Fatalf("Couldn't get files: %v", err)
+	// Gathering files
+	filesFlag := flag.String("files", "", "string of file names for splitting")
+	flag.Parse()
+
+	// see if cmd line files string had any files
+	files := strings.Split(*filesFlag, ",")
+
+	// if not get files from directory
+	if len(files) == 0 {
+		fs, err := testRunner.GetFiles()
+		if err != nil {
+			log.Fatalf("Couldn't get files: %v", err)
+		}
+		files = fs
 	}
 
 	// get config


### PR DESCRIPTION
This PR adds in the functionality to pass in a cmd line variable "files" that is used in place of a full file discovery via the spec directory. The "files" is a comma separated string of file paths e.g. `./test-splitter -files "spec/api/test_plan_spec.rb, spec/api/other_test_plan_spec.rb"`

This feature is intended for internal use only because we want to limit the number of files being split on our integration test pipeline, Buildkite Splitter, so we don't split the full test suite all the time as that uses a lot of compute. For this reason I haven't added any validation or error messages for the spec names - if a spec name is typo'd/invalid it'll result in the rspec cmd later not being able to be run. 