### PR TITLE
Upgrade docker plugin for pipeline

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,7 +1,7 @@
 steps:
   - name: ":cook: Prepare release"
     plugins:
-      - docker#v5.11.0:
+      - docker#v5.13.0:
           image: ghcr.io/caarlos0/svu:v2.1.0
           entrypoint: ""
           command: [".buildkite/steps/prepare-release.sh"]
@@ -23,7 +23,7 @@ steps:
             GITHUB_TOKEN: /pipelines/buildkite/test-engine-client-release/GH_TOKEN
             DOCKERHUB_USER: /pipelines/buildkite/test-engine-client-release/dockerhub-user
             DOCKERHUB_PASSWORD: /pipelines/buildkite/test-engine-client-release/dockerhub-password
-      - docker#v5.11.0:
+      - docker#v5.13.0:
           image: goreleaser/goreleaser:v2.8.1
           entrypoint: ""
           command: [".buildkite/steps/release.sh"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ env:
 steps:
   - name: ":golangci-lint: Lint"
     plugins:
-      - docker#v5.11.0:
+      - docker#v5.13.0:
           image: golangci/golangci-lint:v1.64.8
           workdir: /go/src/github.com/your-org/your-repo
           command:
@@ -50,7 +50,7 @@ steps:
     - name: ":{{matrix.os}}: Build {{matrix.os}} {{matrix.arch}} binary"
       artifact_paths: "dist/**/*"
       plugins:
-        docker#v5.11.0:
+        docker#v5.13.0:
           image: goreleaser/goreleaser:v2.8.1
           mount-buildkite-agent: true
           environment:


### PR DESCRIPTION
I attempted to create a release for v1.6.1, but the build failed because the agent couldn’t create the OIDC token. This is due to the `BUILDKITE_AGENT_JOB_API_SOCKET` environment variable being missing during runtime (docker container). Since agent v3.104, this environment variable is required to create an OIDC token (See https://forum.buildkite.community/t/buildkite-agent-job-api-socket-empty-or-undefined/4497).

The `BUILDKITE_AGENT_JOB_API_SOCKET` and other required env vars are now automatically propagated from the job to the docker container in the docker plugin >= [v5.12.0](https://github.com/buildkite-plugins/docker-buildkite-plugin/releases/tag/v5.12.0). This PR upgraded the docker plugin to the latest version as an attempt to fix the release pipeline.