### PR TITLE
TE-3818: retry on failed muted tests by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	Parallelism int
 	// The path to the result file.
 	ResultPath string
+	// Whether a failed muted test should be retried.
+	// This is default to true because we want more signal for our flaky detection system.
+	RetryForMutedTest bool
 	// ServerBaseUrl is the base URL of the test plan server.
 	ServerBaseUrl string
 	// SplitByExample is the flag to enable split the test by example.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,18 +11,19 @@ import (
 
 func getExampleEnv() env.Env {
 	return env.Map{
-		"BUILDKITE_PARALLEL_JOB_COUNT":           "60",
-		"BUILDKITE_PARALLEL_JOB":                 "7",
-		"BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN": "my_token",
-		"BUILDKITE_TEST_ENGINE_BASE_URL":         "https://build.kite",
-		"BUILDKITE_TEST_ENGINE_TEST_CMD":         "bin/rspec {{testExamples}}",
-		"BUILDKITE_ORGANIZATION_SLUG":            "my_org",
-		"BUILDKITE_TEST_ENGINE_SUITE_SLUG":       "my_suite",
-		"BUILDKITE_BUILD_ID":                     "123",
-		"BUILDKITE_STEP_ID":                      "456",
-		"BUILDKITE_TEST_ENGINE_TEST_RUNNER":      "rspec",
-		"BUILDKITE_TEST_ENGINE_RESULT_PATH":      "tmp/rspec.json",
-		"BUILDKITE_RETRY_COUNT":                  "0",
+		"BUILDKITE_PARALLEL_JOB_COUNT":                       "60",
+		"BUILDKITE_PARALLEL_JOB":                             "7",
+		"BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN":             "my_token",
+		"BUILDKITE_TEST_ENGINE_BASE_URL":                     "https://build.kite",
+		"BUILDKITE_TEST_ENGINE_TEST_CMD":                     "bin/rspec {{testExamples}}",
+		"BUILDKITE_ORGANIZATION_SLUG":                        "my_org",
+		"BUILDKITE_TEST_ENGINE_SUITE_SLUG":                   "my_suite",
+		"BUILDKITE_BUILD_ID":                                 "123",
+		"BUILDKITE_STEP_ID":                                  "456",
+		"BUILDKITE_TEST_ENGINE_TEST_RUNNER":                  "rspec",
+		"BUILDKITE_TEST_ENGINE_DISABLE_RETRY_FOR_MUTED_TEST": "true",
+		"BUILDKITE_TEST_ENGINE_RESULT_PATH":                  "tmp/rspec.json",
+		"BUILDKITE_RETRY_COUNT":                              "0",
 	}
 }
 
