### PR TITLE
Exclude `node_modules` all the time

### DIFF
--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -26,10 +26,6 @@ func NewCypress(c RunnerConfig) Cypress {
 		c.TestCommand = "npx cypress run --spec {{testExamples}}"
 	}
 
-	if c.TestFileExcludePattern == "" {
-		c.TestFileExcludePattern = "**/node_modules"
-	}
-
 	if c.TestFilePattern == "" {
 		c.TestFilePattern = "**/*.cy.{js,jsx,ts,tsx}"
 	}

--- a/internal/runner/discover.go
+++ b/internal/runner/discover.go
@@ -36,6 +36,12 @@ func discoverTestFiles(pattern string, excludePattern string) ([]string, error) 
 			}
 			return nil
 		}
+
+		// Skip the node_modules directory
+		if d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
+
 		// Skip directories that happen to match the include pattern - we're
 		// only interested in files.
 		if d.IsDir() {

--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -66,3 +66,30 @@ func TestDiscoverTestFiles_WithExcludeDirectory(t *testing.T) {
 		t.Errorf("discoverTestFiles(%q, %q) diff (-got +want):\n%s", pattern, excludePattern, diff)
 	}
 }
+
+func TestDiscoverTestFiles_ExcludeNodeModules(t *testing.T) {
+	pattern := "testdata/**/*.js"
+	excludePattern := ""
+	got, err := discoverTestFiles(pattern, excludePattern)
+
+	if err != nil {
+		t.Errorf("discoverTestFiles(%q, %q) error: %v", pattern, excludePattern, err)
+	}
+
+	want := []string{
+		"testdata/cypress/cypress/e2e/failing_spec.cy.js",
+		"testdata/cypress/cypress/e2e/flaky_spec.cy.js",
+		"testdata/cypress/cypress/e2e/passing_spec.cy.js",
+		"testdata/cypress/cypress.config.js",
+		"testdata/jest/failure.spec.js",
+		"testdata/jest/jest.config.js",
+		"testdata/jest/spells/expelliarmus.spec.js",
+		"testdata/playwright/playwright.config.js",
+		"testdata/playwright/tests/example.spec.js",
+		"testdata/playwright/tests/failed.spec.js",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("discoverTestFiles(%q, %q) diff (-got +want):\n%s", pattern, excludePattern, diff)
+	}
+}

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -29,10 +29,6 @@ func NewJest(j RunnerConfig) Jest {
 		j.TestFilePattern = "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}"
 	}
 
-	if j.TestFileExcludePattern == "" {
-		j.TestFileExcludePattern = "node_modules"
-	}
-
 	if j.RetryTestCommand == "" {
 		j.RetryTestCommand = "npx jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 	}

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -23,7 +23,7 @@ func TestNewJest(t *testing.T) {
 			want: RunnerConfig{
 				TestCommand:            "npx jest {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}",
 				TestFilePattern:        "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}",
-				TestFileExcludePattern: "node_modules",
+				TestFileExcludePattern: "",
 				RetryTestCommand:       "npx jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 		},
@@ -326,5 +326,24 @@ func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.
 	desiredString := "couldn't find '{{testNamePattern}}' sentinel in retry command"
 	if err.Error() != desiredString {
 		t.Errorf("retryCommandNameAndArgs() error = %v, want %v", err, desiredString)
+	}
+}
+
+func TestJestGetFiles(t *testing.T) {
+	changeCwd(t, "./testdata/jest")
+	jest := NewJest(RunnerConfig{})
+
+	got, err := jest.GetFiles()
+	if err != nil {
+		t.Errorf("Jest.GetFiles() error = %v", err)
+	}
+
+	want := []string{
+		"failure.spec.js",
+		"spells/expelliarmus.spec.js",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Jest.GetFiles() diff (-got +want):\n%s", diff)
 	}
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -33,10 +33,6 @@ func NewPlaywright(p RunnerConfig) Playwright {
 		p.TestFilePattern = "**/{*.spec,*.test}.{ts,js}"
 	}
 
-	if p.TestFileExcludePattern == "" {
-		p.TestFileExcludePattern = "**/node_modules"
-	}
-
 	return Playwright{p}
 }
 


### PR DESCRIPTION
Currently, we set the default of `BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN` to be `**/node_modules` to exclude files within `node_modules` directory.  If customers configure the `BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN` to their needs, files inside the `node_modules` can accidentally get picked up by the client. We need to exclude files inside `node_modules` all the time.