### PR TITLE
Update Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.1
+## 1.1.0
 - Experimental support for Cypress. See [Cypress usage guide](./docs/cypress.md).
 - Experimental support for Playwright. See [Playwright usage guide](./docs/playwright.md).
 - Update `BUILDKITE_TEST_ENGINE_TEST_CMD` and `BUILDKITE_TEST_ENGINE_RETRY_CMD` for Jest. See [Jest usage guide](./docs/jest.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## 1.0.1
+- Experimental support for Cypress. See [Cypress usage guide](./docs/cypress.md).
+- Experimental support for Playwright. See [Playwright usage guide](./docs/playwright.md).
+- Update `BUILDKITE_TEST_ENGINE_TEST_CMD` and `BUILDKITE_TEST_ENGINE_RETRY_CMD` for Jest. See [Jest usage guide](./docs/jest.md).
+- Remove `**/node_modules` from default value of `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN`. Files inside `node_modules` will be ignore regardless the value of this environment variable.
+
 ## 1.0.0 - 2024-09-23
 - ⚠️ **BREAKING** Rename all environment variables from `BUILDKITE_SPLITTER_*` to `BUILDKITE_TEST_ENGINE_*`. See [Migrating to 1.0.0](https://github.com/buildkite/test-splitter/tree/90b699918b11500336f8a0fce306da917fba7408?tab=readme-ov-file#migrating-to-100)
 - ⚠️ **BREAKING** Add the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` as required environment variable.

--- a/README.md
+++ b/README.md
@@ -12,32 +12,7 @@ bktec supports multiple test runners and offers various features to enhance your
 
 ## Migrating to 1.0.0
 
-The following environment variables are now required
-- `BUILDKITE_TEST_ENGINE_TEST_RUNNER`
-
-  The test runner to use for running tests. You will need to ensure that `BUILDKITE_TEST_ENGINE_TEST_RUNNER` presents in the environment. Currently `rspec` and `jest` are supported.
-
-- `BUILDKITE_TEST_ENGINE_RESULT_PATH`
-
-  The location of where the runner should store test results. We introduced a new feature that requires bktec to read test results from the runner for retries and verification purposes. To enable this feature, it is necessary to configure the `BUILDKITE_TEST_ENGINE_RESULT_PATH` environment variable.
-
-  In addition, we have updated the default test command for RSpec to `bundle exec rspec --format progress --format json --out {{resultPath}} {{testExamples}}`. Test Splitter will automatically replace `{{resultPath}}` with the value specified in `BUILDKITE_TEST_ENGINE_RESULT_PATH`. If you want to customize the RSpec command, make sure to include `--format json --out {{resultPath}}` in the command. 
-
-Furthermore, version 1.0.0 introduces name changes to environment variables. To migrate to v1.0.0, You will need to update the following environment variables in your Pipeline:
-
-| Old variable | New variable |
-| ------------ | ------------ |
-| `BUILDKITE_SPLITTER_API_ACCESS_TOKEN`| `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` |
-| `BUILDKITE_SPLITTER_SUITE_SLUG`| `BUILDKITE_TEST_ENGINE_SUITE_SLUG` |
-| `BUILDKITE_SPLITTER_RESULT_PATH`| `BUILDKITE_TEST_ENGINE_RESULT_PATH` |
-| `BUILDKITE_SPLITTER_DEBUG_ENABLED` | `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` |
-| `BUILDKITE_SPLITTER_RETRY_CMD` | `BUILDKITE_TEST_ENGINE_RETRY_CMD` |
-| `BUILDKITE_SPLITTER_RETRY_COUNT` | `BUILDKITE_TEST_ENGINE_RETRY_COUNT`|
-| `BUILDKITE_SPLITTER_SPLIT_BY_EXAMPLE` | `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` |
-| `BUILDKITE_SPLITTER_TEST_CMD` | `BUILDKITE_TEST_ENGINE_TEST_CMD` |
-| `BUILDKITE_SPLITTER_TEST_FILE_EXCLUDE_PATTERN` | `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` |
-| `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` | `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` |
-| `BUILDKITE_SPLITTER_TEST_RUNNER` | `BUILDKITE_TEST_ENGINE_TEST_RUNNER` |
+Follow this [guide](https://github.com/buildkite/test-splitter/tree/90b699918b11500336f8a0fce306da917fba7408?tab=readme-ov-file#migrating-to-100) to migrate to v1.0.0
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ bktec supports multiple test runners and offers various features to enhance your
 
 | Feature                                            | Rspec | Jest | Playwright | Cypress |
 | -------------------------------------------------- | :---: | :--: | :--------: | :-----: |
-| Discover and filter test files using glob pattern  |   ✅  |   ✅  |    ✅      |    ✅   |
+| Filter test files                                  |   ✅  |   ✅  |    ✅      |    ✅   |
 | Automatically retry failed test                    |   ✅  |   ✅  |    ✅      |    ❌   |
 | Split slow files by individual test example        |   ✅  |   ❌  |    ❌      |    ❌   |
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ bktec supports multiple test runners and offers various features to enhance your
 | Automatically retry failed test                    |   ✅  |   ✅  |    ✅      |    ❌   |
 | Split slow files by individual test example        |   ✅  |   ❌  |    ❌      |    ❌   |
 
-## Migrating to 1.0.0
-
-Follow this [guide](https://github.com/buildkite/test-splitter/tree/90b699918b11500336f8a0fce306da917fba7408?tab=readme-ov-file#migrating-to-100) to migrate to v1.0.0
-
-
 ## Installation
 The latest version of bktec can be downloaded from https://github.com/buildkite/test-engine-client/releases
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ steps:
       BUILDKITE_TEST_ENGINE_RESULT_PATH: tmp/result.json
 ```
 
+### Debugging
+To enable debug mode, set the `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` environment variable to `true`. This will print detailed output to assist in debugging bktec.
+
 ### Possible exit statuses
 
 bktec may exit with a variety of exit statuses, outlined below:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Buildkite Test Engine Client
 
-Buildkite Test Engine Client (bktec) is an open source tool to orchestrate your test suites. It uses your Buildkite Test Engine suite data to intelligently partition and parallelise your tests.
+Buildkite Test Engine Client (bktec) is an open source tool to orchestrate your test suites. It uses your Buildkite Test Engine suite data to intelligently partition and parallelize your tests.
 
-bktec supports RSpec, Jest, Playwright, and Cypress.
+bktec supports multiple test runners and offers various features to enhance your testing workflow. Below is a comparison of the features supported by each test runner:
+
+| Feature                                            | Rspec | Jest | Playwright | Cypress |
+| -------------------------------------------------- | :---: | :--: | :--------: | :-----: |
+| Discover and filter test files using glob pattern  |   ✅  |   ✅  |    ✅      |    ✅   |
+| Automatically retry failed test                    |   ✅  |   ✅  |    ✅      |    ❌   |
+| Split slow files by individual test example        |   ✅  |   ❌  |    ❌      |    ❌   |
 
 ## Migrating to 1.0.0
 

--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -5,7 +5,7 @@ To integrate bktec with Cypress, set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` env
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=cypress
 ```
 
-## Test Command
+## Configure test command
 By default, bktec runs Cypress with the following command:
 
 ```sh
@@ -19,7 +19,7 @@ To customize the test command, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn cypress:run --spec {{testExamples}}"
 ```
 
-## Test Discovery and Filtering
+## Discover and filter test files
 bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/*.cy.{js,jsx,ts,tsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.cy` suffix, such as `/cypress/e2e/login.cy.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
 
 Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.

--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -19,18 +19,24 @@ To customize the test command, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn cypress:run --spec {{testExamples}}"
 ```
 
-## Discover and filter test files
-bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/*.cy.{js,jsx,ts,tsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.cy` suffix, such as `/cypress/e2e/login.cy.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
-
-Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
-
-To customize the discovery pattern and exclude certain files, set the following environment variable:
+## Filter test files
+By default, bktec runs test files that match the `**/*.cy.{js,jsx,ts,tsx}` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run Cypress test files inside a `cypress/e2e` directory, use:
 ```sh
-export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.cy.{ts,tsx}
-export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=cypress/component
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=cypress/e2e/**/*.cy.js
 ```
 
-With the above configurations, bktec will discover all files matching the `**/*.cy.{ts,tsx}` pattern and exclude any files inside the `cypress/component` directory.
+Additionally, you can exclude specific files or directories that match a certain pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable. For example, to exclude test files inside the `cypress/component` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=cypress/component
+```
+
+You can also use both `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` and `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` simultaneously. For example, to run all Cypress test files with `cy.js`, except those in the `cypress/e2e` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=**/*.cy.js
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=cypress/e2e
+```
 
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.

--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -1,0 +1,36 @@
+# Using bktec with Cypress
+To integrate bktec with Cypress, set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` environment variable to `cypress`.
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=cypress
+```
+
+## Test Command
+By default, bktec runs Cypress with the following command:
+
+```sh
+npx cypress run --spec {{testExamples}}
+```
+
+In this command, `{{testExamples}}` is replaced by bktec with the list of test files to run. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.
+
+To customize the test command, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn cypress:run --spec {{testExamples}}"
+```
+
+## Test Discovery and Filtering
+bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/*.cy.{js,jsx,ts,tsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.cy` suffix, such as `/cypress/e2e/login.cy.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+
+Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
+
+To customize the discovery pattern and exclude certain files, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.cy.{ts,tsx}
+export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=cypress/component
+```
+
+With the above configurations, bktec will discover all files matching the `**/*.cy.{ts,tsx}` pattern and exclude any files inside the `cypress/component` directory.
+
+> [!TIP]
+> This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.

--- a/docs/jest.md
+++ b/docs/jest.md
@@ -6,7 +6,7 @@ export BUILDKITE_TEST_ENGINE_TEST_RUNNER=jest
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/jest-result.json
 ```
 
-## Test Command
+## Configure test command
 By default, bktec runs Jest with the following command:
 
 ```sh
@@ -23,7 +23,7 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}} --json --testL
 > [!IMPORTANT]
 > Make sure to append `--json --testLocationInResults --outputFile {{resultPath}}` in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
 
-## Test Discovery and Filtering
+## Discover and filter test files
 bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, or files nested under `__tests__` directory, such as `/__tests__/component/button.tsx` or `/src/component/button.test.tsx`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
 
 Additionally, you can exclude files that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
@@ -39,7 +39,7 @@ With the above configurations, bktec will discover all files matching the `**/*.
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
 
-## Retry Failed Tests
+## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the following command:
 
 ```sh

--- a/docs/jest.md
+++ b/docs/jest.md
@@ -23,18 +23,25 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}} --json --testL
 > [!IMPORTANT]
 > Make sure to append `--json --testLocationInResults --outputFile {{resultPath}}` in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
 
-## Discover and filter test files
-bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, or files nested under `__tests__` directory, such as `/__tests__/component/button.tsx` or `/src/component/button.test.tsx`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+## Filter test files
+By default, bktec runs test files that match the `**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run Jest test files inside the `src/components` directory, use:
 
-Additionally, you can exclude files that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
-
-To customize the discovery pattern and exclude certain files, set the following environment variable:
 ```sh
-export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.test.{ts,tsx}
-export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=spec/e2e
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=src/components/**/*.test.{ts,tsx}
 ```
 
-With the above configurations, bktec will discover all files matching the `**/*.test.{ts,tsx}` pattern and exclude any files inside the `spec/e2e` directory.
+Additionally, you can exclude specific files or directories that match a certain pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable. For example, to exclude test files inside the `src/utilities` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=src/utilities
+```
+
+You can also use both `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` and `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` simultaneously. For example, to run all Jest test files with `spec.ts`, except those in the `src/components` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=**/*.spec.ts
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=src/components
+```
 
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.

--- a/docs/jest.md
+++ b/docs/jest.md
@@ -1,0 +1,58 @@
+# Using bktec with Jest
+To integrate bktec with Jest, set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` environment variable to `jest`. Then, specify the `BUILDKITE_TEST_ENGINE_RESULT_PATH` to define where the JSON result should be stored. bktec will instruct Jest to output the JSON result to this path, which is necessary for bktec to read the test results for retries and verification purposes.
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=jest
+export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/jest-result.json
+```
+
+## Test Command
+By default, bktec runs Jest with the following command:
+
+```sh
+npx jest {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}
+```
+
+In this command, `{{testExamples}}` is replaced by bktec with the list of test files or tests to run, and `{{resultPath}}` is replaced with the value set in `BUILDKITE_TEST_ENGINE_RESULT_PATH`. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.
+
+To customize the test command, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}"
+```
+
+> [!IMPORTANT]
+> Make sure to append `--json --testLocationInResults --outputFile {{resultPath}}` in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
+
+## Test Discovery and Filtering
+bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{__tests__/**/*,*.spec,*.test}.{ts,js,tsx,jsx}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, or files nested under `__tests__` directory, such as `/__tests__/component/button.tsx` or `/src/component/button.test.tsx`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+
+Additionally, you can exclude files that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
+
+To customize the discovery pattern and exclude certain files, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.test.{ts,tsx}
+export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=spec/e2e
+```
+
+With the above configurations, bktec will discover all files matching the `**/*.test.{ts,tsx}` pattern and exclude any files inside the `spec/e2e` directory.
+
+> [!TIP]
+> This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
+
+## Retry Failed Tests
+You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the following command:
+
+```sh
+npx yarn --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}
+```
+
+In this command, `{{testNamePattern}}` is replaced by bktec with the list of failed tests to run, and `{{resultPath}}` is replaced with the value set in `BUILDKITE_TEST_ENGINE_RESULT_PATH`. You can customize this command using the `BUILDKITE_TEST_ENGINE_RETRY_CMD` environment variable.
+
+To enable automatic retry and customize the retry command, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_RETRY_CMD="yarn test --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
+```
+
+> [!IMPORTANT]
+> Make sure to append `--testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}` in your custom retry command.

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -33,18 +33,25 @@ To customize the test command, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}}"
 ```
 
-## Discover and filter test files
-bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{*.spec,*.test}.{ts,js}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, such as `/src/e2e/login.spec.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+## Filter test files
+By default, bktec runs test files that match the `**/{*.spec,*.test}.{ts,js}` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run Playwright test files inside the `tests` directory, use:
 
-Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
-
-To customize the discovery pattern and exclude certain files, set the following environment variable:
 ```sh
-export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.test.ts
-export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=**/component
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=tests/**/*.test.ts
 ```
 
-With the above configurations, bktec will discover all files matching the `**/*.test.ts` pattern and exclude any files inside a `component` directory.
+Additionally, you can exclude specific files or directories that match a certain pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable. For example, to exclude test files inside the `src/components` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=src/components
+```
+
+You can also use both `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` and `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` simultaneously. For example, to run all Playwright test files with `.spec.ts` extension, except those in the `src/components` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=**/*.spec.ts
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=src/components
+```
 
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -19,7 +19,7 @@ export BUILDKITE_TEST_ENGINE_TEST_RUNNER=playwright
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=./tmp/test-results.json
 ```
 
-## Test Command
+## Configure test command
 By default, bktec runs Playwright with the following command:
 
 ```sh
@@ -33,7 +33,7 @@ To customize the test command, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}}"
 ```
 
-## Test Discovery and Filtering
+## Discover and filter test files
 bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{*.spec,*.test}.{ts,js}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, such as `/src/e2e/login.spec.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
 
 Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
@@ -49,7 +49,7 @@ With the above configurations, bktec will discover all files matching the `**/*.
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
 
-## Retry Failed Tests
+## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
 
 To enable automatic retry, set the following environment variable:

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -1,0 +1,58 @@
+# Using bktec with Playwright
+To integrate bktec with Playwright, start by configuring Playwright to output the results to a JSON file. This is necessary for bktec to read the test results for retries and verification purposes.
+
+```js
+// playwright.config.js
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [
+    ['json', { outputFile: './tmp/test-results.json' }]
+  ],
+});
+```
+
+Next, set the `BUILDKITE_TEST_ENGINE_RESULT_PATH` environment variable to the path of your JSON file.
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=playwright
+export BUILDKITE_TEST_ENGINE_RESULT_PATH=./tmp/test-results.json
+```
+
+## Test Command
+By default, bktec runs Playwright with the following command:
+
+```sh
+npx playwright test {{testExamples}}
+```
+
+In this command, `{{testExamples}}` is replaced by bktec with the list of test files to run. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.
+
+To customize the test command, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_CMD="yarn test {{testExamples}}"
+```
+
+## Test Discovery and Filtering
+bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `**/{*.spec,*.test}.{ts,js}` pattern. This means it will recursively find all JavaScript or TypeScript files with a `.test` or `.spec` suffix, such as `/src/e2e/login.spec.ts`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+
+Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
+
+To customize the discovery pattern and exclude certain files, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_PATTERN=**/*.test.ts
+export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=**/component
+```
+
+With the above configurations, bktec will discover all files matching the `**/*.test.ts` pattern and exclude any files inside a `component` directory.
+
+> [!TIP]
+> This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
+
+## Retry Failed Tests
+You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
+
+To enable automatic retry, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
+```

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -1,0 +1,74 @@
+# Using bktec with RSpec
+To integrate bktec with RSpec, set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` environment variable to `rspec`. Then, specify the `BUILDKITE_TEST_ENGINE_RESULT_PATH` to define where the JSON result should be stored. bktec will instruct RSpec to output the JSON result to this path, which is necessary for bktec to read the test results for retries and verification purposes.
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=rspec
+export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/result.json
+```
+
+## Test Command
+By default, bktec runs RSpec with the following command:
+
+```sh
+bundle exec rspec --format progress --format json --out {{resultPath}} {{testExamples}}
+```
+
+In this command, `{{testExamples}}` is replaced by bktec with the list of test files or tests to run, and `{{resultPath}}` is replaced with the value set in `BUILDKITE_TEST_ENGINE_RESULT_PATH`. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.
+
+To customize the test command, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/rspec --format json --out {{resultPath}} {{testExamples}}"
+```
+
+> [!IMPORTANT]
+> Make sure to append `--format json --out {{resultPath}}` in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
+
+> [!IMPORTANT]
+> If you have another formatter configured in an [RSpec configuration file](https://rspec.info/features/3-13/rspec-core/configuration/read-options-from-file/), the default test command will override it. To avoid this, use a custom test command and add a JSON formatter in your RSpec configuration file.
+
+```sh
+export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/rspec-result.json
+export BUILDKITE_TEST_ENGINE_TEST_CMD="bundle exec rspec {{testExamples}}"
+```
+
+Then, in your RSpec configuration file:
+
+```sh
+#.rspec.ci
+--format junit
+--out rspec.xml
+--format json
+--out tmp/rspec-result.json
+```
+
+## Test Discovery and Filtering
+bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `spec/**/*_spec.rb` pattern. This means it will recursively find all Ruby files with a `_spec` suffix within the `spec` directory, such as `/spec/mode/user_spec.rb`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+
+Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
+
+To customize the discovery pattern and exclude certain files, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_PATTERN=spec/**/*_spec.rb
+export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=spec/features
+```
+
+With the above configurations, bktec will discover all files matching the `spec/**/*_spec.rb` pattern and exclude any files inside the `spec/features` directory.
+
+> [!TIP]
+> This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
+
+## Retry Failed Tests
+You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the command set in `BUILDKITE_TEST_ENGINE_RETRY_CMD` environment variable. If this variable is not set, bktec will use either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD` to retry the tests.
+
+To enable automatic retry, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
+```
+
+## Split tests by test example
+By default, bktec splits your tests by test file. To further optimize test execution, you can set the `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` environment variable to `true`. This setting enables bktec to dynamically split slow test files across multiple partitions based on their duration and the number of parallelism.
+
+To enable split by example, set the following environment variable:
+```sh
+export BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE=true
+```

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -41,18 +41,25 @@ Then, in your RSpec configuration file:
 --out tmp/rspec-result.json
 ```
 
-## Discover and filter test files
-bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `spec/**/*_spec.rb` pattern. This means it will recursively find all Ruby files with a `_spec` suffix within the `spec` directory, such as `/spec/mode/user_spec.rb`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
+## Filter test files
+By default, bktec runs test files that match the `spec/**/*_spec.rb` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run test files inside the `spec/features` directory, use:
 
-Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
-
-To customize the discovery pattern and exclude certain files, set the following environment variable:
 ```sh
-export BUILDKITE_TEST_ENGINE_TEST_PATTERN=spec/**/*_spec.rb
-export BUILDKITE_TEST_ENGINE_TEST_EXCLUDE_PATTERN=spec/features
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=spec/features/**/*_spec.rb
 ```
 
-With the above configurations, bktec will discover all files matching the `spec/**/*_spec.rb` pattern and exclude any files inside the `spec/features` directory.
+Additionally, you can exclude specific files or directories that match a certain pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable. For example, to exclude test files inside the `spec/features` directory, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=spec/features
+```
+
+You can also use both `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` and `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` simultaneously. For example, to run all test files inside the `spec/models` directory, except those inside `spec/models/user`, use:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=spec/models/**/*_spec.rb
+export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=spec/models/user
+```
 
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -6,7 +6,7 @@ export BUILDKITE_TEST_ENGINE_TEST_RUNNER=rspec
 export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/result.json
 ```
 
-## Test Command
+## Configure test command
 By default, bktec runs RSpec with the following command:
 
 ```sh
@@ -41,7 +41,7 @@ Then, in your RSpec configuration file:
 --out tmp/rspec-result.json
 ```
 
-## Test Discovery and Filtering
+## Discover and filter test files
 bktec discovers the test files using a glob pattern. By default, it identifies the files matching the `spec/**/*_spec.rb` pattern. This means it will recursively find all Ruby files with a `_spec` suffix within the `spec` directory, such as `/spec/mode/user_spec.rb`. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable.
 
 Additionally, you can exclude certain files or directories that match a specific pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN` environment variable.
@@ -57,7 +57,7 @@ With the above configurations, bktec will discover all files matching the `spec/
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
 
-## Retry Failed Tests
+## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the command set in `BUILDKITE_TEST_ENGINE_RETRY_CMD` environment variable. If this variable is not set, bktec will use either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD` to retry the tests.
 
 To enable automatic retry, set the following environment variable:
@@ -65,7 +65,7 @@ To enable automatic retry, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
 ```
 
-## Split tests by test example
+## Split slow files by individual test example
 By default, bktec splits your tests by test file. To further optimize test execution, you can set the `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` environment variable to `true`. This setting enables bktec to dynamically split slow test files across multiple partitions based on their duration and the number of parallelism.
 
 To enable split by example, set the following environment variable:

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -34,7 +34,7 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="bundle exec rspec {{testExamples}}"
 Then, in your RSpec configuration file:
 
 ```sh
-#.rspec.ci
+#.rspec
 --format junit
 --out rspec.xml
 --format json

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -66,7 +66,7 @@ export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
 ```
 
 ## Split slow files by individual test example
-By default, bktec splits your tests by test file. To further optimize test execution, you can set the `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` environment variable to `true`. This setting enables bktec to dynamically split slow test files across multiple partitions based on their duration and the number of parallelism.
+By default, bktec splits your test suite into batches of test files. In some scenarios, e.g. if your test suite has a few test files that take a very long time to run, you may want to split slow test files into individual test examples for execution. To enable this, you can set the `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` environment variable to `true`. This setting enables bktec to dynamically split slow test files across multiple partitions based on their duration and the number of parallelism.
 
 To enable split by example, set the following environment variable:
 ```sh


### PR DESCRIPTION
bktec has grown into 4 test runners which own default configuration values and available features. This PR restructure the README by introducing the usage guide for each test runner. I choose a feature based guide as opposed to environment variable based guide, to make it easier to see how to configure a feature rather than having to look at the list of environment variables.

I have also removed the "Migrating to 1.0.0" section and replaced it with a link to the original content. v1.0.0 has been released for a while, so I don't think we need to put this information up front any more.