### PR TITLE
Use golang image from official dockerhub repo

### DIFF
--- a/.buildkite/Dockerfile-compile
+++ b/.buildkite/Dockerfile-compile
@@ -1,7 +1,7 @@
 FROM ruby:3.4.1-slim-bookworm AS ruby
 FROM cypress/included:13.17.0 AS cypress
 
-FROM public.ecr.aws/docker/library/golang:1.23.5 AS golang
+FROM golang:1.23.5 AS golang
 
 COPY --from=ruby / /
 COPY --from=cypress / /


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
The build is failing because the agent cannot pull the GoLang image from AWS ECR. I don't see a strong reason for using the image from ECR, so I changed it to use the official image hosted in [dockerhub](https://hub.docker.com/_/golang).

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
[Failed builds](https://buildkite.com/buildkite/test-engine-client/builds?branch=main)

### Changes

<!--
List of what the PR changes.

Can skip if changes are simple or clear from the commit messages.
-->
