### PR TITLE
Remove interface check for all runners.

### DIFF
--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -11,8 +11,6 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-var _ = TestRunner(Cypress{})
-
 type Cypress struct {
 	RunnerConfig
 }

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-var _ = TestRunner(Jest{})
-
 type Jest struct {
 	RunnerConfig
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-var _ = TestRunner(Playwright{})
-
 type Playwright struct {
 	RunnerConfig
 }

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
-var _ = TestRunner(Rspec{})
-
 type Rspec struct {
 	RunnerConfig
 }


### PR DESCRIPTION
In each runner, we have the following code to check if the runner implements the `TestRunner` interface. 
```
var _ = TestRunner(Runner{})
```
This is redundant, because the compiler already checks this inside `DetectRunner` function. 