### PR TITLE
Print actual command when running Jest.

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -1,9 +1,11 @@
 package runner
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 )
 
@@ -15,6 +17,9 @@ func runAndForwardSignal(cmd *exec.Cmd) error {
 	// Create a channel that will be closed when the command finishes.
 	finishCh := make(chan struct{})
 	defer close(finishCh)
+
+	fmt.Println(strings.Join(cmd.Args, " "))
+	fmt.Println("")
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
-	"strings"
 
 	"github.com/buildkite/test-engine-client/internal/debug"
 	"github.com/buildkite/test-engine-client/internal/plan"
@@ -39,7 +38,6 @@ func (c Cypress) Run(testCases []string, retry bool) (RunResult, error) {
 
 	cmd := exec.Command(cmdName, cmdArgs...)
 
-	fmt.Printf("%s %s\n", cmdName, strings.Join(cmdArgs, " "))
 	err = runAndForwardSignal(cmd)
 
 	if err != nil {

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"slices"
-	"strings"
 
 	"github.com/buildkite/test-engine-client/internal/debug"
 	"github.com/buildkite/test-engine-client/internal/plan"
@@ -42,8 +41,6 @@ func (p Playwright) Run(testCases []string, retry bool) (RunResult, error) {
 
 	cmd := exec.Command(cmdName, cmdArgs...)
 
-	// double new line is required because Playwright output removes the last line
-	fmt.Printf("%s %s\n\n", cmdName, strings.Join(cmdArgs, " "))
 	err = runAndForwardSignal(cmd)
 
 	if err == nil { // note: returning success early

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -82,7 +82,6 @@ func (r Rspec) Run(testCases []string, retry bool) (RunResult, error) {
 		return RunResult{Status: RunStatusError}, fmt.Errorf("failed to build command: %w", err)
 	}
 
-	fmt.Printf("%s %s\n", commandName, strings.Join(commandArgs, " "))
 	cmd := exec.Command(commandName, commandArgs...)
 
 	err = runAndForwardSignal(cmd)


### PR DESCRIPTION
`bktec` doesn't print the actual command when running Jest. This PR fixes the issue by moving the printing from each test runner's `Run` function to the underlying `runAndForwardSignal` function used within the `Run` function. This avoids having to print the command in each test runner.