### PR TITLE
Snip reviewers from dependabot yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @buildkite/test-splitting
+* @buildkite/test-engine

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 2
-    reviewers:
-      - "buildkite/test-splitting"


### PR DESCRIPTION
### Description

Per https://github.com/buildkite/test-engine-client/pull/313#issuecomment-2890815336, this PR updates the dependabot configuration to remove the reviewers configuration option. The CODEOWNERS file is also out of date, so this is updated as well.
