### PR TITLE
Handle errors outside of example

### DIFF
--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -40,7 +40,6 @@ func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) e
 	}
 	cmdName, cmdArgs, err := c.commandNameAndArgs(c.TestCommand, testPaths)
 	if err != nil {
-		result.err = err
 		return fmt.Errorf("failed to build command: %w", err)
 	}
 
@@ -48,7 +47,6 @@ func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) e
 
 	err = runAndForwardSignal(cmd)
 
-	result.err = err
 	return err
 }
 

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -28,8 +28,8 @@ func TestCypressRun(t *testing.T) {
 		t.Errorf("Cypress.Run(%q) error = %v", testCases, err)
 	}
 
-	if result.Status() != RunStatusPassed {
-		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusPassed)
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
 	}
 }
 
@@ -47,8 +47,8 @@ func TestCypressRun_TestFailed(t *testing.T) {
 	result := NewRunResult([]plan.TestCase{})
 	err := cypress.Run(result, testCases, false)
 
-	if result.Status() != RunStatusError {
-		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
 	}
 
 	exitError := new(exec.ExitError)
@@ -66,8 +66,8 @@ func TestCypressRun_CommandFailed(t *testing.T) {
 	result := NewRunResult([]plan.TestCase{})
 	err := cypress.Run(result, testCases, false)
 
-	if result.Status() != RunStatusError {
-		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
 	}
 
 	exitError := new(exec.ExitError)
@@ -87,8 +87,8 @@ func TestCypressRun_SignaledError(t *testing.T) {
 	result := NewRunResult([]plan.TestCase{})
 	err := cypress.Run(result, testCases, false)
 
-	if result.Status() != RunStatusError {
-		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Cypress.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
 	}
 
 	signalError := new(ProcessSignaledError)

--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -83,8 +83,10 @@ func TestDiscoverTestFiles_ExcludeNodeModules(t *testing.T) {
 		"testdata/cypress/cypress.config.js",
 		"testdata/jest/failure.spec.js",
 		"testdata/jest/jest.config.js",
+		"testdata/jest/runtimeError.spec.js",
 		"testdata/jest/spells/expelliarmus.spec.js",
 		"testdata/playwright/playwright.config.js",
+		"testdata/playwright/tests/error.spec.js",
 		"testdata/playwright/tests/example.spec.js",
 		"testdata/playwright/tests/failed.spec.js",
 	}

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -119,8 +119,8 @@ func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) erro
 		}
 	}
 
-	for i := 0; i < report.NumRuntimeErrorTestSuites; i++ {
-		result.errors = append(result.errors, ErrOutsideOfTest)
+	if report.NumRuntimeErrorTestSuites > 0 {
+		result.error = fmt.Errorf("Jest failed with runtime error test suites")
 	}
 
 	return nil

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -43,7 +43,6 @@ func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool
 
 	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, testPaths)
 	if err != nil {
-		result.err = err
 		return fmt.Errorf("failed to build command: %w", err)
 	}
 
@@ -52,14 +51,12 @@ func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool
 	err = runAndForwardSignal(cmd)
 
 	if ProcessSignaledError := new(ProcessSignaledError); errors.As(err, &ProcessSignaledError) {
-		result.err = err
 		return err
 	}
 
 	report, parseErr := p.parseReport(p.ResultPath)
 	if parseErr != nil {
 		fmt.Println("Buildkite Test Engine Client: Failed to read Playwright output, tests will not be retried.")
-		result.err = err
 		return err
 	}
 
@@ -69,6 +66,11 @@ func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool
 			result.RecordTestResult(testResult.TestCase, testResult.Status)
 		}
 	}
+
+	for _, reportError := range report.Errors {
+		result.errors = append(result.errors, fmt.Errorf("Playwright error: %s", reportError.Message))
+	}
+
 	return nil
 
 }
