### PR TITLE
Set `make_latest` to `true` if it is not a pre-release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ release:
   name_template: Test Engine Client v{{.Version}}
   draft: false
   prerelease: auto
-  make_latest: false
+  make_latest: "{{not .Prerelease}}"
   mode: replace
 
 changelog:


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
Currently, when we release a stable version (not a pre-release), we need to mark the release in GitHub as the latest release manually. This is because goreleaser didn't support  [_template_](https://goreleaser.com/customization/templates/) (dynamic value) for the `make_latest` attribute. We set the `make_latest` to `false` because we can't mark pre-release as latest release.

 Since goreleaser v2.6.0, the `make_latest` attribute supports _template_. This PR updates the goreleaser configuration to set `make_latest` attribute to `true` when releasing a stable version. So we don't have to set the release as latest release manually.