### PR TITLE
Pull golang docker image from Dockerhub

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.4.4-slim-bookworm AS ruby
 FROM cypress/included:14.3.3 AS cypress
 FROM python:3.13.3-bookworm AS python
 
-FROM public.ecr.aws/docker/library/golang:1.24.3 AS golang
+FROM golang:1.24.3-bookworm AS golang
 
 COPY --from=ruby / /
 COPY --from=cypress / /


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
All builds failed because Buildkite can't pull golang image from AWS ECR. This seems like an issue at the AWS side, and for now, we can pull from Dockerhub instead.
