### PR TITLE
Exclude pending examples from Split by Examples

### DIFF
--- a/internal/runner/fixtures/rspec/spec/with_skipped_examples_spec.rb
+++ b/internal/runner/fixtures/rspec/spec/with_skipped_examples_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe("Spec with skipped examples") do
     fail
   end
 
-  it("skipped using pending option", pending: "skipped") do
+  it("pending example", pending: "not implemented") do
     fail
   end
 end

--- a/internal/runner/fixtures/rspec/spec/with_skipped_examples_spec.rb
+++ b/internal/runner/fixtures/rspec/spec/with_skipped_examples_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe("Spec with skipped examples") do
+  it("not skipped") do
+    true
+  end
+
+  xit("skiped using xit") do
+    fail
+  end
+
+  it("skipped using skip option", skip: "skipped") do
+    fail
+  end
+
+  it("skipped using pending option", pending: "skipped") do
+    fail
+  end
+end

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -217,6 +217,9 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 
 	var testCases []plan.TestCase
 	for _, example := range report.Examples {
+		if example.Status == "pending" {
+			continue
+		}
 		testCases = append(testCases, plan.TestCase{
 			Identifier: example.Id,
 			Name:       example.Description,

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -405,6 +405,12 @@ func TestRspecGetExamples_WithSkippedExamples(t *testing.T) {
 			Path:       "./fixtures/rspec/spec/with_skipped_examples_spec.rb[1:1]",
 			Scope:      "Spec with skipped examples not skipped",
 		},
+		{
+			Identifier: "./fixtures/rspec/spec/with_skipped_examples_spec.rb[1:4]",
+			Name:       "pending example",
+			Path:       "./fixtures/rspec/spec/with_skipped_examples_spec.rb[1:4]",
+			Scope:      "Spec with skipped examples pending example",
+		},
 	}
 
 	if err != nil {

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -390,3 +390,28 @@ func TestRspecGetExamples_WithSharedExamples(t *testing.T) {
 		t.Errorf("Rspec.GetExamples(%q) diff (-got +want):\n%s", files, diff)
 	}
 }
+
+func TestRspecGetExamples_WithSkippedExamples(t *testing.T) {
+	rspec := NewRspec(RunnerConfig{
+		TestCommand: "rspec",
+	})
+	files := []string{"./fixtures/rspec/spec/with_skipped_examples_spec.rb"}
+	got, err := rspec.GetExamples(files)
+
+	want := []plan.TestCase{
+		{
+			Identifier: "./fixtures/rspec/spec/with_skipped_examples_spec.rb[1:1]",
+			Name:       "not skipped",
+			Path:       "./fixtures/rspec/spec/with_skipped_examples_spec.rb[1:1]",
+			Scope:      "Spec with skipped examples not skipped",
+		},
+	}
+
+	if err != nil {
+		t.Errorf("Rspec.GetExamples(%q) error = %v", files, err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Rspec.GetExamples(%q) diff (-got +want):\n%s", files, diff)
+	}
+}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
When Split by Example is enabled, `bktec` will do the dry run for filtered files to get the examples within those files. The examples within those files could include a skipped example (i.e. using `xit` in RSpec). Currently, `bktec` includes those skipped examples when requesting the test plan, which reduce the accuracy of the test plan.

We need to exclude skipped tests when requesting the test plan to have more accurate test plan.
