### PR TITLE
Handle 409 status codes the same as we do 500s

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -158,9 +158,9 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 			return resp, fmt.Errorf("response code: 429")
 		}
 
-		// If we get a 423, we aren't the first client to create the plan so return
+		// If we get a 409, we aren't the first client to create the plan so return
 		// and retry
-		if resp.StatusCode == http.StatusLocked {
+		if resp.StatusCode == http.StatusConflict {
 			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
 		}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -158,6 +158,12 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 			return resp, fmt.Errorf("response code: 429")
 		}
 
+		// If we get a 423, we aren't the first client to create the plan so return
+		// and retry
+		if resp.StatusCode == http.StatusLocked {
+			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
+		}
+
 		// If we get a 5xx, we should return and retry
 		if resp.StatusCode >= 500 {
 			return resp, fmt.Errorf("response code: %d", resp.StatusCode)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -225,7 +225,7 @@ func TestDoWithRetry_429(t *testing.T) {
 	}
 }
 
-func TestDoWithRetry_423(t *testing.T) {
+func TestDoWithRetry_409(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
 
@@ -241,7 +241,7 @@ func TestDoWithRetry_423(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 
-		w.WriteHeader(http.StatusLocked)
+		w.WriteHeader(http.StatusConflict)
 	}))
 	defer svr.Close()
 
@@ -258,7 +258,7 @@ func TestDoWithRetry_423(t *testing.T) {
 		URL:    svr.URL,
 	}, nil)
 
-	// it retries the request and returns ErrRetryTimeout with the 423 status code.
+	// it retries the request and returns ErrRetryTimeout with the 409 status code.
 	if requestCount < 2 {
 		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
 	}
@@ -267,8 +267,8 @@ func TestDoWithRetry_423(t *testing.T) {
 		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
 	}
 
-	if resp.StatusCode != http.StatusLocked {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusLocked)
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusConflict)
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -225,6 +225,53 @@ func TestDoWithRetry_429(t *testing.T) {
 	}
 }
 
+func TestDoWithRetry_423(t *testing.T) {
+	originalTimeout := retryTimeout
+	originalInitialDelay := initialDelay
+
+	retryTimeout = 1000 * time.Millisecond
+	initialDelay = 1 * time.Millisecond
+	t.Cleanup(func() {
+		retryTimeout = originalTimeout
+		initialDelay = originalInitialDelay
+	})
+
+	requestCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		w.WriteHeader(http.StatusLocked)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+
+	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+		Method: http.MethodGet,
+		URL:    svr.URL,
+	}, nil)
+
+	// it retries the request and returns ErrRetryTimeout with the 423 status code.
+	if requestCount < 2 {
+		t.Errorf("http request count = %v, want at least %d", requestCount, 2)
+	}
+
+	if !errors.Is(err, ErrRetryTimeout) {
+		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+	}
+
+	if resp.StatusCode != http.StatusLocked {
+		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusLocked)
+	}
+}
+
 func TestDoWithRetry_500(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay


### PR DESCRIPTION
### Description

We currently return an error in the 5XX range when the client loses the race to create the plan. This is not ideal as it's skewing our error budgets, so we're going to return 409 instead.
