### PR TITLE
Update linux package name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,9 @@ builds:
     ldflags: "-X 'main.Version=v{{ .Version }}'"
     binary: bktec
 
+checksum:
+  name_template: "bktec_{{ .Version }}_checksums.txt"
+
 brews:
   - name: bktec
     description: "Buildkite Test Engine Client"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,6 +92,7 @@ docker_manifests:
 nfpms:
   - vendor: Buildkite
     id: linux-pkg
+    package_name: bktec
     homepage: https://github.com/buildkite/test-engine-client
     maintainer: Buildkite <support@buildkite.com>
     description: Buildkite Test Engine Client


### PR DESCRIPTION
The linux package still built as `test-engine-client` instead of `bktec`. 
<img width="1073" alt="Screenshot 2024-09-17 at 5 26 22 PM" src="https://github.com/user-attachments/assets/53b967ef-2a92-4c84-a6c2-4ec10c2b4df9">


By default `goreleaser` uses project name which is `test-engine-client` as package name, however, we want to use `bktec` as binary/package name. This PR updates the `nfpms` configuration to build linux packages with `bktec` name.

I created a snapshot locally, and this is the generated artifacts
<img width="420" alt="Screenshot 2024-09-17 at 5 31 33 PM" src="https://github.com/user-attachments/assets/f7d642cb-e046-4769-ae06-86892248dcf8">
