### PR TITLE
Add log group for start of bktec + logo

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ _  /_/ /  ,<  / /_ /  __/ /__
 func printStartUpMessage() {
 	const green = "\033[32m"
 	const reset = "\033[0m"
+	fmt.Println("+++ Buildkite Test Engine Client: bktec " + Version + "\n")
 	fmt.Println(green + Logo + reset)
-	fmt.Println("Buildkite Test Engine Client: bktec " + Version + "\n")
 }
 
 type TestRunner interface {


### PR DESCRIPTION
When looking at the job logs for bktec, @jameshill and I realised that the new logo we added wasn't very visible and could often be hidden in the previous log group. Making this change so its more visible 