### PR TITLE
Fix Cypress command

### DIFF
--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
+	"strings"
 
 	"github.com/buildkite/test-engine-client/internal/debug"
 	"github.com/buildkite/test-engine-client/internal/plan"
@@ -73,11 +74,11 @@ func (c Cypress) commandNameAndArgs(cmd string, testCases []string) (string, []s
 		return "", []string{}, err
 	}
 	idx := slices.Index(words, "{{testExamples}}")
+	specs := strings.Join(testCases, ",")
 	if idx < 0 {
-		words = append(words, "--spec")
-		words = append(words, testCases...)
+		words = append(words, "--spec", specs)
 	} else {
-		words = slices.Replace(words, idx, idx+1, testCases...)
+		words[idx] = specs
 	}
 
 	return words[0], words[1:], nil

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -40,7 +40,7 @@ func TestCypressRun_TestFailed(t *testing.T) {
 		TestCommand: "yarn cypress run --spec {{testExamples}}",
 	})
 
-	files := []string{"./cypress/e2e/failing_spec.cy.js"}
+	files := []string{"./cypress/e2e/failing_spec.cy.js", "./cypress/e2e/passing_spec.cy.js"}
 	got, err := cypress.Run(files, false)
 
 	want := RunResult{
@@ -142,7 +142,7 @@ func TestCypressCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	}
 
 	wantName := "cypress"
-	wantArgs := []string{"run", "--spec", "cypress/e2e/passing_spec.cy.js", "cypress/e2e/flaky_spec.cy.js"}
+	wantArgs := []string{"run", "--spec", "cypress/e2e/passing_spec.cy.js,cypress/e2e/flaky_spec.cy.js"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
@@ -168,7 +168,7 @@ func TestCypressCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) 
 	}
 
 	wantName := "cypress"
-	wantArgs := []string{"run", "--spec", "cypress/e2e/passing_spec.cy.js", "cypress/e2e/flaky_spec.cy.js"}
+	wantArgs := []string{"run", "--spec", "cypress/e2e/passing_spec.cy.js,cypress/e2e/flaky_spec.cy.js"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
bktec replaces `{{testExamples}}` with the list of test files, separated by a space, which is not recommended by cypress. 

```bash
⚠ Warning: It looks like you're passing --spec a space-separated list of arguments:
"./cypress/e2e/click.cy.js ./cypress/e2e/visit.cy.js"
This will work, but it's not recommended.
If you are trying to pass multiple arguments, separate them with commas instead:
  cypress run --spec arg1,arg2,arg3
  
The most common cause of this warning is using an unescaped glob pattern. If you are
trying to pass a glob pattern, escape it using quotes:
  cypress run --spec "**/*.spec.js"
```

This PR update the Cypress command to join the list of tests with `,`.
