### PR TITLE
Update default test command for jest to be less opinionated

### DIFF
--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -23,7 +23,7 @@ func (c Cypress) Name() string {
 
 func NewCypress(c RunnerConfig) Cypress {
 	if c.TestCommand == "" {
-		c.TestCommand = "cypress run --spec {{testExamples}}"
+		c.TestCommand = "npx cypress run --spec {{testExamples}}"
 	}
 
 	if c.TestFileExcludePattern == "" {

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -22,7 +22,7 @@ type Jest struct {
 
 func NewJest(j RunnerConfig) Jest {
 	if j.TestCommand == "" {
-		j.TestCommand = "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}"
+		j.TestCommand = "npx jest {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}"
 	}
 
 	if j.TestFilePattern == "" {
@@ -34,7 +34,7 @@ func NewJest(j RunnerConfig) Jest {
 	}
 
 	if j.RetryTestCommand == "" {
-		j.RetryTestCommand = "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
+		j.RetryTestCommand = "npx jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 	}
 
 	return Jest{j}

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -21,22 +21,22 @@ func TestNewJest(t *testing.T) {
 		{
 			input: RunnerConfig{},
 			want: RunnerConfig{
-				TestCommand:            "yarn test {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}",
+				TestCommand:            "npx jest {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}",
 				TestFilePattern:        "**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}",
 				TestFileExcludePattern: "node_modules",
-				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
+				RetryTestCommand:       "npx jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 		},
 		// custom
 		{
 			input: RunnerConfig{
-				TestCommand:            "npx jest --json --outputFile {{resultPath}}",
+				TestCommand:            "yarn test --json --outputFile {{resultPath}}",
 				TestFilePattern:        "spec/models/**/*.spec.js",
 				TestFileExcludePattern: "spec/features/**/*.spec.js",
 				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",
 			},
 			want: RunnerConfig{
-				TestCommand:            "npx jest --json --outputFile {{resultPath}}",
+				TestCommand:            "yarn test --json --outputFile {{resultPath}}",
 				TestFilePattern:        "spec/models/**/*.spec.js",
 				TestFileExcludePattern: "spec/features/**/*.spec.js",
 				RetryTestCommand:       "yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}",


### PR DESCRIPTION
Currently, the default command for jest is `yarn test ...`. Because not all customer will use `yarn`, some are using `npm`, and the script name can be anything than `test`, we need to update to be something less opinionated. I opt to using `npx` which came by default in node.