### PR TITLE
Write a script to run e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ internal/api/pacts/
 
 dist/
 node_modules/
+
+internal/runner/testdata/jest/jest-result.json
+
+internal/runner/testdata/rspec/rspec-result.json

--- a/README.md
+++ b/README.md
@@ -95,3 +95,18 @@ bktec may exit with a variety of exit statuses, outlined below:
   SIGABRT, the exit status returned will be equal to 128 plus the signal number.
   For example, if the runner raises a SIGSEGV, the exit status will be (128 +
   11) = 139.
+
+## Development
+
+Make sure you have Go, Ruby, and Node.js installed in your environment. You can follow the installation guides for each of these tools:
+
+- [Go Installation Guide](https://golang.org/doc/install)
+- [Ruby Installation Guide](https://www.ruby-lang.org/en/documentation/installation/)
+- [Node.js Installation Guide](https://nodejs.org/en/download/package-manager/)
+
+Once you have these dependencies installed, run `bin/setup` to install dependencies for the sample projects for testing purposes. 
+
+To test, run:
+```sh
+go test ./...
+```

--- a/bin/e2e
+++ b/bin/e2e
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script is used to run bktec against the sample project for the given test runner.
+# Sample project can be found in internal/runner/testdata/<test-runner>
+#
+# Usage: ./bin/e2e <test-runner> <parallel-job>
+# 
+# Note: you need to manually set the following environment variables
+# - BUILDKITE_ORGANIZATION_SLUG
+# - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
+# - BUILDKITE_TEST_ENGINE_SUITE_SLUG
+
+export BUILDKITE_BUILD_ID=$(uuidgen)
+export BUILDKITE_PARALLEL_JOB=${2:-0}
+export BUILDKITE_PARALLEL_JOB_COUNT=2
+export BUILDKITE_STEP_ID=$BUILDKITE_TEST_ENGINE_TEST_RUNNER
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="${BUILDKITE_TEST_ENGINE_TEST_RUNNER}-result.json"
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=${1:-rspec}
+
+# Override the following variables to the default value, in case they are set somewhere else
+export BUILDKITE_TEST_ENGINE_TEST_CMD=""
+export BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN=""
+
+# Extra configuration for playwright
+if [ "$BUILDKITE_TEST_ENGINE_TEST_RUNNER" == "playwright" ]; then
+  # We need to tell bktec to use playwright's result path configured in playwright.config.js
+  export BUILDKITE_TEST_ENGINE_RESULT_PATH="test-results/results.json"
+  # error.spec.js will prevent other tests from running, so we exclude it
+  export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN="**/*/error.spec.js"
+fi
+
+cd ./internal/runner/testdata/$BUILDKITE_TEST_ENGINE_TEST_RUNNER
+
+go run ../../../../main.go

--- a/bin/e2e
+++ b/bin/e2e
@@ -3,19 +3,20 @@
 # This script is used to run bktec against the sample project for the given test runner.
 # Sample project can be found in internal/runner/testdata/<test-runner>
 #
-# Usage: ./bin/e2e <test-runner> <parallel-job>
+# Usage: ./bin/e2e <test-runner>
 # 
 # Note: you need to manually set the following environment variables
 # - BUILDKITE_ORGANIZATION_SLUG
 # - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
 # - BUILDKITE_TEST_ENGINE_SUITE_SLUG
 
-export BUILDKITE_BUILD_ID=$(uuidgen)
-export BUILDKITE_PARALLEL_JOB=${2:-0}
-export BUILDKITE_PARALLEL_JOB_COUNT=2
-export BUILDKITE_STEP_ID=$BUILDKITE_TEST_ENGINE_TEST_RUNNER
-export BUILDKITE_TEST_ENGINE_RESULT_PATH="${BUILDKITE_TEST_ENGINE_TEST_RUNNER}-result.json"
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=${1:-rspec}
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="${BUILDKITE_TEST_ENGINE_TEST_RUNNER}-result.json"
+
+export BUILDKITE_BUILD_ID=$(date +%s)
+export BUILDKITE_PARALLEL_JOB=${BUILDKITE_PARALLEL_JOB:-0}
+export BUILDKITE_PARALLEL_JOB_COUNT=${BUILDKITE_PARALLEL_JOB_COUNT:-2}
+export BUILDKITE_STEP_ID=$BUILDKITE_TEST_ENGINE_TEST_RUNNER
 
 # Override the following variables to the default value, in case they are set somewhere else
 export BUILDKITE_TEST_ENGINE_TEST_CMD=""

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+echo "🛠️ Installing dependencies for sample projects..."
+
+cd ./internal/runner/testdata
+# if yarn is available, use it to install dependencies
+# otherwise, use npm
+if command -v yarn &> /dev/null
+then
+  yarn install
+else
+  npm install
+fi
+
+# Install Playwright dependencies
+cd ./playwright
+npx playwright install
+npx playwright install-deps
+
+# Install Cypress dependencies
+cd ../cypress
+npx cypress install
+npx cypress verify
+
+# Install RSpec dependencies
+cd ../rspec
+bundle install
+

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -57,7 +57,7 @@ func TestJestRun(t *testing.T) {
 	changeCwd(t, "./testdata/jest")
 
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{resultPath}}",
+		TestCommand: "npx jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 
@@ -89,7 +89,7 @@ func TestJestRun_Retry(t *testing.T) {
 
 	jest := NewJest(RunnerConfig{
 		TestCommand:      "jest --invalid-option --json --outputFile {{resultPath}}",
-		RetryTestCommand: "jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{resultPath}} ./testdata/jest/spells/expelliarmus.spec.js ./testdata/jest/failure.spec.js",
+		RetryTestCommand: "npx jest --testNamePattern '{{testNamePattern}}' --json --outputFile {{resultPath}} ./testdata/jest/spells/expelliarmus.spec.js ./testdata/jest/failure.spec.js",
 		ResultPath:       "jest.json",
 	})
 
@@ -116,7 +116,7 @@ func TestJestRun_TestFailed(t *testing.T) {
 	changeCwd(t, "./testdata/jest")
 
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{resultPath}}",
+		TestCommand: "npx jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 
@@ -154,7 +154,7 @@ func TestJestRun_TestSkipped(t *testing.T) {
 	changeCwd(t, "./testdata/jest")
 
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{resultPath}}",
+		TestCommand: "npx jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 
@@ -191,7 +191,7 @@ func TestJestRun_RuntimeError(t *testing.T) {
 	changeCwd(t, "./testdata/jest")
 
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --json --outputFile {{resultPath}}",
+		TestCommand: "npx jest --json --outputFile {{resultPath}}",
 		ResultPath:  "jest.json",
 	})
 
@@ -217,7 +217,7 @@ func TestJestRun_RuntimeError(t *testing.T) {
 
 func TestJestRun_CommandFailed(t *testing.T) {
 	jest := NewJest(RunnerConfig{
-		TestCommand: "jest --invalid-option --outputFile {{resultPath}}",
+		TestCommand: "npx jest --invalid-option --outputFile {{resultPath}}",
 	})
 
 	t.Cleanup(func() {

--- a/internal/runner/testdata/rspec/Gemfile
+++ b/internal/runner/testdata/rspec/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rspec"

--- a/internal/runner/testdata/rspec/Gemfile.lock
+++ b/internal/runner/testdata/rspec/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  rspec
+
+BUNDLED WITH
+   2.5.16


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We now have four runners supported in `bktec`. Since we have sample projects for each test runner that we use for unit and integration tests, I thought it would be great to use those sample projects to run end-to-end tests. This PR adds a script that runs `bktec` (using `go run …`) against a sample project located in `internal/runner/testdata`.

To run the e2e test:
```shell
#.bin/e2e <runner> <parallel-job>
.bin/e2e rspec 0
```
