### PR TITLE
Implement basic `pytest` splitting support

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,10 +1,13 @@
 FROM ruby:3.4.2-slim-bookworm AS ruby
 FROM cypress/included:14.1.0 AS cypress
+FROM python:3.13.2-bookworm AS python
 
 FROM public.ecr.aws/docker/library/golang:1.24.1 AS golang
 
 COPY --from=ruby / /
 COPY --from=cypress / /
+COPY --from=python / /
 
 RUN gem install rspec
 RUN yarn global add jest
+RUN pip install pytest

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ci:
     build:
       context: .
-      dockerfile: Dockerfile-compile
+      dockerfile: Dockerfile
     volumes:
       - ../:/work:cached
       - ~/gocache:/gocache

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -42,7 +42,9 @@ func DetectRunner(cfg config.Config) (TestRunner, error) {
 		return NewCypress(runnerConfig), nil
 	case "playwright":
 		return NewPlaywright(runnerConfig), nil
+	case "pytest":
+		return NewPytest(runnerConfig), nil
 	default:
-		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright'")
+		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright', or 'pytest'")
 	}
 }

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"fmt"
+	"os/exec"
+	"slices"
+
+	"github.com/buildkite/test-engine-client/internal/debug"
+	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/kballard/go-shellquote"
+)
+
+type Pytest struct {
+	RunnerConfig
+}
+
+func (p Pytest) Name() string {
+	return "pytest"
+}
+
+func NewPytest(c RunnerConfig) Pytest {
+	if c.TestCommand == "" {
+		c.TestCommand = "pytest {{testExamples}}"
+	}
+
+	if c.TestFilePattern == "" {
+		c.TestFilePattern = "**/{*_test,test_*}.py"
+	}
+
+	return Pytest{
+		RunnerConfig: c,
+	}
+}
+
+func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
+	testPaths := make([]string, len(testCases))
+	for i, tc := range testCases {
+		testPaths[i] = tc.Path
+	}
+	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, testPaths)
+	if err != nil {
+		return fmt.Errorf("failed to build command: %w", err)
+	}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+
+	err = runAndForwardSignal(cmd)
+
+	return err
+}
+
+func (p Pytest) GetFiles() ([]string, error) {
+	debug.Println("Discovering test files with include pattern:", p.TestFilePattern, "exclude pattern:", p.TestFileExcludePattern)
+	files, err := discoverTestFiles(p.TestFilePattern, p.TestFileExcludePattern)
+	debug.Println("Discovered", len(files), "files")
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found with pattern %q and exclude pattern %q", p.TestFilePattern, p.TestFileExcludePattern)
+	}
+
+	return files, nil
+}
+
+func (p Pytest) GetExamples(files []string) ([]plan.TestCase, error) {
+	return nil, fmt.Errorf("not supported in pytest")
+}
+
+func (p Pytest) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+	words, err := shellquote.Split(cmd)
+	if err != nil {
+		return "", []string{}, err
+	}
+	idx := slices.Index(words, "{{testExamples}}")
+	if idx < 0 {
+		words = append(words, testCases...)
+	} else {
+		words = slices.Replace(words, idx, idx+1, testCases...)
+	}
+
+	return words[0], words[1:], nil
+}

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -1,0 +1,163 @@
+package runner
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/google/go-cmp/cmp"
+	"github.com/kballard/go-shellquote"
+)
+
+func TestPytestRun(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := NewPytest(RunnerConfig{})
+	testCases := []plan.TestCase{
+		{Path: "test_sample.py"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+
+	if err != nil {
+		t.Errorf("Pytest.Run(%q) error = %v", testCases, err)
+	}
+
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
+	}
+}
+
+func TestPytestRun_TestFailed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := NewPytest(RunnerConfig{})
+	testCases := []plan.TestCase{
+		{Path: "failed_test.py"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
+	}
+
+	exitError := new(exec.ExitError)
+	if !errors.As(err, &exitError) {
+		t.Errorf("Pytest.Run(%q) error type = %T (%v), want *exec.ExitError", testCases, err, err)
+	}
+}
+
+func TestPytestRun_CommandFailed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := NewPytest(RunnerConfig{
+		TestCommand: "pytest help",
+	})
+
+	testCases := []plan.TestCase{
+		{Path: "test_sample.py"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+
+	if result.Status() != RunStatusUnknown {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusUnknown)
+	}
+
+	exitError := new(exec.ExitError)
+	if !errors.As(err, &exitError) {
+		t.Errorf("Pytest.Run(%q) error type = %T (%v), want *exec.ExitError", testCases, err, err)
+	}
+}
+
+func TestPytestGetFiles(t *testing.T) {
+	pytest := NewPytest(RunnerConfig{})
+
+	got, err := pytest.GetFiles()
+	if err != nil {
+		t.Errorf("Pytest.GetFiles() error = %v", err)
+	}
+
+	want := []string{
+		"testdata/pytest/failed_test.py",
+		"testdata/pytest/test_sample.py",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Pytest.GetFiles() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestPytestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
+	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCommand := "pytest {{testExamples}} --full-trace"
+
+	pytest := NewPytest(RunnerConfig{
+		TestCommand: testCommand,
+	})
+
+	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "pytest"
+	wantArgs := []string{"failed_test.py", "test_sample.py", "--full-trace"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestPytestCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
+	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCommand := "pytest --full-trace"
+
+	pytest := NewPytest(RunnerConfig{
+		TestCommand: testCommand,
+	})
+
+	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	if err != nil {
+		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
+	}
+
+	wantName := "pytest"
+	wantArgs := []string{"--full-trace", "failed_test.py", "test_sample.py"}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
+	}
+}
+
+func TestPytestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
+	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCommand := "pytest '{{testExamples}}"
+
+	pytest := NewPytest(RunnerConfig{
+		TestCommand: testCommand,
+	})
+
+	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+
+	wantName := ""
+	wantArgs := []string{}
+
+	if diff := cmp.Diff(gotName, wantName); diff != "" {
+		t.Errorf("commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs() diff (-got +want):\n%s", diff)
+	}
+	if !errors.Is(err, shellquote.UnterminatedSingleQuoteError) {
+		t.Errorf("commandNameAndArgs() error = %v, want %v", err, shellquote.UnterminatedSingleQuoteError)
+	}
+}

--- a/internal/runner/testdata/pytest/.gitignore
+++ b/internal/runner/testdata/pytest/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/internal/runner/testdata/pytest/failed_test.py
+++ b/internal/runner/testdata/pytest/failed_test.py
@@ -1,0 +1,2 @@
+def test_failed():
+    assert 3 == 5

--- a/internal/runner/testdata/pytest/test_sample.py
+++ b/internal/runner/testdata/pytest/test_sample.py
@@ -1,0 +1,2 @@
+def test_happy():
+    assert 3 == 3


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Add basic splitting support for `pytest`. It doesn't currently read/parse the test output, so retry and other features is not supported.

Missing features:
- Retry
- Skip test
- Mute test

