### PR TITLE
refactor: move `main.Version` to new internal package `version`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - CGO_ENABLED=0
     goos: [linux, darwin]
     goarch: [amd64, arm64]
-    ldflags: "-X 'main.Version=v{{ .Version }}'"
+    ldflags: "-X 'github.com/buildkite/test-engine-client/internal/version.Version=v{{ .Version }}'"
     binary: bktec
 
 checksum:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/buildkite/roko"
 	"github.com/buildkite/test-engine-client/internal/debug"
+	"github.com/buildkite/test-engine-client/internal/version"
 )
 
 // client is a client for the test plan API.
@@ -30,19 +31,20 @@ type ClientConfig struct {
 	AccessToken      string
 	OrganizationSlug string
 	ServerBaseUrl    string
-	Version          string
 }
 
 // authTransport is a middleware for the HTTP client.
 type authTransport struct {
 	accessToken string
-	version     string
 }
 
 // RoundTrip adds the Authorization header to all requests made by the HTTP client.
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+t.accessToken)
-	req.Header.Set("User-Agent", fmt.Sprintf("Buildkite Test Engine Client/%s (%s/%s)", t.version, runtime.GOOS, runtime.GOARCH))
+	req.Header.Set("User-Agent", fmt.Sprintf(
+		"Buildkite Test Engine Client/%s (%s/%s)",
+		version.Version, runtime.GOOS, runtime.GOARCH,
+	))
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -52,7 +54,6 @@ func NewClient(cfg ClientConfig) *Client {
 	httpClient := &http.Client{
 		Transport: &authTransport{
 			accessToken: cfg.AccessToken,
-			version:     cfg.Version,
 		},
 	}
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/test-engine-client/internal/version"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -61,6 +62,12 @@ func TestHttpClient_AttachAccessTokenToRequest(t *testing.T) {
 }
 
 func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
+	originalVersion := version.Version
+	version.Version = "0.5.1"
+	defer func() {
+		version.Version = originalVersion
+	}()
+
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -71,7 +78,6 @@ func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
 		ServerBaseUrl:    svr.URL,
-		Version:          "0.5.1",
 	}
 
 	c := NewClient(cfg)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Injected by .goreleaser.yaml during release build.
+var Version = "dev"

--- a/main.go
+++ b/main.go
@@ -18,11 +18,10 @@ import (
 	"github.com/buildkite/test-engine-client/internal/debug"
 	"github.com/buildkite/test-engine-client/internal/plan"
 	"github.com/buildkite/test-engine-client/internal/runner"
+	"github.com/buildkite/test-engine-client/internal/version"
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/sys/unix"
 )
-
-var Version = ""
 
 const Logo = `
 ______ ______ _____
@@ -35,7 +34,7 @@ _  /_/ /  ,<  / /_ /  __/ /__
 func printStartUpMessage() {
 	const green = "\033[32m"
 	const reset = "\033[0m"
-	fmt.Println("+++ Buildkite Test Engine Client: bktec " + Version + "\n")
+	fmt.Println("+++ Buildkite Test Engine Client: bktec " + version.Version + "\n")
 	fmt.Println(green + Logo + reset)
 }
 
@@ -54,7 +53,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Println(Version)
+		fmt.Printf("bktec %s\n", version.Version)
 		os.Exit(0)
 	}
 
@@ -82,7 +81,6 @@ func main() {
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
-		Version:          Version,
 	})
 
 	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
@@ -207,7 +205,7 @@ func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config,
 	err := apiClient.PostTestPlanMetadata(ctx, cfg.SuiteSlug, cfg.Identifier, api.TestPlanMetadataParams{
 		Timeline:   timeline,
 		Env:        cfg.DumpEnv(),
-		Version:    Version,
+		Version:    version.Version,
 		Statistics: statistics,
 	})
 

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildkite/test-engine-client/internal/config"
 	"github.com/buildkite/test-engine-client/internal/plan"
 	"github.com/buildkite/test-engine-client/internal/runner"
+	"github.com/buildkite/test-engine-client/internal/version"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -837,10 +838,10 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 }
 
 func TestSendMetadata(t *testing.T) {
-	originalVersion := Version
-	Version = "0.1.0"
+	originalVersion := version.Version
+	version.Version = "0.1.0"
 	defer func() {
-		Version = originalVersion
+		version.Version = originalVersion
 	}()
 
 	timeline := []api.Timeline{


### PR DESCRIPTION
I found that with the `Version` global being in package `main`, it couldn't be reached by other packages.

I see that existing usage is either directly in `main` (arguably ready to be refactored into other packages), or threaded through via `api.ClientConfig{…, Version: Version}` and `authTransport{…,  version: …}`. I think this is a (rare?) example of a static build-time value that can just be compiled in and referenced as a global constant from anywhere in the codebase.

So, this PR moves the global `Version` string from package `main` to a new internal package `version`. This allows it to be reached from other packages, e.g. an upcoming `bktec upload` command, without having to thread it through from `main`.

It also initialises the string as `"dev"` instead of `""` so that non-release builds don't just have an empty string:

And, the `-version` flag now prints out `bktec {version}` rather than just `{version}`.

```
pda@pda-m3 ~/bk/bktec $ go build -o bktec && ./bktec --version
bktec dev
```

Related:
- #68