### PR TITLE
Update release process for bktec

### DIFF
--- a/.buildkite/steps/upload-linux-packages.sh
+++ b/.buildkite/steps/upload-linux-packages.sh
@@ -2,7 +2,7 @@
 
 file=${1}
 extension="${file##*.}"
-registry="test-splitter-${extension}"
+registry="test-engine-client-${extension}"
 audience="https://packages.buildkite.com/buildkite/${registry}"
 
 echo "--- :key: :buildkite: Fetching OIDC token for ${audience}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags: "-X 'main.Version=v{{ .Version }}'"
+    binary: bktec
 
 brews:
   - name: test-splitter

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ version: 2
 project_name: test-engine-client
 
 release:
-  name_template: Buildkite Test Engine Client v{{.Version}}
+  name_template: Test Engine Client v{{.Version}}
   draft: false
   prerelease: auto
   make_latest: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 version: 2
+project_name: test-engine-client
 
 release:
   name_template: Buildkite Test Engine Client v{{.Version}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,15 +19,16 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags: "-X 'main.Version=v{{ .Version }}'"
+    binary: bktec
 
 brews:
-  - name: test-engine-client
+  - name: bktec
     description: "Buildkite Test Engine Client"
     homepage: "https://github.com/buildkite/test-engine-client"
     skip_upload: auto
     directory: .
     test: |
-      version_output = shell_output("test-engine-client --version")
+      version_output = shell_output("bktec --version")
       assert_match "v#{version}\n", version_output
     repository:
       owner: buildkite
@@ -98,7 +99,7 @@ nfpms:
       - deb
       - rpm
     provides:
-      - test-engine-client
+      - bktec
 
 publishers:
   - name: buildkite-packages

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 release:
-  name_template: Test Splitter v{{.Version}}
+  name_template: Test Engine Client v{{.Version}}
   draft: false
   prerelease: auto
   make_latest: false
@@ -22,7 +22,7 @@ builds:
 
 brews:
   - name: test-splitter
-    description: "Buildkite test splitting client"
+    description: "Buildkite test engine client"
     homepage: "https://github.com/buildkite/test-splitter"
     skip_upload: auto
     directory: .
@@ -92,7 +92,7 @@ nfpms:
     id: linux-pkg
     homepage: https://github.com/buildkite/test-splitter
     maintainer: Buildkite <support@buildkite.com>
-    description: Buildkite test splitting client
+    description: Buildkite test engine client
     license: MIT
     formats:
       - deb

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
 brews:
   - name: test-splitter
     description: "Buildkite test engine client"
-    homepage: "https://github.com/buildkite/test-splitter"
+    homepage: "https://github.com/buildkite/test-engine-client"
     skip_upload: auto
     directory: .
     test: |
@@ -91,7 +91,7 @@ docker_manifests:
 nfpms:
   - vendor: Buildkite
     id: linux-pkg
-    homepage: https://github.com/buildkite/test-splitter
+    homepage: https://github.com/buildkite/test-engine-client
     maintainer: Buildkite <support@buildkite.com>
     description: Buildkite test engine client
     license: MIT

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,6 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags: "-X 'main.Version=v{{ .Version }}'"
-    binary: bktec
 
 brews:
   - name: test-splitter

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 release:
-  name_template: Test Engine Client v{{.Version}}
+  name_template: Buildkite Test Engine Client v{{.Version}}
   draft: false
   prerelease: auto
   make_latest: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,13 +21,13 @@ builds:
     ldflags: "-X 'main.Version=v{{ .Version }}'"
 
 brews:
-  - name: test-splitter
-    description: "Buildkite test engine client"
+  - name: test-engine-client
+    description: "Buildkite Test Engine Client"
     homepage: "https://github.com/buildkite/test-engine-client"
     skip_upload: auto
     directory: .
     test: |
-      version_output = shell_output("test-splitter --version")
+      version_output = shell_output("test-engine-client --version")
       assert_match "v#{version}\n", version_output
     repository:
       owner: buildkite
@@ -40,25 +40,25 @@ git:
 
 dockers:
   - image_templates:
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-amd64"
     dockerfile: "packaging/Dockerfile"
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-arm64"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-arm64"
     goarch: arm64
     dockerfile: "packaging/Dockerfile"
     build_flag_templates:
       - "--platform=linux/arm64"
   - image_templates:
-      - "buildkite/test-splitter:v{{ .Version }}-amd64"
+      - "buildkite/test-engine-client:v{{ .Version }}-amd64"
     # skip pushing image to Dockerhub if it's a prerelease
     skip_push: auto
     dockerfile: "packaging/Dockerfile"
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
-      - "buildkite/test-splitter:v{{ .Version }}-arm64"
+      - "buildkite/test-engine-client:v{{ .Version }}-arm64"
     # skip pushing image to Dockerhub if it's a prerelease
     skip_push: auto
     goarch: arm64
@@ -66,24 +66,24 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
 docker_manifests:
-  - name_template: "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}"
+  - name_template: "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}"
     image_templates:
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-arm64" 
-  - name_template: "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:latest"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-amd64"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-arm64" 
+  - name_template: "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:latest"
     image_templates:
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-amd64"
-      - "packages.buildkite.com/buildkite/test-splitter-docker/test-splitter:v{{ .Version }}-arm64"
-  - name_template: "buildkite/test-splitter:v{{ .Version }}"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-amd64"
+      - "packages.buildkite.com/buildkite/test-engine-client-docker/test-engine-client:v{{ .Version }}-arm64"
+  - name_template: "buildkite/test-engine-client:v{{ .Version }}"
     image_templates:
-      - "buildkite/test-splitter:v{{ .Version }}-amd64"
-      - "buildkite/test-splitter:v{{ .Version }}-arm64"
+      - "buildkite/test-engine-client:v{{ .Version }}-amd64"
+      - "buildkite/test-engine-client:v{{ .Version }}-arm64"
     # skip pushing manifest to Dockerhub if it's a prerelease
     skip_push: auto
-  - name_template: "buildkite/test-splitter:latest"
+  - name_template: "buildkite/test-engine-client:latest"
     image_templates:
-      - "buildkite/test-splitter:v{{ .Version }}-amd64"
-      - "buildkite/test-splitter:v{{ .Version }}-arm64"
+      - "buildkite/test-engine-client:v{{ .Version }}-amd64"
+      - "buildkite/test-engine-client:v{{ .Version }}-arm64"
     # skip pushing manifest to Dockerhub if it's a prerelease
     skip_push: auto
 
@@ -92,13 +92,13 @@ nfpms:
     id: linux-pkg
     homepage: https://github.com/buildkite/test-engine-client
     maintainer: Buildkite <support@buildkite.com>
-    description: Buildkite test engine client
+    description: Buildkite Test Engine Client
     license: MIT
     formats:
       - deb
       - rpm
     provides:
-      - test-splitter
+      - test-engine-client
 
 publishers:
   - name: buildkite-packages

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 
-COPY test-splitter /usr/local/bin/test-splitter
+COPY test-engine-client /usr/local/bin/test-engine-client
 
-ENTRYPOINT ["/usr/local/bin/test-splitter"]
+ENTRYPOINT ["/usr/local/bin/test-engine-client"]

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
 
-COPY test-engine-client /usr/local/bin/test-engine-client
+COPY bktec /usr/local/bin/bktec
 
-ENTRYPOINT ["/usr/local/bin/test-engine-client"]
+ENTRYPOINT ["/usr/local/bin/bktec"]


### PR DESCRIPTION
### Description

Update Goreleaser: 
- The binary name is called `bktec`
- The binary will be published to new dockerhub and package cloud repositories (with `test-engine-client` in the url) 
- The binary will be published to homebrew as `bktec`

### Testing

Verified the change locally by runing `goreleaser release --clean --skip publish --snapshot`. The binaries are created with name `bktec`

After merging this PR we can release v1.0.0-rc.1 to verify the actual release works
