### PR TITLE
Remove now-redundant line from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: /.buildkite
     schedule:
       interval: weekly
-    reviewers:
-      - "buildkite/test-splitting"
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
### Description

The reviewers key in dependabot.yml is going away in favour of CODEOWNERS. We already have CODEOWNERS configured, so this line can be removed.