### PR TITLE
Exit with error on unknown commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,9 +16,22 @@ import (
 
 func main() {
 	cmd := &cli.Command{
-		Name:   "bktec",
-		Usage:  "Buildkite Test Engine Client",
-		Action: command.Run,
+		Name:  "bktec",
+		Usage: "Buildkite Test Engine Client",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			// This action is called when no command is given, and calls run().
+			// So running `bktec` is the same as running `bktec run`.
+			//
+			// Because this action is also called when no matching command is found
+			// a typo like `bktec plaan` will call run() with "plaan" in cmd.Args().
+			// We error here if any arguments are present and assume the first is a
+			// mis-spelled command name.
+			if cmd.Args().Len() > 0 {
+				fmt.Fprintf(os.Stderr, "invalid command %q\n", cmd.Args().Get(0))
+				cli.ShowRootCommandHelpAndExit(cmd, 1)
+			}
+			return command.Run(ctx, cmd)
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "files",


### PR DESCRIPTION
Ensure misspelt command names cause an error.

## Before

```
$ bktec plaan
+++ Buildkite Test Engine Client: bktec dev


______ ______ _____
___  /____  /___  /____________
__  __ \_  //_/  __/  _ \  ___/
_  /_/ /  ,<  / /_ /  __/ /__
/_.___//_/|_| \__/ \___/\___/

2025/10/24 19:41:02 DEBUG: Discovering test files with include pattern: spec/**/*_spec.rb exclude pattern:
--8<--
```

## After

```
$ bktec plaan
invalid command "plaan"
NAME:
   bktec - Buildkite Test Engine Client

USAGE:
   bktec [global options] [command [command options]]

COMMANDS:
   run      Run tests (default)
   plan     Generate test plan without running tests
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --files string  override the default test file discovery by providing a path to a file containing a list of test files (one per line)
   --version       print version information and exit (default: false)
   --help, -h      show help
```