### PR TITLE
Remove line and column from Jest test result's path

### DIFF
--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -85,6 +85,7 @@ func TestDiscoverTestFiles_ExcludeNodeModules(t *testing.T) {
 		"testdata/jest/jest.config.js",
 		"testdata/jest/runtimeError.spec.js",
 		"testdata/jest/skipped.spec.js",
+		"testdata/jest/slow.spec.js",
 		"testdata/jest/spells/expelliarmus.spec.js",
 		"testdata/playwright/playwright.config.js",
 		"testdata/playwright/tests/error.spec.js",

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -128,7 +128,7 @@ func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) erro
 			testCase := plan.TestCase{
 				Name:  example.Title,
 				Scope: strings.Join(example.AncestorTitles, " "),
-				Path:  fmt.Sprintf("%s:%d:%d", testPath, example.Location.Line, example.Location.Column),
+				Path:  testPath,
 			}
 
 			result.RecordTestResult(testCase, status)

--- a/internal/runner/testdata/jest/slow.spec.js
+++ b/internal/runner/testdata/jest/slow.spec.js
@@ -1,0 +1,5 @@
+describe('slow test', () => {
+  it('wait for 2 seconds', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  })
+})


### PR DESCRIPTION
### Description

@bryankane discovered a bug when a Jest test failed due to a timeout. After retrying, the test eventually passed, but the run result was still marked as failed. This issue happens because we use test name, file path, and location (line and column number) to identify a test.  When a Jest test times out, the location is `null`. However, when the test is retried and passes, the location is set correctly by Jest. Since the test location is `null` during the initial run but set correctly during the retry, these executions are treated as separate tests, causing the final result to be marked as failed.

This PR removes line and column number from Jest's test path, so we can correctly associate the tests that time out (i.e. missing location). This aligns with the approach on https://github.com/buildkite/test-engine-client/pull/281 that removes the line and column number when passing the path to retry failed tests. 

> [!IMPORTANT]
> The implication of this fix is that distinct tests with the same name in the same file will be treated as the same test. This practice is not recommended by Test Engine, and should be handled differently (e.g., by displaying warning when there are multiple distinct tests with same name). However, this is beyond the scope of this PR.

