### PR TITLE
Add Playwright support

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -10,10 +10,12 @@ go install gotest.tools/gotestsum@v1.8.0
 go install github.com/pact-foundation/pact-go/v2@latest
 pact-go -l DEBUG install
 
-# Install node dependencies for js runner tests
+# Install dependencies for js runner tests
 cd internal/runner/testdata
 yarn install
-cd ../../..
+cd playwright
+yarn playwright install
+cd ../../../..
 
 echo '+++ Running tests'
 gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -coverprofile=cover.out -failfast "$@" ./...

--- a/internal/api/runner.go
+++ b/internal/api/runner.go
@@ -9,6 +9,7 @@ const (
 	Rspec Runner = iota
 	Jest
 	Cypress
+	Playwright
 )
 
 func (r Runner) MarshalText() ([]byte, error) {

--- a/internal/api/runner_string.go
+++ b/internal/api/runner_string.go
@@ -11,11 +11,12 @@ func _() {
 	_ = x[Rspec-0]
 	_ = x[Jest-1]
 	_ = x[Cypress-2]
+	_ = x[Playwright-3]
 }
 
-const _Runner_name = "RspecJestCypress"
+const _Runner_name = "RspecJestCypressPlaywright"
 
-var _Runner_index = [...]uint8{0, 5, 9, 16}
+var _Runner_index = [...]uint8{0, 5, 9, 16, 26}
 
 func (i Runner) String() string {
 	if i < 0 || i >= Runner(len(_Runner_index)-1) {

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -40,7 +40,9 @@ func DetectRunner(cfg config.Config) (TestRunner, error) {
 		return NewJest(runnerConfig), nil
 	case "cypress":
 		return NewCypress(runnerConfig), nil
+	case "playwright":
+		return NewPlaywright(runnerConfig), nil
 	default:
-		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress'")
+		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright'")
 	}
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -48,7 +48,8 @@ func (p Playwright) Run(testCases []string, retry bool) (RunResult, error) {
 
 	cmd := exec.Command(cmdName, cmdArgs...)
 
-	fmt.Printf("%s %s\n", cmdName, strings.Join(cmdArgs, " "))
+	// double new line is required because Playwright output removes the last line
+	fmt.Printf("%s %s\n\n", cmdName, strings.Join(cmdArgs, " "))
 	err = runAndForwardSignal(cmd)
 
 	if err == nil { // note: returning success early

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/buildkite/test-engine-client/internal/debug"
+	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/kballard/go-shellquote"
+)
+
+var _ = TestRunner(Playwright{})
+
+type Playwright struct {
+	RunnerConfig
+}
+
+func (p Playwright) Name() string {
+	return "Playwright"
+}
+
+func NewPlaywright(p RunnerConfig) Playwright {
+	if p.TestCommand == "" {
+		p.TestCommand = "npx playwright test"
+	}
+
+	if p.TestFilePattern == "" {
+		p.TestFilePattern = "**/{*.spec,*.test}.{ts,js}"
+	}
+
+	if p.TestFileExcludePattern == "" {
+		p.TestFileExcludePattern = "**/node_modules"
+	}
+
+	return Playwright{p}
+}
+
+func (p Playwright) Run(testCases []string, retry bool) (RunResult, error) {
+	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, testCases)
+	if err != nil {
+		return RunResult{Status: RunStatusError}, fmt.Errorf("failed to build command: %w", err)
+	}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+
+	fmt.Printf("%s %s\n", cmdName, strings.Join(cmdArgs, " "))
+	err = runAndForwardSignal(cmd)
+
+	if err == nil { // note: returning success early
+		return RunResult{Status: RunStatusPassed}, nil
+	}
+
+	return RunResult{Status: RunStatusError}, err
+}
+
+func (p Playwright) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+	words, err := shellquote.Split(cmd)
+	if err != nil {
+		return "", []string{}, err
+	}
+	idx := slices.Index(words, "{{testExamples}}")
+	if idx < 0 {
+		words = append(words, testCases...)
+	} else {
+		words = slices.Replace(words, idx, idx+1, testCases...)
+	}
+
+	return words[0], words[1:], nil
+}
+
+func (p Playwright) GetFiles() ([]string, error) {
+	debug.Println("Discovering test files with include pattern:", p.TestFilePattern, "exclude pattern:", p.TestFileExcludePattern)
+	files, err := discoverTestFiles(p.TestFilePattern, p.TestFileExcludePattern)
+	debug.Println("Discovered", len(files), "files")
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found with pattern %q and exclude pattern %q", p.TestFilePattern, p.TestFileExcludePattern)
+	}
+
+	return files, nil
+}
+
+func (p Playwright) GetExamples(files []string) ([]plan.TestCase, error) {
+	return nil, fmt.Errorf("not supported in Playwright")
+}

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -1,7 +1,10 @@
 package runner
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"slices"
 	"strings"
@@ -52,6 +55,30 @@ func (p Playwright) Run(testCases []string, retry bool) (RunResult, error) {
 		return RunResult{Status: RunStatusPassed}, nil
 	}
 
+	if ProcessSignaledError := new(ProcessSignaledError); errors.As(err, &ProcessSignaledError) {
+		return RunResult{Status: RunStatusError}, err
+	}
+
+	if exitError := new(exec.ExitError); errors.As(err, &exitError) {
+		report, parseErr := p.parseReport(p.ResultPath)
+		if parseErr != nil {
+			fmt.Println("Buildkite Test Engine Client: Failed to read Playwright output, tests will not be retried.")
+			return RunResult{Status: RunStatusError}, err
+		}
+
+		if report.Stats.Unexpected > 0 {
+			var failedTests []string
+			for _, suite := range report.Suites {
+				for _, spec := range suite.Specs {
+					if !spec.Ok {
+						failedTests = append(failedTests, fmt.Sprintf("%s:%d", spec.File, spec.Line))
+					}
+				}
+			}
+			return RunResult{Status: RunStatusFailed, FailedTests: failedTests}, nil
+		}
+	}
+
 	return RunResult{Status: RunStatusError}, err
 }
 
