### PR TITLE
Send run summary statistics as part of the metadata call

### DIFF
--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
+	"github.com/buildkite/test-engine-client/internal/runner"
 )
 
 type Timeline struct {
@@ -12,9 +14,10 @@ type Timeline struct {
 }
 
 type TestPlanMetadataParams struct {
-	Version  string            `json:"version"`
-	Env      map[string]string `json:"env"`
-	Timeline []Timeline        `json:"timeline"`
+	Version    string               `json:"version"`
+	Env        map[string]string    `json:"env"`
+	Timeline   []Timeline           `json:"timeline"`
+	Statistics runner.RunStatistics `json:"statistics"`
 }
 
 func (c Client) PostTestPlanMetadata(ctx context.Context, suiteSlug string, identifier string, params TestPlanMetadataParams) error {

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/buildkite/test-engine-client/internal/runner"
 	"github.com/pact-foundation/pact-go/v2/consumer"
 	"github.com/pact-foundation/pact-go/v2/matchers"
 )
@@ -38,6 +39,9 @@ func TestPostTestPlanMetadata(t *testing.T) {
 				Event:     "test_end",
 				Timestamp: "2024-06-20T04:49:09.609793Z",
 			},
+		},
+		Statistics: runner.RunStatistics{
+			Total: 3,
 		},
 	}
 
@@ -111,6 +115,9 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 				Event:     "test_end",
 				Timestamp: "2024-06-20T04:49:09.609793Z",
 			},
+		},
+		Statistics: runner.RunStatistics{
+			Total: 3,
 		},
 	}
 

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -132,13 +132,13 @@ func (r *RunResult) Error() error {
 }
 
 type RunStatistics struct {
-	Total            int
-	PassedOnFirstRun int
-	PassedOnRetry    int
-	MutedPassed      int
-	MutedFailed      int
-	Failed           int
-	Skipped          int
+	Total            int `json:"total"`
+	PassedOnFirstRun int `json:"passed_on_first_run"`
+	PassedOnRetry    int `json:"passed_on_retry"`
+	MutedPassed      int `json:"muted_passed"`
+	MutedFailed      int `json:"muted_failed"`
+	Failed           int `json:"failed"`
+	Skipped          int `json:"skipped"`
 }
 
 func (r *RunResult) Statistics() RunStatistics {

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func main() {
 	// At this point, the runner is expected to have completed
 
 	if !testPlan.Fallback {
-		sendMetadata(ctx, apiClient, cfg, timeline)
+		sendMetadata(ctx, apiClient, cfg, timeline, runResult.Statistics())
 	}
 
 	printReport(runResult, testPlan.SkippedTests, testRunner.Name())
@@ -203,11 +203,12 @@ func createTimestamp() string {
 	return time.Now().Format(time.RFC3339Nano)
 }
 
-func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config, timeline []api.Timeline) {
+func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config, timeline []api.Timeline, statistics runner.RunStatistics) {
 	err := apiClient.PostTestPlanMetadata(ctx, cfg.SuiteSlug, cfg.Identifier, api.TestPlanMetadataParams{
-		Timeline: timeline,
-		Env:      cfg.DumpEnv(),
-		Version:  Version,
+		Timeline:   timeline,
+		Env:        cfg.DumpEnv(),
+		Version:    Version,
+		Statistics: statistics,
 	})
 
 	// Error is suppressed because we don't want to fail the build if we can't send metadata.

--- a/main_test.go
+++ b/main_test.go
@@ -841,6 +841,9 @@ func TestSendMetadata(t *testing.T) {
 				"BUILDKITE_TEST_ENGINE_TEST_RUNNER":               "rspec",
 				"BUILDKITE_BRANCH":                                "",
 			},
+			Statistics: runner.RunStatistics{
+				Total: 3,
+			},
 		}
 
 		if diff := cmp.Diff(got, want); diff != "" {
@@ -863,7 +866,11 @@ func TestSendMetadata(t *testing.T) {
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
 
-	sendMetadata(context.Background(), client, cfg, timeline)
+	statistics := runner.RunStatistics{
+		Total: 3,
+	}
+
+	sendMetadata(context.Background(), client, cfg, timeline, statistics)
 }
 
 func TestSendMetadata_Unauthorized(t *testing.T) {
@@ -884,5 +891,9 @@ func TestSendMetadata_Unauthorized(t *testing.T) {
 
 	timeline := []api.Timeline{}
 
-	sendMetadata(context.Background(), client, cfg, timeline)
+	statistics := runner.RunStatistics{
+		Total: 3,
+	}
+
+	sendMetadata(context.Background(), client, cfg, timeline, statistics)
 }


### PR DESCRIPTION
### Description

As part of the sparkly badge to show on pipelines build pages to upsel bktec, we want to send the run summary statistics as part of the bktec metadata call.

This PR does the needful.

### Testing

I've tested that the statistics are being added to the metadata call by running against a local copy of bk/bk and logging out the params.

**Question:** Are we happy to send the statistics through in title-case as opposed to snake-case?

```
"statistics"
=>{"Total"=>37, "PassedOnFirstRun"=>37, "PassedOnRetry"=>0, "MutedPassed"=>0, "MutedFailed"=>0, "Failed"=>0, "Skipped"=>0}
```