### PR TITLE
Retry only if there are failed tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,8 +248,14 @@ func runTestsWithRetry(testRunner TestRunner, testsCases *[]plan.TestCase, maxRe
 			return *runResult, nil
 		}
 
-		// Retry only the failed tests.
-		*testsCases = runResult.FailedTests()
+		// Retry only if there are failed tests.
+		failedTests := runResult.FailedTests()
+
+		if len(failedTests) == 0 {
+			return *runResult, nil
+		}
+
+		*testsCases = failedTests
 		attemptCount++
 	}
 


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
With the introduction of #230, there is a scenario where a test fails, but there are no failed tests (occur when there is an error outside of the tests). In such cases, if retry is enabled, bktec attempts to retry the entire test suite, which can be time-consuming. This PR addresses this issue by only triggering the retry when there are failed tests.

### Context
https://linear.app/buildkite/issue/TET-469/retry-tests-only-when-there-is-failed-test