@@ -68,6 +95,20 @@ func (p Playwright) commandNameAndArgs(cmd string, testCases []string) (string, 
 	}
 
 	return words[0], words[1:], nil
+}
+
+func (p Playwright) parseReport(path string) (PlaywrightReport, error) {
+	var report PlaywrightReport
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return PlaywrightReport{}, fmt.Errorf("failed to read playwright output: %v", err)
+	}
+
+	if err := json.Unmarshal(data, &report); err != nil {
+		return PlaywrightReport{}, fmt.Errorf("failed to parse playwright output: %s", err)
+	}
+
+	return report, nil
 }
 
 func (p Playwright) GetFiles() ([]string, error) {
@@ -88,4 +129,26 @@ func (p Playwright) GetFiles() ([]string, error) {
 
 func (p Playwright) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in Playwright")
+}
+
+type PlaywrightSpec struct {
+	File   string
+	Line   int
+	Column int
+	Id     string
+	Title  string
+	Ok     bool
+}
+
+type PlaywrightReportSuite struct {
+	Title string
+	Specs []PlaywrightSpec
+}
+
+type PlaywrightReport struct {
+	Suites []PlaywrightReportSuite
+	Stats  struct {
+		Expected   int
+		Unexpected int
+	}
 }

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -1,0 +1,125 @@
+package runner
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPlaywrightRun(t *testing.T) {
+	mockCwd(t, "./testdata/playwright")
+
+	playwright := NewPlaywright(RunnerConfig{
+		TestCommand: "yarn run playwright test",
+	})
+
+	files := []string{"./testdata/playwright/tests/example.spec.js"}
+	got, err := playwright.Run(files, false)
+
+	want := RunResult{
+		Status: RunStatusPassed,
+	}
+
+	if err != nil {
+		t.Errorf("Playwright.Run(%q) error = %v", files, err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Playwright.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+}
+
+func TestPlaywrightRun_TestFailed(t *testing.T) {
+	mockCwd(t, "./testdata/playwright")
+
+	playwright := NewPlaywright(RunnerConfig{})
+
+	files := []string{"./tests/failed.spec.js"}
+	got, err := playwright.Run(files, false)
+
+	want := RunResult{
+		Status: RunStatusError,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Playwright.Run(%q) diff (-got +want):\n%s", files, diff)
+	}
+
+	exitError := new(exec.ExitError)
+	if !errors.As(err, &exitError) {
+		t.Errorf("Playwright.Run(%q) error type = %T (%v), want *exec.ExitError", files, err, err)
+	}
+}
+
+func TestPlaywrightCommandNameAndArgs_WithPlaceholder(t *testing.T) {
+	testCases := []string{"tests/example.spec.js", "tests/failed.spec.js"}
+	testCommand := "npx playwright test {{testExamples}}"
+
+	rspec := Rspec{
+		RunnerConfig{
+			TestCommand: testCommand,
+		},
+	}
+
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "npx"
+	wantArgs := []string{"playwright", "test", "tests/example.spec.js", "tests/failed.spec.js"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestPlaywrightCommandNameAndArgs_WithoutPlaceholder(t *testing.T) {
+	testCases := []string{"tests/example.spec.js", "tests/failed.spec.js"}
+	testCommand := "npx playwright test"
+
+	rspec := Rspec{
+		RunnerConfig{
+			TestCommand: testCommand,
+		},
+	}
+
+	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "npx"
+	wantArgs := []string{"playwright", "test", "tests/example.spec.js", "tests/failed.spec.js"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestCypressGetFiles(t *testing.T) {
+	mockCwd(t, "./testdata/playwright")
+	playwright := NewPlaywright(RunnerConfig{})
+
+	got, err := playwright.GetFiles()
+	if err != nil {
+		t.Errorf("Playwright.GetFiles() error = %v", err)
+	}
+
+	want := []string{
+		"tests/example.spec.js",
+		"tests/failed.spec.js",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Playwright.GetFiles() diff (-got +want):\n%s", diff)
+	}
+}

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPlaywrightRun(t *testing.T) {
-	mockCwd(t, "./testdata/playwright")
+	changeCwd(t, "./testdata/playwright")
 
 	playwright := NewPlaywright(RunnerConfig{
 		TestCommand: "yarn run playwright test",
@@ -31,7 +31,7 @@ func TestPlaywrightRun(t *testing.T) {
 }
 
 func TestPlaywrightRun_TestFailed(t *testing.T) {
-	mockCwd(t, "./testdata/playwright")
+	changeCwd(t, "./testdata/playwright")
 
 	playwright := NewPlaywright(RunnerConfig{
 		ResultPath: "test-results/results.json",
@@ -106,8 +106,8 @@ func TestPlaywrightCommandNameAndArgs_WithoutPlaceholder(t *testing.T) {
 	}
 }
 
-func TestCypressGetFiles(t *testing.T) {
-	mockCwd(t, "./testdata/playwright")
+func TestPlaywrightGetFiles(t *testing.T) {
+	changeCwd(t, "./testdata/playwright")
 	playwright := NewPlaywright(RunnerConfig{})
 
 	got, err := playwright.GetFiles()

--- a/internal/runner/testdata/package.json
+++ b/internal/runner/testdata/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": [
     "cypress",
-    "jest"
+    "jest",
+    "playwright"
   ]
 }

--- a/internal/runner/testdata/playwright/.gitignore
+++ b/internal/runner/testdata/playwright/.gitignore
@@ -1,0 +1,3 @@
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/internal/runner/testdata/playwright/index.html
+++ b/internal/runner/testdata/playwright/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Playwright example</title>
+</head>
+
+<body>
+  <h1>Hello, World!</h1>
+</body>
+
+</html>

--- a/internal/runner/testdata/playwright/package.json
+++ b/internal/runner/testdata/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "playwright-example",
+  "version": "1.0.0",
+  "dependencies": {
+    "http-server": "^14.1.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  },
+  "scripts": {
+    "start": "yarn run http-server -p 8080",
+    "test": "yarn run playwright test"
+  }
+}

--- a/internal/runner/testdata/playwright/playwright.config.js
+++ b/internal/runner/testdata/playwright/playwright.config.js
@@ -5,7 +5,10 @@ const { defineConfig, devices } = require('@playwright/test');
  */
 module.exports = defineConfig({
   testDir: './tests',
-  reporter: [['line']],
+  reporter: [
+    ['line'],
+    ['json', { outputFile: './test-results/results.json' }]
+  ],
   webServer: {
     command: 'yarn start',
     url: 'http://127.0.0.1:8080',

--- a/internal/runner/testdata/playwright/playwright.config.js
+++ b/internal/runner/testdata/playwright/playwright.config.js
@@ -1,0 +1,17 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+  testDir: './tests',
+  reporter: [['line']],
+  webServer: {
+    command: 'yarn start',
+    url: 'http://127.0.0.1:8080',
+  },
+  use: {
+    baseURL: 'http://localhost:8080/',
+  },
+});
+

--- a/internal/runner/testdata/playwright/tests/example.spec.js
+++ b/internal/runner/testdata/playwright/tests/example.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('home page', () => {
+  test('has title', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveTitle(/Playwright example/);
+  });
+
+  test('says hello', async ({ page }) => {
+    await page.goto('/');
+
+    const h1 = await page.locator('h1');
+    await expect(h1).toHaveText('Hello, World!');
+  })
+});

--- a/internal/runner/testdata/playwright/tests/failed.spec.js
+++ b/internal/runner/testdata/playwright/tests/failed.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('says good bye', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveText('good bye');
+});

--- a/internal/runner/testdata/playwright/tests/failed.spec.js
+++ b/internal/runner/testdata/playwright/tests/failed.spec.js
@@ -5,3 +5,7 @@ test('says good bye', async ({ page }) => {
 
   await expect(page).toHaveText('good bye');
 });
+
+test('it passes', () => {
+  expect(true).toBeTruthy();
+});

--- a/internal/runner/testdata/yarn.lock
+++ b/internal/runner/testdata/yarn.lock
@@ -568,6 +568,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@playwright/test@^1.48.0":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.0.tgz#4b81434a3ca75e2a6f82a645287784223a45434c"
+  integrity sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==
+  dependencies:
+    playwright "1.48.0"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -773,6 +780,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 async@^3.2.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -870,6 +884,13 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+basic-auth@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -988,7 +1009,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1125,6 +1146,11 @@ core-util-is@1.0.2:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
+corser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
+  integrity sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==
+
 create-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
@@ -1208,7 +1234,7 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -1338,6 +1364,11 @@ eventemitter2@6.4.7:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
@@ -1458,6 +1489,11 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.0.0:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -1486,6 +1522,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.2:
   version "2.3.3"
@@ -1619,10 +1660,50 @@ hasown@^2.0.0, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
+http-server@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-14.1.1.tgz#d60fbb37d7c2fdff0f0fbff0d0ee6670bd285e2e"
+  integrity sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==
+  dependencies:
+    basic-auth "^2.0.1"
+    chalk "^4.1.2"
+    corser "^2.0.1"
+    he "^1.2.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy "^1.18.1"
+    mime "^1.6.0"
+    minimist "^1.2.6"
+    opener "^1.5.1"
+    portfinder "^1.0.28"
+    secure-compare "3.0.1"
+    union "~0.5.0"
+    url-join "^4.0.1"
 
 http-signature@~1.3.6:
   version "1.3.6"
@@ -1642,6 +1723,13 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -2275,7 +2363,7 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2344,6 +2432,11 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.52.0"
 
+mime@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2356,10 +2449,17 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.8:
+minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
@@ -2411,6 +2511,11 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+opener@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 ospath@^1.2.2:
   version "1.2.2"
@@ -2517,6 +2622,29 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright-core@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.0.tgz#34d209dd4aba8fccd4a96116f1c4f7630f868722"
+  integrity sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==
+
+playwright@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.0.tgz#00855d9a25f1991d422867f1c32af5d90f457b48"
+  integrity sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==
+  dependencies:
+    playwright-core "1.48.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
+portfinder@^1.0.28:
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
+  integrity sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==
+  dependencies:
+    async "^2.6.4"
+    debug "^3.2.7"
+    mkdirp "^0.5.6"
+
 pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
@@ -2571,6 +2699,13 @@ pure-rand@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
+
+qs@^6.4.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+  dependencies:
+    side-channel "^1.0.6"
 
 qs@~6.10.3:
   version "6.10.5"
@@ -2652,15 +2787,25 @@ rxjs@^7.5.1:
   dependencies:
     tslib "^2.1.0"
 
+safe-buffer@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+secure-compare@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -2696,7 +2841,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel@^1.0.4:
+side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
   integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
@@ -2927,6 +3072,13 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
+union@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
+  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
+  dependencies:
+    qs "^6.4.0"
+
 universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
@@ -2949,6 +3101,11 @@ update-browserslist-db@^1.1.0:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.0"
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-parse@^1.5.3:
   version "1.5.10"
@@ -2987,6 +3144,13 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Adds support for Playwright test runner. The Playwright runner currently supports basic splitting, include/exclude patterns, retries. Split by example is not yet supported.

### Validation
Build the binary and run it from inside `internal/runner/testdata/playwright`
```
export BUILDKITE_BUILD_ID=abc
export BUILDKITE_ORGANIZATION_SLUG=my-org
export BUILDKITE_PARALLEL_JOB=0
export BUILDKITE_PARALLEL_JOB_COUNT=2
export BUILDKITE_STEP_ID=xyz
export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=token
export BUILDKITE_TEST_ENGINE_DEBUG_ENABLED=true
export BUILDKITE_TEST_ENGINE_RESULT_PATH=test-results/results.json
export BUILDKITE_TEST_ENGINE_SUITE_SLUG=my-suite
export BUILDKITE_TEST_ENGINE_TEST_RUNNER=playwright
bktec
```