### PR TITLE
Add script to publish and release pact

### DIFF
--- a/bin/publish-pact
+++ b/bin/publish-pact
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Use this to publish pact json files to the pact broker.
+# The pact JSON needs to be generated first by running the tests.
+# You'll need to have an environment variable called PACT_BROKER_TOKEN
+# with a write-access token.
+#
+# Run it like: bin/publish-pact v0.6.0
+
+VERSION=$1
+PACT_BROKER_BASE_URL=https://buildkite.pactflow.io
+
+docker run --rm \
+  -w ${PWD} \
+  -v ${PWD}:${PWD} \
+  -e PACT_BROKER_BASE_URL \
+  -e PACT_BROKER_TOKEN \
+    pactfoundation/pact-cli:latest \
+    publish \
+    ${PWD}/internal/api/pacts \
+    --consumer-app-version ${VERSION} \
+    --tag-with-git-branch

--- a/bin/release-pact-version
+++ b/bin/release-pact-version
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Use this to record a published pact version as a production release.
+# You'll need to have an environment variable called PACT_BROKER_TOKEN
+# with a write-access token.
+#
+# Run it like: bin/release-pact-version v0.6.0
+
+VERSION=$1
+PACT_BROKER_BASE_URL=https://buildkite.pactflow.io
+
+docker run --rm \
+  -e PACT_BROKER_BASE_URL \
+  -e PACT_BROKER_TOKEN \
+    pactfoundation/pact-cli:latest \
+    pact-broker \
+    record-release \
+    --environment production \
+    --pacticipant TestEngineClient \
+    --version ${VERSION}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Add scripts to publish and release pact files to the broker.

To publish pact files:
```bash
# generate pact files
go test github.com/buildkite/test-engine-client/internal/api -count=1

PACT_BROKER_TOKEN=your_token bin/publish-pact v1.3.0
```

To release pact version:
```bash
PACT_BROKER_TOKEN=your_token bin/release-pact-version v1.3.0
```
