### PR TITLE
[TE-4791] Allow bktec run command to specify 'plan-identifier' flag

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -55,6 +55,10 @@ func Run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 
+	if cmd.String("plan-identifier") != "" {
+		cfg.Identifier = cmd.String("plan-identifier")
+	}
+
 	testRunner, err := runner.DetectRunner(cfg)
 	if err != nil {
 		return fmt.Errorf("unsupported value for BUILDKITE_TEST_ENGINE_TEST_RUNNER: %w", err)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,13 @@ func main() {
 				Name:   "run",
 				Usage:  "Run tests (default)",
 				Action: command.Run,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "plan-identifier",
+						Value: "",
+						Usage: "run the tests from a plan previously generated matching the provided plan-identifier",
+					},
+				},
 			},
 			{
 				Name:   "plan",


### PR DESCRIPTION
### Description

Allow the `run` command to support specifying a `plan_identifier`
flag. This would override the default behaviour deriving the
`identifier` by concatenating BUILDKITE_BUILD_ID and BUILDKITE_STEP_ID

This will be useful when a different step (or build) generates
the plan with the `plan` command. And we have a separate step
to run/execute the plan.

### Context

TE-4791

### Changes

Modified config.New to accept cli.Command which will derive
the config from the commands in addition to env vars.

### Testing

We currently don't have a comprehensive process to test the CLI tool 
and the flags.
