### PR TITLE
`env.Env` interface with `OS` (real) and `Map` (test) implementations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	Branch string
 	// JobRetryCount is the count of the number of times the job has been retried.
 	JobRetryCount int
+	// Env provides access to environment variables.
+	// It's public because many tests in other packages reference it (perhaps they should not).
+	Env env.Env
 	// errs is a map of environment variables name and the validation errors associated with them.
 	errs InvalidConfigError
 }
@@ -46,6 +49,7 @@ type Config struct {
 // It returns Config struct and an InvalidConfigError if there is an invalid configuration.
 func New(env env.Env) (Config, error) {
 	c := Config{
+		Env:  env,
 		errs: InvalidConfigError{},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/buildkite/test-engine-client/internal/env"
+
 // Config is the internal representation of the complete test engine client configuration.
 type Config struct {
 	// AccessToken is the access token for the API.
@@ -42,11 +44,13 @@ type Config struct {
 
 // New wraps the readFromEnv and validate functions to create a new Config struct.
 // It returns Config struct and an InvalidConfigError if there is an invalid configuration.
-func New() (Config, error) {
-	c := Config{errs: InvalidConfigError{}}
+func New(env env.Env) (Config, error) {
+	c := Config{
+		errs: InvalidConfigError{},
+	}
 
 	// TODO: remove error from readFromEnv and validate functions
-	_ = c.readFromEnv()
+	_ = c.readFromEnv(env)
 	_ = c.validate()
 
 	if len(c.errs) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,7 +27,9 @@ func getExampleEnv() env.Env {
 }
 
 func TestNewConfig(t *testing.T) {
-	c, err := New(getExampleEnv())
+	env := getExampleEnv()
+
+	c, err := New(env)
 	if err != nil {
 		t.Errorf("config.New() error = %v", err)
 	}
@@ -44,6 +46,7 @@ func TestNewConfig(t *testing.T) {
 		SuiteSlug:        "my_suite",
 		TestRunner:       "rspec",
 		JobRetryCount:    0,
+		Env:              env,
 		errs:             InvalidConfigError{},
 	}
 
@@ -82,6 +85,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 		TestRunner:       "rspec",
 		ResultPath:       "tmp/rspec.json",
 		JobRetryCount:    0,
+		Env:              env,
 	}
 
 	if diff := cmp.Diff(c, want, cmpopts.IgnoreUnexported(Config{})); diff != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,34 +2,32 @@ package config
 
 import (
 	"errors"
-	"os"
 	"testing"
 
+	"github.com/buildkite/test-engine-client/internal/env"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func setEnv(t *testing.T) {
-	t.Helper()
-	os.Setenv("BUILDKITE_PARALLEL_JOB_COUNT", "60")
-	os.Setenv("BUILDKITE_PARALLEL_JOB", "7")
-	os.Setenv("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN", "my_token")
-	os.Setenv("BUILDKITE_TEST_ENGINE_BASE_URL", "https://build.kite")
-	os.Setenv("BUILDKITE_TEST_ENGINE_TEST_CMD", "bin/rspec {{testExamples}}")
-	os.Setenv("BUILDKITE_ORGANIZATION_SLUG", "my_org")
-	os.Setenv("BUILDKITE_TEST_ENGINE_SUITE_SLUG", "my_suite")
-	os.Setenv("BUILDKITE_BUILD_ID", "123")
-	os.Setenv("BUILDKITE_STEP_ID", "456")
-	os.Setenv("BUILDKITE_TEST_ENGINE_TEST_RUNNER", "rspec")
-	os.Setenv("BUILDKITE_TEST_ENGINE_RESULT_PATH", "tmp/rspec.json")
-	os.Setenv("BUILDKITE_RETRY_COUNT", "0")
+func getExampleEnv() env.Env {
+	return env.Map{
+		"BUILDKITE_PARALLEL_JOB_COUNT":           "60",
+		"BUILDKITE_PARALLEL_JOB":                 "7",
+		"BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN": "my_token",
+		"BUILDKITE_TEST_ENGINE_BASE_URL":         "https://build.kite",
+		"BUILDKITE_TEST_ENGINE_TEST_CMD":         "bin/rspec {{testExamples}}",
+		"BUILDKITE_ORGANIZATION_SLUG":            "my_org",
+		"BUILDKITE_TEST_ENGINE_SUITE_SLUG":       "my_suite",
+		"BUILDKITE_BUILD_ID":                     "123",
+		"BUILDKITE_STEP_ID":                      "456",
+		"BUILDKITE_TEST_ENGINE_TEST_RUNNER":      "rspec",
+		"BUILDKITE_TEST_ENGINE_RESULT_PATH":      "tmp/rspec.json",
+		"BUILDKITE_RETRY_COUNT":                  "0",
+	}
 }
 
 func TestNewConfig(t *testing.T) {
-	setEnv(t)
-	defer os.Clearenv()
-
-	c, err := New()
+	c, err := New(getExampleEnv())
 	if err != nil {
 		t.Errorf("config.New() error = %v", err)
 	}
@@ -55,9 +53,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestNewConfig_EmptyConfig(t *testing.T) {
-	os.Clearenv()
-
-	_, err := New()
+	_, err := New(env.Map{})
 
 	if !errors.As(err, new(InvalidConfigError)) {
 		t.Errorf("config.Validate() error = %v, want InvalidConfigError", err)
@@ -65,13 +61,12 @@ func TestNewConfig_EmptyConfig(t *testing.T) {
 }
 
 func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
-	setEnv(t)
-	os.Unsetenv("BUILDKITE_TEST_ENGINE_MODE")
-	os.Unsetenv("BUILDKITE_TEST_ENGINE_BASE_URL")
-	os.Unsetenv("BUILDKITE_TEST_ENGINE_TEST_CMD")
-	defer os.Clearenv()
+	env := getExampleEnv()
+	env.Delete("BUILDKITE_TEST_ENGINE_MODE")
+	env.Delete("BUILDKITE_TEST_ENGINE_BASE_URL")
+	env.Delete("BUILDKITE_TEST_ENGINE_TEST_CMD")
 
-	c, err := New()
+	c, err := New(env)
 	if err != nil {
 		t.Errorf("config.New() error = %v", err)
 	}
@@ -95,12 +90,11 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 }
 
 func TestNewConfig_InvalidConfig(t *testing.T) {
-	setEnv(t)
-	os.Setenv("BUILDKITE_TEST_ENGINE_MODE", "dynamic")
-	os.Unsetenv("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
-	defer os.Clearenv()
+	env := getExampleEnv()
+	env.Set("BUILDKITE_TEST_ENGINE_MODE", "dynamic")
+	env.Delete("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
 
-	_, err := New()
+	_, err := New(env)
 
 	var invConfigError InvalidConfigError
 	if !errors.As(err, &invConfigError) {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,15 +1,16 @@
 package config
 
 import (
-	"os"
 	"strconv"
+
+	"github.com/buildkite/test-engine-client/internal/env"
 )
 
 // getEnvWithDefault retrieves the value of the environment variable named by the key.
 // If the variable is present and not empty, the value is returned.
 // Otherwise the returned value will be the default value.
-func getEnvWithDefault(key string, defaultValue string) string {
-	value, ok := os.LookupEnv(key)
+func getEnvWithDefault(env env.Env, key string, defaultValue string) string {
+	value, ok := env.Lookup(key)
 	if !ok {
 		return defaultValue
 	}
@@ -19,8 +20,8 @@ func getEnvWithDefault(key string, defaultValue string) string {
 	return value
 }
 
-func getIntEnvWithDefault(key string, defaultValue int) (int, error) {
-	value := os.Getenv(key)
+func getIntEnvWithDefault(env env.Env, key string, defaultValue int) (int, error) {
+	value := env.Get(key)
 	// If the environment variable is not set, return the default value.
 	if value == "" {
 		return defaultValue, nil
@@ -34,7 +35,7 @@ func getIntEnvWithDefault(key string, defaultValue int) (int, error) {
 	return valueInt, nil
 }
 
-func (c Config) DumpEnv() map[string]string {
+func (c Config) DumpEnv(env env.Env) map[string]string {
 	keys := []string{
 		"BUILDKITE_BUILD_ID",
 		"BUILDKITE_JOB_ID",
@@ -57,7 +58,7 @@ func (c Config) DumpEnv() map[string]string {
 
 	envs := make(map[string]string)
 	for _, key := range keys {
-		envs[key] = os.Getenv(key)
+		envs[key] = env.Get(key)
 	}
 
 	envs["BUILDKITE_TEST_ENGINE_IDENTIFIER"] = c.Identifier

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -35,7 +35,7 @@ func getIntEnvWithDefault(env env.Env, key string, defaultValue int) (int, error
 	return valueInt, nil
 }
 
-func (c Config) DumpEnv(env env.Env) map[string]string {
+func (c Config) DumpEnv() map[string]string {
 	keys := []string{
 		"BUILDKITE_BUILD_ID",
 		"BUILDKITE_JOB_ID",
@@ -58,7 +58,7 @@ func (c Config) DumpEnv(env env.Env) map[string]string {
 
 	envs := make(map[string]string)
 	for _, key := range keys {
-		envs[key] = env.Get(key)
+		envs[key] = c.Env.Get(key)
 	}
 
 	envs["BUILDKITE_TEST_ENGINE_IDENTIFIER"] = c.Identifier

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -2,20 +2,18 @@ package config
 
 import (
 	"errors"
-	"os"
 	"strconv"
 	"testing"
+
+	"github.com/buildkite/test-engine-client/internal/env"
 )
 
 func TestGetIntEnvWithDefault(t *testing.T) {
-	os.Setenv("MY_KEY", "10")
-	defer os.Unsetenv("MY_KEY")
-
-	os.Setenv("EMPTY_KEY", "")
-	defer os.Unsetenv("EMPTY_KEY")
-
-	os.Setenv("INVALID_KEY", "invalid_value")
-	defer os.Unsetenv("INVALID_KEY")
+	env := env.Map{
+		"MY_KEY":      "10",
+		"EMPTY_KEY":   "",
+		"INVALID_KEY": "invalid_value",
+	}
 
 	tests := []struct {
 		key          string
@@ -51,7 +49,7 @@ func TestGetIntEnvWithDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
-			got, err := getIntEnvWithDefault(tt.key, tt.defaultValue)
+			got, err := getIntEnvWithDefault(env, tt.key, tt.defaultValue)
 			if err != nil && !errors.Is(err, tt.err) {
 				t.Errorf("getIntEnvWithDefault(%q, %d) error = %v, want %v", tt.key, tt.defaultValue, err, tt.err)
 			}
@@ -63,14 +61,11 @@ func TestGetIntEnvWithDefault(t *testing.T) {
 }
 
 func TestGetEnvWithDefault(t *testing.T) {
-	os.Setenv("MY_KEY", "my_value")
-	defer os.Unsetenv("MY_KEY")
-
-	os.Setenv("EMPTY_KEY", "")
-	defer os.Unsetenv("EMPTY_KEY")
-
-	os.Setenv("OTHER_KEY", "other_value")
-	defer os.Unsetenv("OTHER_KEY")
+	env := env.Map{
+		"MY_KEY":    "my_value",
+		"EMPTY_KEY": "",
+		"OTHER_KEY": "other_value",
+	}
 
 	tests := []struct {
 		key          string
@@ -94,14 +89,14 @@ func TestGetEnvWithDefault(t *testing.T) {
 		},
 		{
 			key:          "EMPTY_KEY",
-			defaultValue: os.Getenv("OTHER_KEY"),
+			defaultValue: env.Get("OTHER_KEY"),
 			want:         "other_value",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
-			if got := getEnvWithDefault(tt.key, tt.defaultValue); got != tt.want {
+			if got := getEnvWithDefault(env, tt.key, tt.defaultValue); got != tt.want {
 				t.Errorf("getEnvWithDefault(%q, %q) = %q, want %q", tt.key, tt.defaultValue, got, tt.want)
 			}
 		})

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
+
+	"github.com/buildkite/test-engine-client/internal/env"
 )
 
 // readFromEnv reads the configuration from environment variables and sets it to the Config struct.
@@ -30,57 +31,56 @@ import (
 //
 // If we are going to support other CI environment in the future,
 // we will need to change where we read the configuration from.
-func (c *Config) readFromEnv() error {
+func (c *Config) readFromEnv(env env.Env) error {
+	c.AccessToken = env.Get("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
+	c.OrganizationSlug = env.Get("BUILDKITE_ORGANIZATION_SLUG")
+	c.SuiteSlug = env.Get("BUILDKITE_TEST_ENGINE_SUITE_SLUG")
 
-	c.AccessToken = os.Getenv("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
-	c.OrganizationSlug = os.Getenv("BUILDKITE_ORGANIZATION_SLUG")
-	c.SuiteSlug = os.Getenv("BUILDKITE_TEST_ENGINE_SUITE_SLUG")
-
-	buildId := os.Getenv("BUILDKITE_BUILD_ID")
+	buildId := env.Get("BUILDKITE_BUILD_ID")
 	if buildId == "" {
 		c.errs.appendFieldError("BUILDKITE_BUILD_ID", "must not be blank")
 	}
 
-	stepId := os.Getenv("BUILDKITE_STEP_ID")
+	stepId := env.Get("BUILDKITE_STEP_ID")
 	if stepId == "" {
 		c.errs.appendFieldError("BUILDKITE_STEP_ID", "must not be blank")
 	}
 
 	c.Identifier = fmt.Sprintf("%s/%s", buildId, stepId)
 
-	c.ServerBaseUrl = getEnvWithDefault("BUILDKITE_TEST_ENGINE_BASE_URL", "https://api.buildkite.com")
-	c.TestCommand = os.Getenv("BUILDKITE_TEST_ENGINE_TEST_CMD")
-	c.TestFilePattern = os.Getenv("BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN")
-	c.TestFileExcludePattern = os.Getenv("BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN")
-	c.TestRunner = os.Getenv("BUILDKITE_TEST_ENGINE_TEST_RUNNER")
-	c.ResultPath = os.Getenv("BUILDKITE_TEST_ENGINE_RESULT_PATH")
+	c.ServerBaseUrl = getEnvWithDefault(env, "BUILDKITE_TEST_ENGINE_BASE_URL", "https://api.buildkite.com")
+	c.TestCommand = env.Get("BUILDKITE_TEST_ENGINE_TEST_CMD")
+	c.TestFilePattern = env.Get("BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN")
+	c.TestFileExcludePattern = env.Get("BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN")
+	c.TestRunner = env.Get("BUILDKITE_TEST_ENGINE_TEST_RUNNER")
+	c.ResultPath = env.Get("BUILDKITE_TEST_ENGINE_RESULT_PATH")
 
-	c.SplitByExample = strings.ToLower(os.Getenv("BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE")) == "true"
+	c.SplitByExample = strings.ToLower(env.Get("BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE")) == "true"
 
 	// used by Buildkite only, for experimental plans
-	c.Branch = os.Getenv("BUILDKITE_BRANCH")
+	c.Branch = env.Get("BUILDKITE_BRANCH")
 
-	JobRetryCount, err := getIntEnvWithDefault("BUILDKITE_RETRY_COUNT", 0)
+	JobRetryCount, err := getIntEnvWithDefault(env, "BUILDKITE_RETRY_COUNT", 0)
 	c.JobRetryCount = JobRetryCount
 	if err != nil {
-		c.errs.appendFieldError("BUILDKITE_RETRY_COUNT", "was %q, must be a number", os.Getenv("BUILDKITE_RETRY_COUNT"))
+		c.errs.appendFieldError("BUILDKITE_RETRY_COUNT", "was %q, must be a number", env.Get("BUILDKITE_RETRY_COUNT"))
 	}
 
-	MaxRetries, err := getIntEnvWithDefault("BUILDKITE_TEST_ENGINE_RETRY_COUNT", 0)
+	MaxRetries, err := getIntEnvWithDefault(env, "BUILDKITE_TEST_ENGINE_RETRY_COUNT", 0)
 	c.MaxRetries = MaxRetries
 	if err != nil {
-		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_RETRY_COUNT", "was %q, must be a number", os.Getenv("BUILDKITE_TEST_ENGINE_RETRY_COUNT"))
+		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_RETRY_COUNT", "was %q, must be a number", env.Get("BUILDKITE_TEST_ENGINE_RETRY_COUNT"))
 	}
-	c.RetryCommand = os.Getenv("BUILDKITE_TEST_ENGINE_RETRY_CMD")
+	c.RetryCommand = env.Get("BUILDKITE_TEST_ENGINE_RETRY_CMD")
 
-	parallelism := os.Getenv("BUILDKITE_PARALLEL_JOB_COUNT")
+	parallelism := env.Get("BUILDKITE_PARALLEL_JOB_COUNT")
 	parallelismInt, err := strconv.Atoi(parallelism)
 	if err != nil {
 		c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %q, must be a number", parallelism)
 	}
 	c.Parallelism = parallelismInt
 
-	nodeIndex := os.Getenv("BUILDKITE_PARALLEL_JOB")
+	nodeIndex := env.Get("BUILDKITE_PARALLEL_JOB")
 	nodeIndexInt, err := strconv.Atoi(nodeIndex)
 	if err != nil {
 		c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %q, must be a number", nodeIndex)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,54 @@
+package env
+
+import "os"
+
+type Env interface {
+	Get(key string) string
+	Set(key string, value string) error
+	Delete(key string) error
+	Lookup(key string) (string, bool)
+}
+
+// OS is an Env backed by real operating system environment
+type OS struct{}
+
+func (OS) Get(key string) string {
+	return os.Getenv(key)
+}
+
+func (OS) Set(key string, value string) error {
+	return os.Setenv(key, value)
+}
+
+func (OS) Delete(key string) error {
+	return os.Unsetenv(key)
+}
+
+func (OS) Lookup(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+// Map is an Env backed by a map[string]string for testing etc
+type Map map[string]string
+
+func (env Map) Get(key string) string {
+	return env[key]
+}
+
+func (env Map) Set(key string, value string) error {
+	env[key] = value
+	return nil
+}
+
+func (env Map) Delete(key string) error {
+	delete(env, key)
+	return nil
+}
+
+func (env Map) Lookup(key string) (string, bool) {
+	if val, ok := env[key]; ok {
+		return val, true
+	} else {
+		return "", false
+	}
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,108 @@
+package env_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/buildkite/test-engine-client/internal/env"
+	"github.com/google/go-cmp/cmp"
+)
+
+// Note: out of the two implementations of interface env:
+// - I'm testing env.OS because it's used by real code,
+// - I'm not testing env.Map because it's only used in tests.
+
+func TestOSGet(t *testing.T) {
+	defer setenvWithUnset("BKTEC_ENV_TEST_VALUE", "hello")()
+
+	env := env.OS{}
+
+	got, want := env.Get("BKTEC_ENV_TEST_VALUE"), "hello"
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("env.Get() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestOSGetMissing(t *testing.T) {
+	os.Unsetenv("BKTEC_ENV_TEST_VALUE") // just in case
+
+	env := env.OS{}
+
+	got, want := env.Get("BKTEC_ENV_TEST_VALUE"), ""
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("env.Get() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestOSLookup(t *testing.T) {
+	defer setenvWithUnset("BKTEC_ENV_TEST_VALUE", "hello")()
+
+	env := env.OS{}
+
+	got, ok := env.Lookup("BKTEC_ENV_TEST_VALUE")
+	want := "hello"
+
+	if !ok {
+		t.Errorf("env.Lookup() ok value should be true: %v", ok)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("env.Lookup() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestOSLookupMissing(t *testing.T) {
+	os.Unsetenv("BKTEC_ENV_TEST_VALUE") // just in case
+
+	env := env.OS{}
+
+	got, ok := env.Lookup("BKTEC_ENV_TEST_VALUE")
+	want := ""
+
+	if ok {
+		t.Errorf("env.Lookup() ok value should be false: %v", ok)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("env.Lookup() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestOSDelete(t *testing.T) {
+	defer setenvWithUnset("BKTEC_ENV_TEST_VALUE", "hello")()
+
+	env := env.OS{}
+
+	err := env.Delete("BKTEC_ENV_TEST_VALUE")
+	if err != nil {
+		t.Error(err)
+	}
+
+	got, want := os.Getenv("BKTEC_ENV_TEST_VALUE"), ""
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("os.Getenv() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestOSSet(t *testing.T) {
+	os.Unsetenv("BKTEC_ENV_TEST_VALUE")       // ensure pre-condition
+	defer os.Unsetenv("BKTEC_ENV_TEST_VALUE") // ensure post-condition (cleanup)
+
+	env := env.OS{}
+
+	err := env.Set("BKTEC_ENV_TEST_VALUE", "Set()")
+	if err != nil {
+		t.Error(err)
+	}
+
+	got, want := os.Getenv("BKTEC_ENV_TEST_VALUE"), "Set()"
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("os.Getenv() diff (-got +want):\n%s", diff)
+	}
+}
+
+// intended to be called like: `defer setenvWithUnset(...)()`
+func setenvWithUnset(key string, value string) func() {
+	os.Setenv(key, value)
+	return func() { os.Unsetenv(key) }
+}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		OrganizationSlug: cfg.OrganizationSlug,
 	})
 
-	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, env, files, testRunner)
+	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		logErrorAndExit(16, "Couldn't fetch or create test plan: %v", err)
 	}
@@ -120,7 +120,7 @@ func main() {
 	// At this point, the runner is expected to have completed
 
 	if !testPlan.Fallback {
-		sendMetadata(ctx, apiClient, cfg, env, timeline, runResult.Statistics())
+		sendMetadata(ctx, apiClient, cfg, timeline, runResult.Statistics())
 	}
 
 	printReport(runResult, testPlan.SkippedTests, testRunner.Name())
@@ -204,10 +204,10 @@ func createTimestamp() string {
 	return time.Now().Format(time.RFC3339Nano)
 }
 
-func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config, env env.Env, timeline []api.Timeline, statistics runner.RunStatistics) {
+func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config, timeline []api.Timeline, statistics runner.RunStatistics) {
 	err := apiClient.PostTestPlanMetadata(ctx, cfg.SuiteSlug, cfg.Identifier, api.TestPlanMetadataParams{
 		Timeline:   timeline,
-		Env:        cfg.DumpEnv(env),
+		Env:        cfg.DumpEnv(),
 		Version:    version.Version,
 		Statistics: statistics,
 	})
@@ -297,7 +297,7 @@ func logErrorAndExit(exitCode int, format string, v ...any) {
 
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg config.Config, env env.Env, files []string, testRunner TestRunner) (plan.TestPlan, error) {
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg config.Config, files []string, testRunner TestRunner) (plan.TestPlan, error) {
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.
@@ -339,7 +339,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 
 	debug.Println("No test plan found, creating a new plan")
 	// If the cache is empty, create a new plan.
-	params, err := createRequestParam(ctx, cfg, env, files, *apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, files, *apiClient, testRunner)
 	if err != nil {
 		return handleError(err)
 	}
@@ -366,7 +366,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg confi
 // createRequestParam generates the parameters needed for a test plan request.
 // For runners other than "rspec", it constructs the test plan parameters with all test files.
 // For the "rspec" runner, it filters the test files through the Test Engine API and splits the filtered files into examples.
-func createRequestParam(ctx context.Context, cfg config.Config, env env.Env, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
+func createRequestParam(ctx context.Context, cfg config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
 	testFiles := []plan.TestCase{}
 	for _, file := range files {
 		testFiles = append(testFiles, plan.TestCase{
@@ -394,7 +394,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, env env.Env, fil
 	// The SplitByExample flag indicates whether to filter slow files for splitting by example.
 	// Regardless of the flag's state, the API will still filter other files that need to be split by example, such as those containing skipped tests.
 	// Therefore, we must filter and split files even when SplitByExample is disabled.
-	testParams, err := filterAndSplitFiles(ctx, cfg, env, client, testFiles, runner)
+	testParams, err := filterAndSplitFiles(ctx, cfg, client, testFiles, runner)
 	if err != nil {
 		return api.TestPlanParams{}, err
 	}
@@ -411,12 +411,12 @@ func createRequestParam(ctx context.Context, cfg config.Config, env env.Env, fil
 // filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
 // It returns the test plan parameters with the examples from the filtered files and the remaining files.
 // An error is returned if there is a failure in any of the process.
-func filterAndSplitFiles(ctx context.Context, cfg config.Config, env env.Env, client api.Client, files []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
+func filterAndSplitFiles(ctx context.Context, cfg config.Config, client api.Client, files []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
 	// Filter files that need to be split.
 	debug.Printf("Filtering %d files", len(files))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
 		Files: files,
-		Env:   cfg.DumpEnv(env),
+		Env:   cfg.DumpEnv(),
 	})
 
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -342,12 +342,12 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 	defer svr.Close()
 
 	ctx := context.Background()
-	env := env.Map{}
 	cfg := config.Config{
 		NodeIndex:     0,
 		Parallelism:   10,
 		Identifier:    "identifier",
 		ServerBaseUrl: svr.URL,
+		Env:           env.Map{},
 	}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
@@ -363,7 +363,7 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, env, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -418,8 +418,8 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		OrganizationSlug: "org",
 		SuiteSlug:        "suite",
 		Branch:           "tat-123/my-cool-feature",
+		Env:              env.Map{},
 	}
-	env := env.Map{}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 		OrganizationSlug: cfg.OrganizationSlug,
@@ -437,7 +437,7 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, cfg, env, tests, testRunner)
+	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, cfg, tests, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, tests, err)
 	}
@@ -466,8 +466,8 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 		Identifier:    "identifier",
 		Branch:        "tat-123/my-cool-feature",
 		ServerBaseUrl: svr.URL,
+		Env:           env.Map{},
 	}
-	env := env.Map{}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
@@ -475,7 +475,7 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, env, files, TestRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, TestRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -505,8 +505,8 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 		Identifier:    "identifier",
 		Branch:        "tat-123/my-cool-feature",
 		ServerBaseUrl: svr.URL,
+		Env:           env.Map{},
 	}
-	env := env.Map{}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
@@ -514,7 +514,7 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, cfg, env, files, testRunner)
+	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -541,8 +541,8 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 		Identifier:    "identifier",
 		Branch:        "",
 		ServerBaseUrl: svr.URL,
+		Env:           env.Map{},
 	}
-	env := env.Map{}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
@@ -550,7 +550,7 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	// we want the function to return an empty test plan and an error
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, env, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
 	}
@@ -577,8 +577,8 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 		Identifier:    "identifier",
 		Branch:        "",
 		ServerBaseUrl: svr.URL,
+		Env:           env.Map{},
 	}
-	env := env.Map{}
 	apiClient := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
@@ -586,7 +586,7 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, env, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -614,8 +614,8 @@ func TestCreateRequestParams(t *testing.T) {
 		Parallelism:      7,
 		Branch:           "",
 		TestRunner:       "rspec",
+		Env:              env.Map{},
 	}
-	env := env.Map{}
 
 	client := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: svr.URL,
@@ -630,7 +630,7 @@ func TestCreateRequestParams(t *testing.T) {
 		"testdata/rspec/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, env, files, *client, runner.Rspec{
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
 		RunnerConfig: runner.RunnerConfig{
 			TestCommand: "rspec",
 		},
@@ -708,8 +708,8 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 				Parallelism:      7,
 				Branch:           "",
 				TestRunner:       r.Name(),
+				Env:              env.Map{},
 			}
-			env := env.Map{}
 
 			client := api.NewClient(api.ClientConfig{
 				ServerBaseUrl: svr.URL,
@@ -720,7 +720,7 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 				"testdata/fruits/cherry.spec.js",
 			}
 
-			got, err := createRequestParam(context.Background(), cfg, env, files, *client, r)
+			got, err := createRequestParam(context.Background(), cfg, files, *client, r)
 
 			if err != nil {
 				t.Errorf("createRequestParam() error = %v", err)
@@ -761,8 +761,8 @@ func TestCreateRequestParams_FilterTestsError(t *testing.T) {
 		Parallelism:      7,
 		Branch:           "",
 		SplitByExample:   true,
+		Env:              env.Map{},
 	}
-	env := env.Map{}
 
 	client := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: svr.URL,
@@ -777,7 +777,7 @@ func TestCreateRequestParams_FilterTestsError(t *testing.T) {
 		"grape_spec.rb",
 	}
 
-	_, err := createRequestParam(context.Background(), cfg, env, files, *client, runner.Rspec{})
+	_, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{})
 
 	if err.Error() != "filter tests: forbidden" {
 		t.Errorf("createRequestParam() error = %v, want forbidden error", err)
@@ -800,8 +800,8 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 		Parallelism:      7,
 		Branch:           "",
 		SplitByExample:   true,
+		Env:              env.Map{},
 	}
-	env := env.Map{}
 
 	client := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: svr.URL,
@@ -816,7 +816,7 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 		"testdata/rspec/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, env, files, *client, runner.Rspec{
+	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
 		RunnerConfig: runner.RunnerConfig{
 			TestCommand: "rspec",
 		},
@@ -934,6 +934,7 @@ func TestSendMetadata(t *testing.T) {
 		SuiteSlug:        "rspec",
 		Identifier:       "fruitsabc",
 		ServerBaseUrl:    svr.URL,
+		Env:              env,
 	}
 	client := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
@@ -943,7 +944,7 @@ func TestSendMetadata(t *testing.T) {
 		Total: 3,
 	}
 
-	sendMetadata(context.Background(), client, cfg, env, timeline, statistics)
+	sendMetadata(context.Background(), client, cfg, timeline, statistics)
 }
 
 func TestSendMetadata_Unauthorized(t *testing.T) {
@@ -957,8 +958,8 @@ func TestSendMetadata_Unauthorized(t *testing.T) {
 		SuiteSlug:        "my-suite",
 		Identifier:       "identifier",
 		ServerBaseUrl:    svr.URL,
+		Env:              env.Map{},
 	}
-	env := env.Map{}
 	client := api.NewClient(api.ClientConfig{
 		ServerBaseUrl: cfg.ServerBaseUrl,
 	})
@@ -969,5 +970,5 @@ func TestSendMetadata_Unauthorized(t *testing.T) {
 		Total: 3,
 	}
 
-	sendMetadata(context.Background(), client, cfg, env, timeline, statistics)
+	sendMetadata(context.Background(), client, cfg, timeline, statistics)
 }


### PR DESCRIPTION
Introduce a new internal package `env`, with an `Env` interface abstracting `os.Getenv`, `os.LookupEnv` etc.

There's an `env.OS` implementation for real use, and an `env.Map` implementation for testing. This makes it easier for tests to inject fake environment, without affecting or being affected by the actual environment of the test process.

An upcoming `bktec upload` feature will be loading yet more environment variables from environment (detecting CI build environment etc); this PR is intended to make it easier to write tests in that PR.

~I chose to thread these through from `main()` to anything that depends on environment, which ended up a bit awkward purely because of `Config.DumpEnv()` which I think maybe could use a bit of thought anyway; I don't think it should need to read from environment at call time, it should probably read from the config values? Anyway, that's out of scope, but it explains the threading of `env` through several layers of method calls.~

There's a bit of stutter in the `env.Env` interface name, but I think it's acceptable; similar to `template.Template`, `context.Context` etc in stdlib.