### PR TITLE
fix: brew path should be in Formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ brews:
     description: "Buildkite Test Engine Client"
     homepage: "https://github.com/buildkite/test-engine-client"
     skip_upload: auto
-    directory: .
+    directory: Formula
     test: |
       version_output = shell_output("bktec --version")
       assert_match "v#{version}\n", version_output


### PR DESCRIPTION
### Description

Currently we have duplicate rb files in the homebrew dir because we push to root, but also have some in Formula. Having them in the latter is the best practise, though.

### Context

[homebrew-buildkite](https://github.com/buildkite/homebrew-buildkite) contains duplicate `.rb` files for formulas, which will cause `brew` to warn when `brew doctor` is run with;

```sh
Warning: Found Ruby file outside /opt/homebrew/Library/taps/buildkite/ tap formula directory.
```

### Changes

- Points GoReleaser to the Formula directory for brew releases

### Rollback
Safe. Just revert the change.

### Follow Up

We should delete the `.rb` files at the root of the homebrew dir
