### PR TITLE
Escape special characters in testCases in Jest retry command

### DIFF
--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -169,7 +170,12 @@ func (j Jest) retryCommandNameAndArgs(cmd string, testCases []string) (string, [
 		return "", []string{}, err
 	}
 
-	testNamePattern := fmt.Sprintf("(%s)", strings.Join(testCases, "|"))
+	escapedTestCases := make([]string, len(testCases))
+	for i, testCase := range testCases {
+		escapedTestCases[i] = regexp.QuoteMeta(testCase)
+	}
+
+	testNamePattern := fmt.Sprintf("(%s)", strings.Join(escapedTestCases, "|"))
 
 	words = slices.Replace(words, idx, idx+1, testNamePattern)
 

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -299,6 +299,33 @@ func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
 	}
 }
 
+func TestJestRetryCommandNameAndArgs_WithSpecialCharacters(t *testing.T) {
+	testCases := []string{"this will fail", "test with special characters .+*?()|[]{}^$"}
+	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
+
+	jest := Jest{
+		RunnerConfig{
+			RetryTestCommand: retryTestCommand,
+			ResultPath:       "jest.json",
+		},
+	}
+
+	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases)
+	if err != nil {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
+	}
+
+	wantName := "jest"
+	wantArgs := []string{"--testNamePattern", `(this will fail|test with special characters \.\+\*\?\(\)\|\[\]\{\}\^\$)`, "--json", "--testLocationInResults", "--outputFile", "jest.json"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+	}
+}
+
 func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	testCases := []string{"this will fail", "this other one will fail"}
 	retryTestCommand := "jest --json --outputFile {{resultPath}}"

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -300,7 +300,7 @@ func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
 }
 
 func TestJestRetryCommandNameAndArgs_WithSpecialCharacters(t *testing.T) {
-	testCases := []string{"this will fail", "test with special characters .+*?()|[]{}^$"}
+	testCases := []string{"test with special characters .+*?()|[]{}^$", "another test"}
 	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 
 	jest := Jest{
@@ -316,7 +316,7 @@ func TestJestRetryCommandNameAndArgs_WithSpecialCharacters(t *testing.T) {
 	}
 
 	wantName := "jest"
-	wantArgs := []string{"--testNamePattern", `(this will fail|test with special characters \.\+\*\?\(\)\|\[\]\{\}\^\$)`, "--json", "--testLocationInResults", "--outputFile", "jest.json"}
+	wantArgs := []string{"--testNamePattern", `(test with special characters \.\+\*\?\(\)\|\[\]\{\}\^\$|another test)`, "--json", "--testLocationInResults", "--outputFile", "jest.json"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)


### PR DESCRIPTION
Jest use regex to execute an individual test. When there is a failed test and retry is enabled, `bktec` passes the failed test name as regex to Jest to execute. However, test name may contain special characters that need to be escaped. 

This pull request fixes the issue and ensures that special characters are escaped using the `regexp.QuoteMeta` function before constructing the test name pattern. This prevents any potential issues or errors when retrying tests with special characters in their names.