### PR TITLE
Add logo to startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,21 @@ import (
 
 var Version = ""
 
+const Logo = `
+______ ______ _____
+___  /____  /___  /____________
+__  __ \_  //_/  __/  _ \  ___/
+_  /_/ /  ,<  / /_ /  __/ /__
+/_.___//_/|_| \__/ \___/\___/
+`
+
+func printStartUpMessage() {
+	const green = "\033[32m"
+	const reset = "\033[0m"
+	fmt.Println(green + Logo + reset)
+	fmt.Println("Buildkite Test Engine Client: bktec " + Version + "\n")
+}
+
 type TestRunner interface {
 	Run(testCases []plan.TestCase, retry bool) (runner.RunResult, error)
 	GetExamples(files []string) ([]plan.TestCase, error)
@@ -41,6 +56,8 @@ func main() {
 		fmt.Println(Version)
 		os.Exit(0)
 	}
+
+	printStartUpMessage()
 
 	// get config
 	cfg, err := config.New()


### PR DESCRIPTION
This adds the speedy bktec logo to the startup of the bktec program. I picked the same green as we use in this text here: 

<img width="267" alt="Screenshot 2024-11-19 at 3 00 41 PM" src="https://github.com/user-attachments/assets/fb06fd1e-69a7-4d6f-bdb6-e7ab54e2d344">

Have included a screenshot if this working locally but it doesn't have the version number included because we set that on the release pipeline 

<img width="975" alt="Screenshot 2024-11-19 at 3 05 45 PM" src="https://github.com/user-attachments/assets/6ff81e2a-afd2-411b-85bb-cb51087c2c9c">

