### PR TITLE
Better handling of runtime error for Jest

### DIFF
--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -108,7 +108,6 @@ func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) erro
 		// When a TestResult has status "failed" but has no AssertionResults, it indicates a runtime error at the file level.
 		if testResult.Status == "failed" && len(testResult.AssertionResults) == 0 {
 			result.error = fmt.Errorf("Jest failed with runtime error test suites")
-			continue
 		}
 
 		for _, example := range testResult.AssertionResults {

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -244,6 +244,11 @@ func TestJestRun_RuntimeError(t *testing.T) {
 		t.Errorf("Jest.Run(%q) error = %v", testCases, err)
 	}
 
+	// Make sure that we capture other tests that are not affected by the runtime error (expelliarmus.spec.js)
+	if len(result.tests) != 1 {
+		t.Errorf("Jest.Run(%q) len(RunResult.tests) = %d, want 1", testCases, len(result.tests))
+	}
+
 	if result.Status() != RunStatusError {
 		t.Errorf("Jest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
 	}


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
A customer reported that `bktec` failed to catch a file-level runtime error in the Vitest suite. Although Vitest isn’t officially supported by `bktec`, you can use the `jest` runner to split the Vitest test suite. This is because Jest and Vitest have a similar report structure. 

We don’t currently have a plan to introduce a dedicated runner for Vitest. However, since Vitest shared many similarities with Jest, I thought we could update the existing `jest` runner to catch file-level runtime errors from both Jest and Vitest.

Currently, the `jest` runner detects runtime errors by checking the `numRuntimeErrorTestSuites` attribute from the [report](https://jestjs.io/docs/configuration#testresultsprocessor-string). However, this attribute doesn't exist in the Vitest [report](https://vitest.dev/guide/reporters.html#json-reporter). After looking at Jest & Vitest reports structure when there is a runtime error, I found that both will return a `test_result` with `status: "failed"` and `assertionResults: []`. We can use this pattern to detect and catch a runtime error for both Jest and Vitest.

```json
// jest report
{
  "numFailedTestSuites": 2,
  "numFailedTests": 2,
  "numPassedTestSuites": 1,
  "numPassedTests": 1,
  "numPendingTestSuites": 0,
  "numPendingTests": 0,
  "numRuntimeErrorTestSuites": 1,
  "numTodoTests": 0,
  "numTotalTestSuites": 3,
  "numTotalTests": 3,
  "openHandles": [],
  "snapshot": {...},
  "startTime": 1761253453607,
  "success": false,
  "testResults": [
    { => this is the file that failed to run because of runtime error
      "assertionResults": [],
      "coverage": {},
      "endTime": 1761253453978,
      "message": "  ● Test suite failed to run\n\n    Jest encountered an unexpected token\n\n    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.\n\n    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.\n\n    By default \"node_modules\" folder is ignored by transformers.\n\n    Here's what you can do:\n     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.\n     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript\n     • To have some of your \"node_modules\" files transformed, you can specify a custom \"transformIgnorePatterns\" in your config.\n     • If you need a custom transformation specify a \"transform\" option in your config.\n     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the \"moduleNameMapper\" config option.\n\n    You'll find more details and examples of these config options in the docs:\n    https://jestjs.io/docs/configuration\n    For information about custom transformations, see:\n    https://jestjs.io/docs/code-transformation\n\n    Details:\n\n    /Users/naufan/Documents/Repositories/buildkite/test-engine-client/internal/runner/testdata/jest/fileLevelRuntimeError.spec.js:1\n    ({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,jest){import nonExistent from 'non-existent-module';\n                                                                                      ^^^^^^\n\n    SyntaxError: Cannot use import statement outside a module\n\n      at Runtime.createScriptFromCode (../node_modules/jest-runtime/build/index.js:1505:14)\n",
      "name": "/Users/naufan/Documents/Repositories/buildkite/test-engine-client/internal/runner/testdata/jest/fileLevelRuntimeError.spec.js",
      "startTime": 1761253453978,
      "status": "failed",
      "summary": ""
    },
    {
      "assertionResults": [
        {
          "ancestorTitles": ["expelliarmus"],
          "duration": 3,
          "failureDetails": [],
          "failureMessages": [],
          "fullName": "expelliarmus disarms the opponent",
          "invocations": 1,
          "location": { "column": 3, "line": 2 },
          "numPassingAsserts": 1,
          "retryReasons": [],
          "status": "passed",
          "title": "disarms the opponent"
        }
      ],
      "endTime": 1761253453956,
      "message": "",
      "name": "/Users/naufan/Documents/Repositories/buildkite/test-engine-client/internal/runner/testdata/jest/spells/expelliarmus.spec.js",
      "startTime": 1761253453715,
      "status": "passed",
      "summary": ""
    },
  ],
  "wasInterrupted": false
}
```

```json
// vitest report
{
  "numTotalTestSuites": 3,
  "numPassedTestSuites": 2,
  "numFailedTestSuites": 1,
  "numPendingTestSuites": 0,
  "numTotalTests": 1,
  "numPassedTests": 1,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "snapshot": {...},
  "startTime": 1761180624653,
  "success": false,
  "testResults": [
    { => this is the file that failed to run because of runtime error
      "assertionResults": [],
      "startTime": 1761180624653,
      "endTime": 1761180624653,
      "status": "failed",
      "message": "Cannot find package 'void' imported from '/Users/naufan/Documents/Repositories/buildkite/test-collector-javascript/examples/vitest/example.test.js'",
      "name": "/Users/naufan/Documents/Repositories/buildkite/test-collector-javascript/examples/vitest/example.test.js"
    },
    {
      "assertionResults": [
        {
          "ancestorTitles": ["passed"],
          "fullName": "passed is true",
          "status": "passed",
          "title": "is true",
          "duration": 0.5377500057220459,
          "failureMessages": [],
          "location": { "line": 4, "column": 5 },
          "meta": {}
        }
      ],
      "startTime": 1761180624874,
      "endTime": 1761180624874.5378,
      "status": "passed",
      "message": "",
      "name": "/Users/naufan/Documents/Repositories/buildkite/test-collector-javascript/examples/vitest/passed.test.js"
    }
  ]
}
```

> [!NOTE]
> This isn’t official support for Vitest, but rather a patch to the `jest` runner to cover some Vitest behaviour. Ideally, we should introduce a dedicated Vitest runner.

> [!IMPORTANT] 
> I'm merging this PR to `v1.6.x` branch as we want this as hotfix for `v1.6.0`. This PR will be merged back to `main` once we release the hotfix.

### Context

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->
https://linear.app/buildkite/issue/TE-4851

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
Run Jest/Vitest that has a file level runtime-error (e.g. importing non existing module) with bktec using `jest` runner. `bktec` should catch the error and exit with code `1`