@@ -35,19 +36,20 @@ func TestNewConfig(t *testing.T) {
 	}
 
 	want := Config{
-		Parallelism:      60,
-		NodeIndex:        7,
-		ServerBaseUrl:    "https://build.kite",
-		Identifier:       "123/456",
-		TestCommand:      "bin/rspec {{testExamples}}",
-		AccessToken:      "my_token",
-		OrganizationSlug: "my_org",
-		ResultPath:       "tmp/rspec.json",
-		SuiteSlug:        "my_suite",
-		TestRunner:       "rspec",
-		JobRetryCount:    0,
-		Env:              env,
-		errs:             InvalidConfigError{},
+		Parallelism:       60,
+		NodeIndex:         7,
+		ServerBaseUrl:     "https://build.kite",
+		Identifier:        "123/456",
+		TestCommand:       "bin/rspec {{testExamples}}",
+		AccessToken:       "my_token",
+		OrganizationSlug:  "my_org",
+		RetryForMutedTest: false,
+		ResultPath:        "tmp/rspec.json",
+		SuiteSlug:         "my_suite",
+		TestRunner:        "rspec",
+		JobRetryCount:     0,
+		Env:               env,
+		errs:              InvalidConfigError{},
 	}
 
 	if diff := cmp.Diff(c, want, cmpopts.IgnoreUnexported(Config{})); diff != "" {
@@ -68,6 +70,7 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	env.Delete("BUILDKITE_TEST_ENGINE_MODE")
 	env.Delete("BUILDKITE_TEST_ENGINE_BASE_URL")
 	env.Delete("BUILDKITE_TEST_ENGINE_TEST_CMD")
+	env.Delete("BUILDKITE_TEST_ENGINE_DISABLE_RETRY_FOR_MUTED_TEST")
 
 	c, err := New(env)
 	if err != nil {
@@ -75,17 +78,18 @@ func TestNewConfig_MissingConfigWithDefault(t *testing.T) {
 	}
 
 	want := Config{
-		Parallelism:      60,
-		NodeIndex:        7,
-		ServerBaseUrl:    "https://api.buildkite.com",
-		Identifier:       "123/456",
-		AccessToken:      "my_token",
-		OrganizationSlug: "my_org",
-		SuiteSlug:        "my_suite",
-		TestRunner:       "rspec",
-		ResultPath:       "tmp/rspec.json",
-		JobRetryCount:    0,
-		Env:              env,
+		Parallelism:       60,
+		NodeIndex:         7,
+		ServerBaseUrl:     "https://api.buildkite.com",
+		Identifier:        "123/456",
+		AccessToken:       "my_token",
+		OrganizationSlug:  "my_org",
+		SuiteSlug:         "my_suite",
+		TestRunner:        "rspec",
+		RetryForMutedTest: true,
+		ResultPath:        "tmp/rspec.json",
+		JobRetryCount:     0,
+		Env:               env,
 	}
 
 	if diff := cmp.Diff(c, want, cmpopts.IgnoreUnexported(Config{})); diff != "" {

--- a/internal/config/read.go
+++ b/internal/config/read.go
@@ -53,6 +53,7 @@ func (c *Config) readFromEnv(env env.Env) error {
 	c.TestFilePattern = env.Get("BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN")
 	c.TestFileExcludePattern = env.Get("BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN")
 	c.TestRunner = env.Get("BUILDKITE_TEST_ENGINE_TEST_RUNNER")
+	c.RetryForMutedTest = strings.ToLower(env.Get("BUILDKITE_TEST_ENGINE_DISABLE_RETRY_FOR_MUTED_TEST")) != "true"
 	c.ResultPath = env.Get("BUILDKITE_TEST_ENGINE_RESULT_PATH")
 
 	c.SplitByExample = strings.ToLower(env.Get("BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE")) == "true"

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -12,21 +12,22 @@ import (
 func TestConfigReadFromEnv(t *testing.T) {
 	c := Config{}
 	err := c.readFromEnv(env.Map{
-		"BUILDKITE_PARALLEL_JOB_COUNT":                    "10",
-		"BUILDKITE_PARALLEL_JOB":                          "0",
-		"BUILDKITE_TEST_ENGINE_BASE_URL":                  "https://buildkite.localhost",
-		"BUILDKITE_TEST_ENGINE_TEST_CMD":                  "bin/rspec {{testExamples}}",
-		"BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN":          "my_token",
-		"BUILDKITE_ORGANIZATION_SLUG":                     "my_org",
-		"BUILDKITE_TEST_ENGINE_SUITE_SLUG":                "my_suite",
-		"BUILDKITE_TEST_ENGINE_RETRY_COUNT":               "3",
-		"BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE":          "TRUE",
-		"BUILDKITE_BUILD_ID":                              "123",
-		"BUILDKITE_STEP_ID":                               "456",
-		"BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN":         "spec/unit/**/*_spec.rb",
-		"BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN": "spec/feature/**/*_spec.rb",
-		"BUILDKITE_TEST_ENGINE_RESULT_PATH":               "result.json",
-		"BUILDKITE_TEST_ENGINE_TEST_RUNNER":               "rspec",
+		"BUILDKITE_PARALLEL_JOB_COUNT":                       "10",
+		"BUILDKITE_PARALLEL_JOB":                             "0",
+		"BUILDKITE_TEST_ENGINE_BASE_URL":                     "https://buildkite.localhost",
+		"BUILDKITE_TEST_ENGINE_TEST_CMD":                     "bin/rspec {{testExamples}}",
+		"BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN":             "my_token",
+		"BUILDKITE_ORGANIZATION_SLUG":                        "my_org",
+		"BUILDKITE_TEST_ENGINE_SUITE_SLUG":                   "my_suite",
+		"BUILDKITE_TEST_ENGINE_RETRY_COUNT":                  "3",
+		"BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE":             "TRUE",
+		"BUILDKITE_BUILD_ID":                                 "123",
+		"BUILDKITE_STEP_ID":                                  "456",
+		"BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN":            "spec/unit/**/*_spec.rb",
+		"BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN":    "spec/feature/**/*_spec.rb",
+		"BUILDKITE_TEST_ENGINE_DISABLE_RETRY_FOR_MUTED_TEST": "TRUE",
+		"BUILDKITE_TEST_ENGINE_RESULT_PATH":                  "result.json",
+		"BUILDKITE_TEST_ENGINE_TEST_RUNNER":                  "rspec",
 	})
 
 	want := Config{
@@ -44,6 +45,7 @@ func TestConfigReadFromEnv(t *testing.T) {
 		TestFileExcludePattern: "spec/feature/**/*_spec.rb",
 		TestRunner:             "rspec",
 		ResultPath:             "result.json",
+		RetryForMutedTest:      false,
 		JobRetryCount:          0,
 	}
 

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -107,6 +107,17 @@ func (r *RunResult) SkippedTests() []plan.TestCase {
 	return skippedTests
 }
 
+func (r *RunResult) FailedMutedTests() []plan.TestCase {
+	var failedTests []plan.TestCase
+
+	for _, test := range r.tests {
+		if test.Status == TestStatusFailed && test.Muted {
+			failedTests = append(failedTests, test.TestCase)
+		}
+	}
+	return failedTests
+}
+
 // Status returns the overall status of the test run.
 // If there is an error, it returns RunStatusError.
 // If there are failed tests, it returns RunStatusFailed.


### PR DESCRIPTION
### Description

As we make more progress on statistic based flaky monitor, we discovered a problem: if a test is muted, it won't be retried. It means a sudden signal cutoff for some of our flaky detection models. 

We want rich signal. 

This PR: 
* make retry for failed muted test by default. 
* offer a new env var `BUILDKITE_TEST_ENGINE_DISABLE_RETRY_FOR_MUTED_TEST` as opt-out mechanism. 

### Context

TE-3818


I recommend ignoring whitespace when reviewing this change. 