### PR TITLE
TE-3690: go test x bktec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,15 +14,18 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pact-foundation/pact-go/v2 v2.4.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.32.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -7,7 +7,8 @@ const (
 	TestCaseFormatExample TestCaseFormat = "example"
 )
 
-// TestCase represents a single test case.
+// TestCase currently can represent a single test case or a single test file (when used as output of test plan API).
+// TODO: it's best if we split this into two types.
 type TestCase struct {
 	EstimatedDuration int            `json:"estimated_duration,omitempty"`
 	Format            TestCaseFormat `json:"format,omitempty"`
@@ -18,14 +19,18 @@ type TestCase struct {
 	// In RSpec, the path can be a test file like `user_spec.rb` or an individual test id like `user_spec.rb[1,2]`.
 	// In Jest, the path is a test file like `src/components/Button.spec.tsx`.
 	// In pytest, the path can be a test file like `test_hello.py` or a node id like `test_hello.py::TestHello::test_greet`
+	// In go test, the path can only be package name like "example.com/foo/bar".
 	Path  string `json:"path"`
 	Scope string `json:"scope,omitempty"`
 }
 
 // Task represents the task for the given node.
 type Task struct {
-	NodeNumber int        `json:"node_number"`
-	Tests      []TestCase `json:"tests"`
+	NodeNumber int `json:"node_number"`
+	// When splitting by file, this tests array is essentially an array of test files.
+	// When splitting by example, this array is an array of proper test cases.
+	// See comment above, we plan to split TestCase into two types or clarify its usage.
+	Tests []TestCase `json:"tests"`
 }
 
 // TestPlan represents the entire test plan.

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -47,7 +47,10 @@ func DetectRunner(cfg config.Config) (TestRunner, error) {
 		return NewPlaywright(runnerConfig), nil
 	case "pytest":
 		return NewPytest(runnerConfig), nil
+	case "gotest":
+		return NewGoTest(runnerConfig), nil
 	default:
-		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright', or 'pytest'")
+		// Update the error message to include the new runner
+		return nil, errors.New("runner value is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright', 'pytest', or 'gotest'")
 	}
 }

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/buildkite/test-engine-client/internal/debug"
+	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/kballard/go-shellquote"
+)
+
+type GoTest struct {
+	RunnerConfig
+}
+
+// Compile-time check that GoTest implements TestRunner
+var _ TestRunner = (*GoTest)(nil)
+
+func NewGoTest(c RunnerConfig) GoTest {
+	if c.TestCommand == "" {
+		c.TestCommand = "gotestsum --junitfile={{resultPath}} {{packages}}"
+	}
+
+	if c.RetryTestCommand == "" {
+		c.RetryTestCommand = c.TestCommand
+	}
+
+	return GoTest{
+		RunnerConfig: c,
+	}
+}
+
+func (g GoTest) Name() string {
+	return "gotest"
+}
+
+func (g GoTest) GetExamples(files []string) ([]plan.TestCase, error) {
+	return nil, fmt.Errorf("not supported in go test")
+}
+
+// Run executes the configured command for the specified packages.
+func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
+	cmdName, cmdArgs, err := g.commandNameAndArgs(g.TestCommand, testCases)
+	if err != nil {
+		return fmt.Errorf("failed to build command: %w", err)
+	}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+	err = runAndForwardSignal(cmd)
+	// go test output does not differentiate build fail or test fail. They both return 1
+	// What is even more bizarre is that even when go test failed on compliation, it will still generate an output xml
+	// file that says "TestMain" failed..
+	if exitError := new(exec.ExitError); errors.As(err, &exitError) && exitError.ExitCode() != 1 {
+		return err
+	}
+
+	testResults, err := loadAndParseGotestJUnitXmlResult(g.ResultPath)
+
+	if err != nil {
+		return fmt.Errorf("failed to load and parse test result: %w", err)
+	}
+
+	for _, test := range testResults {
+		result.RecordTestResult(plan.TestCase{
+			Format: plan.TestCaseFormatExample,
+			Scope:  test.Classname,
+			Name:   test.Name,
+			// This is the special thing about go test support.
+			Path: test.Classname,
+		}, test.Result)
+	}
+
+	return nil // Success
+}
+
+// GetFiles discovers Go packages using `go list ./...`.
+// Note that "file" does not exist as a first level concept in Golang projects
+// So this func is returning a list of packages instead of files.
+// The implication is that the Server-side smart test splitting will never work.
+// It almost will always fallback to simple splitting.
+func (g GoTest) GetFiles() ([]string, error) {
+	debug.Println("Discovering Go packages with `go list ./...`")
+	cmd := exec.Command("go", "list", "./...")
+	output, err := cmd.Output()
+	if err != nil {
+		// Handle stderr for better error messages
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("go list failed: %w\nstderr:\n%s", err, string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("failed to run go list: %w", err)
+	}
+	packages := strings.Split(strings.TrimSpace(string(output)), "\n")
+	// Filter out empty strings if any
+	validPackages := []string{}
+	for _, pkg := range packages {
+		if pkg != "" {
+			validPackages = append(validPackages, pkg)
+		}
+	}
+	debug.Println("Discovered", len(validPackages), "packages")
+	if len(validPackages) == 0 {
+		return nil, fmt.Errorf("no Go packages found using `go list ./...`")
+	}
+	return validPackages, nil
+}
+
+func (p GoTest) commandNameAndArgs(cmd string, testCases []plan.TestCase) (string, []string, error) {
+	packages, err := p.getPackages(testCases)
+	if err != nil {
+		return "", []string{}, nil
+	}
+
+	concatenatedPackages := strings.Join(packages, " ")
+
+	if strings.Contains(cmd, "{{packages}}") {
+		cmd = strings.Replace(cmd, "{{packages}}", concatenatedPackages, 1)
+	} else {
+		cmd = cmd + " " + concatenatedPackages
+	}
+
+	cmd = strings.Replace(cmd, "{{resultPath}}", p.ResultPath, 1)
+
+	args, err := shellquote.Split(cmd)
+
+	if err != nil {
+		return "", []string{}, err
+	}
+
+	return args[0], args[1:], nil
+}
+
+// Pluck unique packages from test cases
+func (g GoTest) getPackages(testCases []plan.TestCase) ([]string, error) {
+	packages := make([]string, 0, len(testCases))
+
+	packagesSeen := map[string]bool{}
+	for _, tc := range testCases {
+		packageName := tc.Path
+		if !packagesSeen[packageName] {
+			packages = append(packages, packageName)
+			packagesSeen[packageName] = true
+		}
+	}
+	if len(packages) == 0 {
+		// The likelihood of this is very low
+		return nil, fmt.Errorf("Unable to extract package names from test plan")
+	}
+	debug.Printf("Packages: %v\n", packages)
+
+	return packages, nil
+}

--- a/internal/runner/gotest_junit.go
+++ b/internal/runner/gotest_junit.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Struct to decode gotestsun --junitfile=...
+type GoTestJUnitResult struct {
+	Classname string           `xml:"classname,attr"`
+	Name      string           `xml:"name,attr"`
+	Result    TestStatus       // passed | failed | skipped
+	Failure   *JUnitXMLFailure `xml:"failure"`
+	Skipped   *JUnitXMLSkipped `xml:"skipped"`
+}
+
+// JUnitXMLFailure represents the <failure> element in JUnit XML
+type JUnitXMLFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Content string `xml:",chardata"`
+}
+
+// JUnitXMLSkipped represents the <skipped> element in JUnit XML
+type JUnitXMLSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+// JUnitXMLTestSuite represents the <testsuite> element in JUnit XML
+type JUnitXMLTestSuite struct {
+	XMLName   xml.Name            `xml:"testsuite"`
+	Name      string              `xml:"name,attr"`
+	Tests     int                 `xml:"tests,attr"`
+	Failures  int                 `xml:"failures,attr"`
+	Errors    int                 `xml:"errors,attr"`
+	Time      float64             `xml:"time,attr"`
+	Timestamp string              `xml:"timestamp,attr"`
+	TestCases []GoTestJUnitResult `xml:"testcase"`
+}
+
+// JUnitXMLTestSuites represents the root <testsuites> element in JUnit XML
+type JUnitXMLTestSuites struct {
+	XMLName    xml.Name            `xml:"testsuites"`
+	Tests      int                 `xml:"tests,attr"`
+	Failures   int                 `xml:"failures,attr"`
+	Errors     int                 `xml:"errors,attr"`
+	Time       float64             `xml:"time,attr"`
+	TestSuites []JUnitXMLTestSuite `xml:"testsuite"`
+}
+
+func loadAndParseGotestJUnitXmlResult(path string) ([]GoTestJUnitResult, error) {
+	xmlFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open JUnit XML file %s: %w", path, err)
+	}
+	defer xmlFile.Close()
+
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JUnit XML file %s: %w", path, err)
+	}
+
+	var testSuites JUnitXMLTestSuites
+	err = xml.Unmarshal(byteValue, &testSuites)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JUnit XML file %s: %w", path, err)
+	}
+
+	var results []GoTestJUnitResult
+	for _, suite := range testSuites.TestSuites {
+		for _, tc := range suite.TestCases {
+			testCase := tc // Create a new variable to avoid closure capturing the loop variable
+			if testCase.Failure != nil {
+				testCase.Result = TestStatusFailed
+			} else if testCase.Skipped != nil {
+				testCase.Result = TestStatusSkipped
+			} else {
+				testCase.Result = TestStatusPassed
+			}
+			results = append(results, testCase)
+		}
+	}
+
+	return results, nil
+}

