### PR TITLE
[TAT-112] A short instruction for install and use test splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,4 @@ chmod +x test-splitter
 ./test-splitter # fetches the test plan for this node, and then executes the rspec tests
 ```
 
-## Release
-To release a new version, open a PR and update the version number in `version/VERSION`. 
-Once the PR is merged to `main`, a [release pipeline](https://buildkite.com/buildkite/test-splitter-client-release) will be triggered and the new version will be released.
-Currently, we only release to [GitHub](https://github.com/buildkite/test-splitter/releases). The release pipeline will generate the release notes and attach the compiled binary to the GitHub release.
 


### PR DESCRIPTION
### Description

We are going to make the repo public. A short instruction for install and use the test splitter is needed.
### Context

https://linear.app/buildkite/issue/TAT-112/adding-installation-instructions-to-readme

### Changes

Instructions to install the test splitter
Instructions to use the test splitter

