### PR TITLE
[TE-4853] Update .gitignore to ignore test-engine-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ internal/runner/testdata/cucumber/cucumber.json
 .envrc
 
 .direnv
+
+# Output binary with `go build`
+test-engine-client


### PR DESCRIPTION
### Description

test-engine-client is produced when running `go build`.
We can ignore this file in `.gitignore`

### Context

TE-4853