--- a/internal/runner/gotest_junit_test.go
+++ b/internal/runner/gotest_junit_test.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const exampleJUnitXML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="4" failures="1" errors="0" time="1.639386">
+	<testsuite tests="4" failures="1" time="1.306000" name="github.com/buildkite/test-engine-client/internal/debug" timestamp="2025-04-22T15:34:03+10:00">
+		<properties>
+			<property name="go.version" value="go1.24.1 darwin/arm64"></property>
+		</properties>
+		<testcase classname="github.com/buildkite/test-engine-client/internal/debug" name="TestPrintf" time="0.000000">
+			<failure message="Failed" type="">=== RUN   TestPrintf&#xA;    debug_test.go:21: error matching output: &lt;nil&gt;&#xA;--- FAIL: TestPrintf (0.00s)&#xA;</failure>
+		</testcase>
+		<testcase classname="github.com/buildkite/test-engine-client/internal/debug" name="TestPrintf_disabled" time="1.000000"></testcase>
+		<testcase classname="github.com/buildkite/test-engine-client/internal/debug" name="TestPrintln" time="0.000000"></testcase>
+		<testcase classname="github.com/buildkite/test-engine-client/internal/debug" name="TestPrintln_disabled" time="0.000000"></testcase>
+	</testsuite>
+</testsuites>`
+
+func TestLoadAndParseGotestJUnitXmlResult(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "junit.*.xml")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	_, err = tmpfile.WriteString(exampleJUnitXML)
+	require.NoError(t, err)
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	results, err := loadAndParseGotestJUnitXmlResult(tmpfile.Name())
+	require.NoError(t, err)
+
+	require.Len(t, results, 4)
+
+	assert.Equal(t, "github.com/buildkite/test-engine-client/internal/debug", results[0].Classname)
+	assert.Equal(t, "TestPrintf", results[0].Name)
+	assert.Equal(t, TestStatusFailed, results[0].Result)
+	assert.NotNil(t, results[0].Failure)
+	assert.Nil(t, results[0].Skipped)
+
+	assert.Equal(t, "github.com/buildkite/test-engine-client/internal/debug", results[1].Classname)
+	assert.Equal(t, "TestPrintf_disabled", results[1].Name)
+	assert.Equal(t, TestStatusPassed, results[1].Result)
+	assert.Nil(t, results[1].Failure)
+	assert.Nil(t, results[1].Skipped)
+
+	assert.Equal(t, "github.com/buildkite/test-engine-client/internal/debug", results[2].Classname)
+	assert.Equal(t, "TestPrintln", results[2].Name)
+	assert.Equal(t, TestStatusPassed, results[2].Result)
+	assert.Nil(t, results[2].Failure)
+	assert.Nil(t, results[2].Skipped)
+
+	assert.Equal(t, "github.com/buildkite/test-engine-client/internal/debug", results[3].Classname)
+	assert.Equal(t, "TestPrintln_disabled", results[3].Name)
+	assert.Equal(t, TestStatusPassed, results[3].Result)
+	assert.Nil(t, results[3].Failure)
+	assert.Nil(t, results[3].Skipped)
+}

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGotestRun(t *testing.T) {
+	changeCwd(t, "./testdata/go")
+
+	gotest := NewGoTest(RunnerConfig{
+		ResultPath: getRandomXmlTempFilename(),
+	})
+	testCases := []plan.TestCase{
+		{Path: "example.com/hello"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := gotest.Run(result, testCases, false)
+
+	assert.NoError(t, err)
+	if result.Status() != RunStatusPassed {
+		t.Errorf("Gotest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusPassed)
+	}
+
+	fmt.Printf("result.tests: %v\n", result.tests)
+
+	testResult := result.tests["example.com/hello/TestHelloWorld/example.com/hello"]
+	if testResult.Path != "example.com/hello" {
+		t.Errorf("TestResult.Path = %v, want %v", testResult.Path, "example.com/hello")
+	}
+}
+
+func TestGotestRun_TestFailed(t *testing.T) {
+	changeCwd(t, "./testdata/go")
+
+	gotest := NewGoTest(RunnerConfig{
+		ResultPath: getRandomXmlTempFilename(),
+	})
+	testCases := []plan.TestCase{
+		{Path: "example.com/hello/bad"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := gotest.Run(result, testCases, false)
+
+	assert.NoError(t, err)
+	if result.Status() != RunStatusFailed {
+		t.Errorf("Gotest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusFailed)
+	}
+}
+
+func TestGotestRun_CommandFailed(t *testing.T) {
+	changeCwd(t, "./testdata/go")
+
+	gotest := NewGoTest(RunnerConfig{
+		TestCommand: "gotestsum --junitfile {{resultPath}} bluhbluh",
+		ResultPath:  getRandomXmlTempFilename(),
+	})
+	testCases := []plan.TestCase{
+		{Path: "example.com/hello"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := gotest.Run(result, testCases, false)
+
+	assert.NoError(t, err) // sadly we don't have a way to reliably differentiate test fail vs build fail (yet).
+	if result.Status() != RunStatusFailed {
+		t.Errorf("Gotest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusFailed)
+	}
+}
+
+func TestGotestGetFiles(t *testing.T) {
+	changeCwd(t, "./testdata/go")
+
+	gotest := NewGoTest(RunnerConfig{})
+
+	got, err := gotest.GetFiles()
+	if err != nil {
+		t.Errorf("Gotest.GetFiles() error = %v", err)
+	}
+
+	want := []string{
+		"example.com/hello",
+		"example.com/hello/bad",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Gotest.GetFiles() diff (-got +want):\n%s", diff)
+	}
+}
+
+func getRandomXmlTempFilename() string {
+	tempDir, err := os.MkdirTemp("", "bktec-*")
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(tempDir, "test-results.xml")
+}

--- a/internal/runner/testdata/go/bad/bad_test.go
+++ b/internal/runner/testdata/go/bad/bad_test.go
@@ -1,0 +1,9 @@
+package bad
+
+import (
+	"testing"
+)
+
+func TestBad(t *testing.T) {
+	t.Errorf("Test failed: expected %v, got %v", true, false)
+}

--- a/internal/runner/testdata/go/go.mod
+++ b/internal/runner/testdata/go/go.mod
@@ -1,0 +1,3 @@
+module example.com/hello
+
+go 1.21

--- a/internal/runner/testdata/go/hello_test.go
+++ b/internal/runner/testdata/go/hello_test.go
@@ -1,0 +1,9 @@
+package hello
+
+import (
+	"testing"
+)
+
+func TestHelloWorld(t *testing.T) {
+	// A simple placeholder test
+}

--- a/main.go
+++ b/main.go
@@ -40,8 +40,14 @@ func printStartUpMessage() {
 }
 
 type TestRunner interface {
+	// Run takes testCases as input, executes the test against the test cases, and mutates the runner.RunResult with the test results.
 	Run(result *runner.RunResult, testCases []plan.TestCase, retry bool) error
+	// GetExamples discovers all tests within given files.
+	// This function is only used for split by example use case. Currently only supported by RSpec.
 	GetExamples(files []string) ([]plan.TestCase, error)
+	// GetFiles discover all test files that the runner should execute.
+	// This is sent to server-side when creating test plan.
+	// This is also used to obtain a fallback non-intelligent test splitting mechanism.
 	GetFiles() ([]string, error)
 	Name() string
 }


### PR DESCRIPTION
### Description

Introduce an experimental Go test support. 

Go test, different from other test runners in that it does not really have a concept of "file", so I tried I might to use "package" as a replacement. In another word, the "Path" for a test case in golang, is "package" instead of file path. 

This means: 

- Smart test splitting will never work (because server will never have file stats for "package"). I expect server-side to return non-intelligent simple test splitting test plan.
- Auto test retry happen on package level. 

### Context

part of TE-3690

subsequent PRs incoming for Readme change.

### Changes

* Added `gotest` runner.
* Added many codedoc clarifying behavior of bktec internal.