@@ -187,5 +189,8 @@ type PlaywrightReport struct {
 	Stats  struct {
 		Expected   int
 		Unexpected int
+	}
+	Errors []struct {
+		Message string
 	}
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -67,8 +67,8 @@ func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool
 		}
 	}
 
-	for _, reportError := range report.Errors {
-		result.errors = append(result.errors, fmt.Errorf("Playwright error: %s", reportError.Message))
+	if len(report.Errors) > 0 {
+		result.error = fmt.Errorf("Playwright failed with errors")
 	}
 
 	return nil

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -117,8 +117,8 @@ func (r Rspec) Run(result *RunResult, testCases []plan.TestCase, retry bool) err
 		result.RecordTestResult(mapExampleToTestCase(example), status)
 	}
 
-	for i := 0; i < report.Summary.ErrorsOutsideOfExamplesCount; i++ {
-		result.errors = append(result.errors, ErrOutsideOfTest)
+	if report.Summary.ErrorsOutsideOfExamplesCount > 0 {
+		result.error = fmt.Errorf("RSpec failed with errors outside of examples")
 	}
 
 	return nil

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -1,8 +1,6 @@
 package runner
 
 import (
-	"errors"
-
 	"github.com/buildkite/test-engine-client/internal/plan"
 )
 
@@ -20,8 +18,6 @@ const (
 	RunStatusUnknown RunStatus = "unknown"
 )
 
-var ErrOutsideOfTest = errors.New("errors outside of tests")
-
 // RunResult is a struct to keep track the results of a test run.
 // It contains the logics to record test results, calculate the status of the run.
 type RunResult struct {
@@ -30,7 +26,7 @@ type RunResult struct {
 	// mutedTestLookup is a map containing the test identifiers of muted tests.
 	// This list might contain tests that are not part of the current run (i.e. belong to a different node).
 	mutedTestLookup map[string]bool
-	errors          []error
+	error           error
 }
 
 func NewRunResult(mutedTests []plan.TestCase) *RunResult {
@@ -105,7 +101,7 @@ func (r *RunResult) MutedTests() []TestResult {
 // If there are failed tests, it returns RunStatusFailed.
 // Otherwise, it returns RunStatusPassed.
 func (r *RunResult) Status() RunStatus {
-	if len(r.errors) > 0 {
+	if r.error != nil {
 		return RunStatusError
 	}
 
@@ -118,6 +114,10 @@ func (r *RunResult) Status() RunStatus {
 	}
 
 	return RunStatusPassed
+}
+
+func (r *RunResult) Error() error {
+	return r.error
 }
 
 type RunStatistics struct {

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -127,7 +127,6 @@ type RunStatistics struct {
 	MutedPassed      int
 	MutedFailed      int
 	Failed           int
-	Error            int
 }
 
 func (r *RunResult) Statistics() RunStatistics {
@@ -156,12 +155,11 @@ func (r *RunResult) Statistics() RunStatistics {
 	}
 
 	return RunStatistics{
-		Total:            len(r.tests) + len(r.errors),
+		Total:            len(r.tests),
 		PassedOnFirstRun: passedOnFirstRun,
 		PassedOnRetry:    passedOnRetry,
 		MutedPassed:      mutedPassed,
 		MutedFailed:      mutedFailed,
 		Failed:           failed,
-		Error:            len(r.errors),
 	}
 }

--- a/internal/runner/run_result_test.go
+++ b/internal/runner/run_result_test.go
@@ -192,16 +192,44 @@ func TestRunStatistics(t *testing.T) {
 	r.RecordTestResult(plan.TestCase{Scope: "banana", Name: "is yellow"}, TestStatusFailed)
 	r.RecordTestResult(plan.TestCase{Scope: "banana", Name: "is yellow"}, TestStatusFailed) // test failed twice
 
+	// error: 1
+	r.errors = append(r.errors, ErrOutsideOfTest)
+
 	stats := r.Statistics()
 
 	if diff := cmp.Diff(stats, RunStatistics{
-		Total:            6,
+		Total:            7,
 		PassedOnFirstRun: 2,
 		PassedOnRetry:    1,
 		MutedPassed:      1,
 		MutedFailed:      1,
 		Failed:           1,
+		Error:            1,
 	}); diff != "" {
 		t.Errorf("Statistics() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestRunStatus(t *testing.T) {
+	r := NewRunResult([]plan.TestCase{})
+	r.RecordTestResult(plan.TestCase{Scope: "mango", Name: "is sour"}, TestStatusPassed)
+	if r.Status() != RunStatusPassed {
+		t.Errorf("Status() is %s, want %s", r.Status(), RunStatusPassed)
+	}
+}
+
+func TestRunStatus_Failed(t *testing.T) {
+	r := NewRunResult([]plan.TestCase{})
+	r.RecordTestResult(plan.TestCase{Scope: "mango", Name: "is sour"}, TestStatusFailed)
+	if r.Status() != RunStatusFailed {
+		t.Errorf("Status() is %s, want %s", r.Status(), RunStatusFailed)
+	}
+}
+
+func TestRunStatus_Error(t *testing.T) {
+	r := NewRunResult([]plan.TestCase{})
+	r.errors = append(r.errors, ErrOutsideOfTest)
+	if r.Status() != RunStatusError {
+		t.Errorf("Status() is %s, want %s", r.Status(), RunStatusError)
 	}
 }

--- a/internal/runner/run_result_test.go
+++ b/internal/runner/run_result_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -224,7 +225,7 @@ func TestRunStatus_Failed(t *testing.T) {
 
 func TestRunStatus_Error(t *testing.T) {
 	r := NewRunResult([]plan.TestCase{})
-	r.errors = append(r.errors, ErrOutsideOfTest)
+	r.error = fmt.Errorf("error")
 	if r.Status() != RunStatusError {
 		t.Errorf("Status() is %s, want %s", r.Status(), RunStatusError)
 	}

--- a/internal/runner/run_result_test.go
+++ b/internal/runner/run_result_test.go
@@ -192,19 +192,15 @@ func TestRunStatistics(t *testing.T) {
 	r.RecordTestResult(plan.TestCase{Scope: "banana", Name: "is yellow"}, TestStatusFailed)
 	r.RecordTestResult(plan.TestCase{Scope: "banana", Name: "is yellow"}, TestStatusFailed) // test failed twice
 
-	// error: 1
-	r.errors = append(r.errors, ErrOutsideOfTest)
-
 	stats := r.Statistics()
 
 	if diff := cmp.Diff(stats, RunStatistics{
-		Total:            7,
+		Total:            6,
 		PassedOnFirstRun: 2,
 		PassedOnRetry:    1,
 		MutedPassed:      1,
 		MutedFailed:      1,
 		Failed:           1,
-		Error:            1,
 	}); diff != "" {
 		t.Errorf("Statistics() diff (-got +want):\n%s", diff)
 	}

--- a/internal/runner/testdata/jest/runtimeError.spec.js
+++ b/internal/runner/testdata/jest/runtimeError.spec.js
@@ -1,0 +1,3 @@
+describe('this will fail', () => {
+  boom()
+})

--- a/internal/runner/testdata/playwright/tests/error.spec.js
+++ b/internal/runner/testdata/playwright/tests/error.spec.js
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+boom();
+
+test.describe('test group', () => {
+  test('failed', () => {
+    expect(1).toBe(2);
+  })
+});

--- a/internal/runner/testdata/rspec/spec/bad_syntax_spec.rb
+++ b/internal/runner/testdata/rspec/spec/bad_syntax_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe "bad syntax" do
+  it "is missing an end" do
+    if true
+      expect(true).to be_truthy
+  end
+end

--- a/main.go
+++ b/main.go
@@ -130,13 +130,6 @@ func main() {
 }
 
 func printReport(runResult runner.RunResult) {
-	statistics := runResult.Statistics()
-
-	if statistics.Total == 0 {
-		return
-	}
-
-	// Print statistics
 	fmt.Println("+++ ========== Buildkite Test Engine Report  ==========")
 
 	switch runResult.Status() {
@@ -145,9 +138,12 @@ func printReport(runResult runner.RunResult) {
 	case runner.RunStatusFailed:
 		fmt.Println("❌ Some tests failed.")
 	case runner.RunStatusError:
-		fmt.Println("🚨 Errors encountered outside of tests.")
+		fmt.Printf("🚨 %s\n", runResult.Error())
 	}
+	fmt.Println("")
 
+	// Print statistics
+	statistics := runResult.Statistics()
 	data := [][]string{
 		{"Passed", "first run", strconv.Itoa(statistics.PassedOnFirstRun)},
 		{"Passed", "on retry", strconv.Itoa(statistics.PassedOnRetry)},

--- a/main_test.go
+++ b/main_test.go
@@ -237,12 +237,12 @@ func TestRunTestsWithRetry_ExecError(t *testing.T) {
 		t.Errorf("runTestsWithRetry(%q) error type = %T (%v), want *exec.Error", testCases, err, err)
 	}
 
-	if testResult.Status() != runner.RunStatusError {
-		t.Errorf("runTestsWithRetry(...) testResult.Status = %v, want %v", testResult.Status(), runner.RunStatusError)
+	if testResult.Status() != runner.RunStatusUnknown {
+		t.Errorf("runTestsWithRetry(...) testResult.Status = %v, want %v", testResult.Status(), runner.RunStatusUnknown)
 	}
 }
 
-func TestRunTestsWithRetry_Error(t *testing.T) {
+func TestRunTestsWithRetry_CommandError(t *testing.T) {
 	testRunner := runner.NewRspec(runner.RunnerConfig{
 		TestCommand: "rspec --invalid-option",
 	})
@@ -258,8 +258,8 @@ func TestRunTestsWithRetry_Error(t *testing.T) {
 		t.Errorf("runTestsWithRetry(...) error type = %T (%v), want *exec.ExitError", err, err)
 	}
 
-	if testResult.Status() != runner.RunStatusError {
-		t.Errorf("runTestsWithRetry(...) testResult.Status = %v, want %v", testResult.Status(), runner.RunStatusError)
+	if testResult.Status() != runner.RunStatusUnknown {
+		t.Errorf("runTestsWithRetry(...) testResult.Status = %v, want %v", testResult.Status(), runner.RunStatusUnknown)
 	}
 
 	if len(timeline) != 2 {

--- a/testdata/rspec/spec/bad_syntax_spec.rb
+++ b/testdata/rspec/spec/bad_syntax_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe "bad syntax" do
+  it "is missing an end" do
+    if true
+      expect(true).to be_truthy
+  end
+end


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
When there is a failure outside of test (e.g. syntax error, runtime error), bktec might exit with `0` exit code when there is no other test failure. These changes handle the failure outside of tests to avoid bktec reporting a false positive (false "pass").

### Changes
1. To handle test error (not test failure), we need to distinguish between error in the command (runner exits prematurely) and error in the test (test finished with error). The `Run` function in each runner will return the followings:
   - test finished without failure/error: `RunResult.Status: 'passed', err: nil`
   - test finished with failure(s): `RunResult.Status: 'failed', err: nil`
   - test finished with error(s): `RunResult.Status: 'error', err: nil`
   - test didn't finish or finished without readable result: `RunResult.Status: 'unknown', err: any error from the runner process`
1. I updated and tidied up the "exit" logic in main function. The main function will now exit with code `1` when the `RunResult.Status` is `error` (e.g. there are errors outside of tests). It will also print the run status in the report.

<img width="578" alt="Screenshot 2024-12-09 at 5 14 58 PM" src="https://github.com/user-attachments/assets/92677143-dff0-4abb-a907-8fd07375dbbb">
