### PR TITLE
Skip sendMetadata when using fallback plan

### DIFF
--- a/internal/plan/fallback.go
+++ b/internal/plan/fallback.go
@@ -32,6 +32,7 @@ func CreateFallbackPlan(files []string, parallelism int) TestPlan {
 	}
 
 	return TestPlan{
-		Tasks: tasks,
+		Tasks:    tasks,
+		Fallback: true,
 	}
 }

--- a/internal/plan/fallback_test.go
+++ b/internal/plan/fallback_test.go
@@ -62,6 +62,10 @@ func TestCreateFallbackPlan(t *testing.T) {
 			got[task.NodeNumber] = task.Tests
 		}
 
+		if !plan.Fallback {
+			t.Errorf("CreateFallbackPlan(%v, %v) Fallback is %v, want %v", s.files, s.parallelism, plan.Fallback, true)
+		}
+
 		if diff := cmp.Diff(got, s.want); diff != "" {
 			t.Errorf("CreateFallbackPlan(%v, %v) diff (-got +want):\n%s", s.files, s.parallelism, diff)
 		}

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -27,4 +27,5 @@ type Task struct {
 type TestPlan struct {
 	Experiment string           `json:"experiment"`
 	Tasks      map[string]*Task `json:"tasks"`
+	Fallback   bool
 }


### PR DESCRIPTION
We don't want to send metadata when the client falls back to non-intelligent split, because there is very little value of tracking the execution of the test with non-intelligent split. Moreover, when the client falls back to non-intelligent split, there might not be a test plan in the server, which means that sending the metadata back to the server is even useless.

This PR adds `Fallback` attribute to the `TestPlan` struct, updates the `CreateFallbackPlan` method to return test plan with `Fallback: true`, and updates the `main` function to skip sending metadata when the plan has `Fallback: true`.

