### PR TITLE
Update OIDC roles to use session tokens

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -12,8 +12,12 @@ steps:
   - name: ":rocket: Release"
     artifact_paths: "dist/**/*"
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client-release
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
             GITHUB_TOKEN: /pipelines/buildkite/test-engine-client-release/GH_TOKEN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,8 +18,12 @@ steps:
       - cover.{html,out}
       - internal/api/pacts/*
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
             BUILDKITE_TEST_ENGINE_SUITE_TOKEN: /pipelines/buildkite/test-engine-client/SUITE_TOKEN


### PR DESCRIPTION
### Description

Rolling out using OIDC session tokens in all buildkite pipelines that assume IAM roles.

Notably rolls out https://github.com/buildkite/terraform-modules/pull/60 in alignment with our incident 486 findings.

This moves everyone away from the glob matching sub claims and over to session tokens, from https://github.com/buildkite/terraform-modules/pull/56

The IAM role trust policies are being updated in buildkite-dev account in PR: https://github.com/buildkite/aws-buildkite-dev/pull/468 - this will need to be merged and applied before any of these pipeline.yml changes work.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

<!--
List of what the PR changes.

Can skip if changes are simple or clear from the commit messages.
-->

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
