### PR TITLE
Handle billing error

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,14 +208,14 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 
 	handleError := func(err error) (plan.TestPlan, error) {
 		if errors.Is(err, api.ErrRetryTimeout) {
-			fmt.Println("Could not fetch or create plan from server, using fallback mode. Your build may take longer than usual.")
+			fmt.Println("\033[33mCould not fetch or create plan from server, using fallback mode. Your build may take longer than usual.\033[0m")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
 
 		if billingError := new(api.BillingError); errors.As(err, &billingError) {
-			fmt.Println(billingError.Message)
-			fmt.Println("Using fallback mode. Your build may take longer than usual.")
+			fmt.Println("\033[33m" + billingError.Message)
+			fmt.Println("Using fallback mode. Your build may take longer than usual.\033[0m")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
@@ -231,7 +231,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 		// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
-			fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
+			fmt.Println("\033[33mError plan received, using fallback mode. Your build may take longer than usual.\033[0m")
 			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return testPlan, nil
 		}
@@ -257,7 +257,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
-		fmt.Println("Error plan received, using fallback mode. Your build may take longer than usual.")
+		fmt.Println("\033[33mError plan received, using fallback mode. Your build may take longer than usual.\033[0m")
 		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
 	}
 

--- a/main.go
+++ b/main.go
@@ -212,6 +212,14 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
+
+		if billingError := new(api.BillingError); errors.As(err, &billingError) {
+			fmt.Println(billingError.Message)
+			fmt.Println("Using fallback mode. Your build may take longer than usual.")
+			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
+			return p, nil
+		}
+
 		return plan.TestPlan{}, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -208,14 +208,14 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 
 	handleError := func(err error) (plan.TestPlan, error) {
 		if errors.Is(err, api.ErrRetryTimeout) {
-			fmt.Println("\033[33mCould not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
+			fmt.Println("⚠️ Could not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
 
 		if billingError := new(api.BillingError); errors.As(err, &billingError) {
-			fmt.Println("\033[33m" + billingError.Message)
-			fmt.Println("Falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
+			fmt.Println(billingError.Message)
+			fmt.Println("⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
@@ -231,7 +231,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 		// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
-			fmt.Println("\033[33mError plan received, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
+			fmt.Println("⚠️ Error plan received, falling back to non-intelligent splitting. Your build may take longer than usual.")
 			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return testPlan, nil
 		}
@@ -257,7 +257,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
-		fmt.Println("\033[33mError plan received, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
+		fmt.Println("⚠️ Error plan received, falling back to non-intelligent splitting. Your build may take longer than usual.")
 		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
 	}
 

--- a/main.go
+++ b/main.go
@@ -208,14 +208,14 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 
 	handleError := func(err error) (plan.TestPlan, error) {
 		if errors.Is(err, api.ErrRetryTimeout) {
-			fmt.Println("\033[33mCould not fetch or create plan from server, using fallback mode. Your build may take longer than usual.\033[0m")
+			fmt.Println("\033[33mCould not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
 
 		if billingError := new(api.BillingError); errors.As(err, &billingError) {
 			fmt.Println("\033[33m" + billingError.Message)
-			fmt.Println("Using fallback mode. Your build may take longer than usual.\033[0m")
+			fmt.Println("Falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
 			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return p, nil
 		}
@@ -231,7 +231,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 		// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
-			fmt.Println("\033[33mError plan received, using fallback mode. Your build may take longer than usual.\033[0m")
+			fmt.Println("\033[33mError plan received, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
 			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
 			return testPlan, nil
 		}
@@ -257,7 +257,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
-		fmt.Println("\033[33mError plan received, using fallback mode. Your build may take longer than usual.\033[0m")
+		fmt.Println("\033[33mError plan received, falling back to non-intelligent splitting. Your build may take longer than usual.\033[0m")
 		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
 	}
 


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We have updated the API to require the new billing plan. This PR updates the client to handle the billing error and switch to fallback mode. 

This is the output will be after the changes

```
http://api.buildkite.localhost/v2/analytics/organizations/buildkite/suites/buildkite/test_plan?identifier=fruitszxc/rspec
Billing Error: Test Splitting is not enabled on your plan: please upgrade at https://buildkite.com/organizations/buildkite/billing.
Using fallback mode. Your build may take longer than usual.
+++ Buildkite Test Engine Client: Running tests
rspec ./test/spec/fruits/apple_spec.rb ./test/spec/fruits/tomato_spec.rb --format documentation --format json --out ./tmp/rspec.json
...
```

