### PR TITLE
Allow customization of retry test command for pytest

### DIFF
--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -30,6 +30,10 @@ func NewPytest(c RunnerConfig) Pytest {
 		c.TestFilePattern = "**/{*_test,test_*}.py"
 	}
 
+	if c.RetryTestCommand == "" {
+		c.RetryTestCommand = c.TestCommand
+	}
+
 	return Pytest{
 		RunnerConfig: c,
 	}
@@ -40,7 +44,14 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	for i, tc := range testCases {
 		testPaths[i] = tc.Path
 	}
-	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, testPaths)
+
+	command := p.TestCommand
+
+	if retry {
+		command = p.RetryTestCommand
+	}
+
+	cmdName, cmdArgs, err := p.commandNameAndArgs(command, testPaths)
 	if err != nil {
 		return fmt.Errorf("failed to build command: %w", err)
 	}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
https://github.com/buildkite/test-engine-client/pull/286 introduced changes to support retry test for pytest. This PR allows customers to customize the command used when retrying failed tests.