### PR TITLE
TE-3707 follow up: stop collecting test fixture test cases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client
       - aws-ssm#v1.0.0:
           parameters:
-            BUILDKITE_ANALYTICS_TOKEN: /pipelines/buildkite/test-engine-client/SUITE_TOKEN
+            BUILDKITE_TEST_ENGINE_SUITE_TOKEN: /pipelines/buildkite/test-engine-client/SUITE_TOKEN
             BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client/API_ACCESS_TOKEN
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
@@ -30,11 +30,14 @@ steps:
           run: ci
           propagate-environment: true
           environment:
-            - BUILDKITE_ANALYTICS_TOKEN
+            - BUILDKITE_TEST_ENGINE_SUITE_TOKEN
             - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
       - test-collector#v1.11.0:
           files: "junit-*.xml"
           format: "junit"
+          # This is to prevent the test runner as part of our test fixture trigger test collection
+          # such as pytest + python test collector
+          api-token-env-name: "BUILDKITE_TEST_ENGINE_SUITE_TOKEN"
 
   - wait
 


### PR DESCRIPTION
### Description

one funny thing with using bktec on bktec is that the BUILDKITE_ANALYTICS_TOKEN will be used by the test code too.
So we end up having our test cases + those test fixture test execution collected in test engine.

This PR stops collecting test fixture test cases. 