### PR TITLE
Fix cmd line argument handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,11 +29,11 @@ func main() {
 	filesFlag := flag.String("files", "", "string of file names for splitting")
 	flag.Parse()
 
-	// see if cmd line files string had any files
-	files := strings.Split(*filesFlag, ",")
+	var files []string
 
-	// if not get files from directory
-	if len(files) == 0 {
+	if *filesFlag != "" {
+		files = strings.Split(*filesFlag, ",")
+	} else {
 		fs, err := testRunner.GetFiles()
 		if err != nil {
 			log.Fatalf("Couldn't get files: %v", err)


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
e2e tests failed after we merge https://github.com/buildkite/test-splitter/pull/33.
@niceking and I had a pairing session and found an issue in the way we check the value of the command line argument `-files`. Apparently, splitting an empty string, return an array with empty string `[""]`, so the check is incorrect.
This PR fix such issue.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/TAT-106/e2e-pipeline-triggered-from-splitter-client-failed-due-to-unable-to
