### PR TITLE
Fix zzglob import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/DrJosh9000/zzglob v0.3.4
+	drjosh.dev/zzglob v0.4.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/pact-foundation/pact-go/v2 v2.0.8
 	golang.org/x/sys v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DrJosh9000/zzglob v0.3.4 h1:in47P18U5dFihwQ2QzDXuILQ2X9iNRkMHylukO3i48w=
-github.com/DrJosh9000/zzglob v0.3.4/go.mod h1:rMssZ45uIKN5WFJWLonPnC+fJTULGts9mjM7JjdF7UI=
+drjosh.dev/zzglob v0.4.0 h1:gOb46aIHyHG8BlYpvZZM4dqR2dpsbKtI82IbYVAYIj4=
+drjosh.dev/zzglob v0.4.0/go.mod h1:c3V3WPyfG+81h/bNOalEaba0jEQl16i9efSAmWOeOw8=
 github.com/buildkite/roko v1.2.0 h1:hbNURz//dQqNl6Eo9awjQOVOZwSDJ8VEbBDxSfT9rGQ=
 github.com/buildkite/roko v1.2.0/go.mod h1:23R9e6nHxgedznkwwfmqZ6+0VJZJZ2Sg/uVcp2cP46I=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/runner/discover.go
+++ b/internal/runner/discover.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/DrJosh9000/zzglob"
+	"drjosh.dev/zzglob"
 )
 
 func discoverTestFiles(pattern string, excludePattern string) ([]string, error) {


### PR DESCRIPTION
### Description

I moved the cheese.

### Context

Fixes dependabot and future releases.

### Testing

No testing performed. The new version of the library is just the old version but at a different path.