### PR TITLE
TE-3708: fix windows compilation error undefined SIGCHLD

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -39,9 +39,8 @@ func runAndForwardSignal(cmd *exec.Cmd) error {
 		for {
 			select {
 			case sig := <-sigCh:
-				// When the subprocess exits, it sends SIGCHLD to the parent process.
-				// We ignore this signal because we don't want to forward it back to the subprocess.
-				if sig == syscall.SIGCHLD {
+				// Check if the signal should be ignored (e.g., SIGCHLD on Unix).
+				if isIgnoredSignal(sig) {
 					continue
 				}
 				// Ignore the error when sending the signal to the command.

--- a/internal/runner/signal_unix.go
+++ b/internal/runner/signal_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package runner
+
+import (
+	"os"
+	"syscall"
+)
+
+// isIgnoredSignal checks if the signal should be ignored.
+// On Unix-like systems, we ignore SIGCHLD, which is sent when a child process terminates.
+var isIgnoredSignal = func(sig os.Signal) bool {
+	return sig == syscall.SIGCHLD
+}

--- a/internal/runner/signal_windows.go
+++ b/internal/runner/signal_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package runner
+
+import "os"
+
+// isIgnoredSignal checks if the signal should be ignored.
+// On Windows, there isn't a direct equivalent to SIGCHLD that needs ignoring in this context.
+var isIgnoredSignal = func(sig os.Signal) bool {
+	return false
+}


### PR DESCRIPTION
### Description

Fix a compilation error on Windows: 

`C:\GoPath\pkg\mod\github.com\buildkite\test-engine-client@v1.5.0-rc.1\internal\runner\command.go:44:23: undefined: syscall.SIGCHLD`


This blocks agent adopting bktec

### Context

part of TE-3708