### PR TITLE
Make parallelism config optional on plan command

### DIFF
--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -56,7 +56,7 @@ func TestPlan(t *testing.T) {
 	cfg.TestFilePattern = "testdata/rspec/spec/**/*_spec.rb"
 	cfg.ServerBaseUrl = svr.URL
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Validate(config.ValidationOpts{}); err != nil {
 		t.Errorf("Invalid config: %v", err)
 	}
 

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -21,6 +21,10 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 		})
 	}
 
+	if cfg.MaxParallelism != 0 && cfg.Parallelism == 0 {
+		cfg.Parallelism = 1
+	}
+
 	// Splitting files by example is only supported for rspec runner & cucumber
 	if runner.Name() != "RSpec" && runner.Name() != "Cucumber" {
 		params := api.TestPlanParams{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -5,8 +5,12 @@ import (
 	"net/url"
 )
 
+type ValidationOpts struct {
+	SkipParallelism bool
+}
+
 // Validate checks if the Config struct is valid and returns InvalidConfigError if it's invalid.
-func (c *Config) Validate() error {
+func (c *Config) Validate(opts ValidationOpts) error {
 
 	if c.MaxRetries < 0 {
 		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_RETRY_COUNT", "was %d, must be greater than or equal to 0", c.MaxRetries)
@@ -25,28 +29,30 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// The order of the range validation matters.
-	// The range validation of BUILDKITE_PARALLEL_JOB depends on the result of BUILDKITE_PARALLEL_JOB_COUNT validation at the first step.
-	// We need to validate the range of BUILDKITE_PARALLEL_JOB first before we add the range validation error to BUILDKITE_PARALLEL_JOB_COUNT.
-	if c.errs["BUILDKITE_PARALLEL_JOB"] == nil {
-		if got, min := c.NodeIndex, 0; got < 0 {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
+	if !opts.SkipParallelism {
+		// The order of the range validation matters.
+		// The range validation of BUILDKITE_PARALLEL_JOB depends on the result of BUILDKITE_PARALLEL_JOB_COUNT validation at the first step.
+		// We need to validate the range of BUILDKITE_PARALLEL_JOB first before we add the range validation error to BUILDKITE_PARALLEL_JOB_COUNT.
+		if c.errs["BUILDKITE_PARALLEL_JOB"] == nil {
+			if got, min := c.NodeIndex, 0; got < 0 {
+				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must be greater than or equal to %d", got, min)
+			}
+
+			if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
+				if got, max := c.NodeIndex, c.Parallelism-1; got > max {
+					c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+				}
+			}
 		}
 
 		if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
-			if got, max := c.NodeIndex, c.Parallelism-1; got > max {
-				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB", "was %d, must not be greater than %d", got, max)
+			if got, min := c.Parallelism, 1; got < min {
+				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
 			}
-		}
-	}
 
-	if c.errs["BUILDKITE_PARALLEL_JOB_COUNT"] == nil {
-		if got, min := c.Parallelism, 1; got < min {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must be greater than or equal to %d", got, min)
-		}
-
-		if got, max := c.Parallelism, 1000; got > max {
-			c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
+			if got, max := c.Parallelism, 1000; got > max {
+				c.errs.appendFieldError("BUILDKITE_PARALLEL_JOB_COUNT", "was %d, must not be greater than %d", got, max)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -261,7 +261,7 @@ func main() {
 func run(ctx context.Context, cmd *cli.Command) error {
 	debug.SetDebug(cmd.Bool("debug"))
 
-	err := cfg.Validate()
+	err := cfg.Validate(config.ValidationOpts{})
 	if err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
@@ -273,7 +273,7 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 	debug.SetDebug(cmd.Bool("debug"))
 	debug.SetOutput(os.Stderr)
 
-	err := cfg.Validate()
+	err := cfg.Validate(config.ValidationOpts{SkipParallelism: true})
 	if err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}


### PR DESCRIPTION
`bktec plan` is intended to be run without `parallelism` set on the build step.

The env vars `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` are currently always required when validating the `bktec` config, but these variables are absent on a build step without `parallelism` specified.

- Add a `config.ValidationOpts` struct to control validation options
- Add `config.ValidationOpts.SkipParallism` as an option
- Skip validation of `BUILDKITE_PARALLEL_JOB` and `BUILDKITE_PARALLEL_JOB_COUNT` when `ValidationOpts.SkipParallism` is `true`

Best reviewed with "Hide whitespace" on.