### PR TITLE
Pass config by reference.

### DIFF
--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -11,7 +11,7 @@ import (
 
 type FilterTestsParams struct {
 	Files []plan.TestCase `json:"files"`
-	Env   config.Config   `json:"env"`
+	Env   *config.Config  `json:"env"`
 }
 
 type FilteredTest struct {

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -42,7 +42,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 				Path: "./turtle_spec.rb",
 			},
 		},
-		Env: cfg,
+		Env: &cfg,
 	}
 
 	err = mockProvider.

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -16,7 +16,7 @@ type Timeline struct {
 
 type TestPlanMetadataParams struct {
 	Version    string               `json:"version"`
-	Env        config.Config        `json:"env"`
+	Env        *config.Config       `json:"env"`
 	Timeline   []Timeline           `json:"timeline"`
 	Statistics runner.RunStatistics `json:"statistics"`
 }

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -29,7 +29,7 @@ func TestPostTestPlanMetadata(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		Env:     cfg,
+		Env:     &cfg,
 		Timeline: []Timeline{
 			{
 				Event:     "test_start",
@@ -104,7 +104,7 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		Env:     cfg,
+		Env:     &cfg,
 		Timeline: []Timeline{
 			{
 				Event:     "test_start",

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -28,7 +28,7 @@ type TestPlanSummary struct {
 
 // This command creates a test plan via the API and returns the plan identifier
 // and parallelism of the plan in JSON format to STDOUT.
-func Plan(ctx context.Context, cfg config.Config, testFileList string) error {
+func Plan(ctx context.Context, cfg *config.Config, testFileList string) error {
 	testRunner, err := runner.DetectRunner(cfg)
 	if err != nil {
 		return fmt.Errorf("unsupported value for BUILDKITE_TEST_ENGINE_TEST_RUNNER: %w", err)

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -68,7 +68,7 @@ func TestPlan(t *testing.T) {
 	command.SetPlanWriter(&buf)
 
 	// This is the method under test
-	err := command.Plan(ctx, cfg, "")
+	err := command.Plan(ctx, &cfg, "")
 
 	if err != nil {
 		t.Errorf("command.Plan(...) error = %v", err)

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -13,7 +13,7 @@ import (
 // createRequestParam generates the parameters needed for a test plan request.
 // For runners other than "rspec", it constructs the test plan parameters with all test files.
 // For the "rspec" runner, it filters the test files through the Test Engine API and splits the filtered files into examples.
-func createRequestParam(ctx context.Context, cfg config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
+func createRequestParam(ctx context.Context, cfg *config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
 	testFiles := []plan.TestCase{}
 	for _, file := range files {
 		testFiles = append(testFiles, plan.TestCase{
@@ -76,7 +76,7 @@ func createRequestParam(ctx context.Context, cfg config.Config, files []string, 
 // filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
 // It returns the test plan parameters with the examples from the filtered files and the remaining files.
 // An error is returned if there is a failure in any of the process.
-func filterAndSplitFiles(ctx context.Context, cfg config.Config, client api.Client, files []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
+func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, files []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
 	// Filter files that need to be split.
 	debug.Printf("Filtering %d files", len(files))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -40,7 +40,7 @@ _  /_/ /  ,<  / /_ /  __/ /__
 /_.___//_/|_| \__/ \___/\___/
 `
 
-func Run(ctx context.Context, cfg config.Config, testListFilename string) error {
+func Run(ctx context.Context, cfg *config.Config, testListFilename string) error {
 	printStartUpMessage()
 
 	testRunner, err := runner.DetectRunner(cfg)
@@ -185,7 +185,7 @@ func createTimestamp() string {
 	return time.Now().Format(time.RFC3339Nano)
 }
 
-func sendMetadata(ctx context.Context, apiClient *api.Client, cfg config.Config, timeline []api.Timeline, statistics runner.RunStatistics) {
+func sendMetadata(ctx context.Context, apiClient *api.Client, cfg *config.Config, timeline []api.Timeline, statistics runner.RunStatistics) {
 	err := apiClient.PostTestPlanMetadata(ctx, cfg.SuiteSlug, cfg.Identifier, api.TestPlanMetadataParams{
 		Timeline:   timeline,
 		Env:        cfg,
@@ -284,7 +284,7 @@ func logSignalAndExit(name string, signal syscall.Signal) {
 
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg config.Config, files []string, testRunner TestRunner) (plan.TestPlan, error) {
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, files []string, testRunner TestRunner) (plan.TestPlan, error) {
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -425,7 +425,7 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -498,7 +498,7 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, cfg, tests, testRunner)
+	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, &cfg, tests, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, tests, err)
 	}
@@ -535,7 +535,7 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, TestRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, TestRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -573,7 +573,7 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -608,7 +608,7 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	// we want the function to return an empty test plan and an error
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
 	}
@@ -643,7 +643,7 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -686,7 +686,7 @@ func TestCreateRequestParams(t *testing.T) {
 		"testdata/rspec/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
+	got, err := createRequestParam(context.Background(), &cfg, files, *client, runner.Rspec{
 		RunnerConfig: runner.RunnerConfig{
 			TestCommand: "rspec",
 		},
@@ -775,7 +775,7 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 				"testdata/fruits/cherry.spec.js",
 			}
 
-			got, err := createRequestParam(context.Background(), cfg, files, *client, r)
+			got, err := createRequestParam(context.Background(), &cfg, files, *client, r)
 
 			if err != nil {
 				t.Errorf("createRequestParam() error = %v", err)
@@ -835,7 +835,7 @@ func TestCreateRequestParams_PytestPants(t *testing.T) {
 			"test/cherry_test.py",
 		}
 
-		got, err := createRequestParam(context.Background(), cfg, files, *client, runner)
+		got, err := createRequestParam(context.Background(), &cfg, files, *client, runner)
 
 		if err != nil {
 			t.Errorf("createRequestParam() error = %v", err)
@@ -890,7 +890,7 @@ func TestCreateRequestParams_FilterTestsError(t *testing.T) {
 		"grape_spec.rb",
 	}
 
-	_, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{})
+	_, err := createRequestParam(context.Background(), &cfg, files, *client, runner.Rspec{})
 
 	if err.Error() != "filter tests: forbidden" {
 		t.Errorf("createRequestParam() error = %v, want forbidden error", err)
@@ -928,7 +928,7 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 		"testdata/rspec/spec/fruits/grape_spec.rb",
 	}
 
-	got, err := createRequestParam(context.Background(), cfg, files, *client, runner.Rspec{
+	got, err := createRequestParam(context.Background(), &cfg, files, *client, runner.Rspec{
 		RunnerConfig: runner.RunnerConfig{
 			TestCommand: "rspec",
 		},
@@ -1005,7 +1005,7 @@ func TestSendMetadata(t *testing.T) {
 		want := api.TestPlanMetadataParams{
 			Version:  "0.1.0",
 			Timeline: timeline,
-			Env:      cfg,
+			Env:      &cfg,
 			Statistics: runner.RunStatistics{
 				Total: 3,
 			},
@@ -1029,7 +1029,7 @@ func TestSendMetadata(t *testing.T) {
 		Total: 3,
 	}
 
-	sendMetadata(context.Background(), client, cfg, timeline, statistics)
+	sendMetadata(context.Background(), client, &cfg, timeline, statistics)
 }
 
 func TestSendMetadata_Unauthorized(t *testing.T) {
@@ -1054,5 +1054,5 @@ func TestSendMetadata_Unauthorized(t *testing.T) {
 		Total: 3,
 	}
 
-	sendMetadata(context.Background(), client, cfg, timeline, statistics)
+	sendMetadata(context.Background(), client, &cfg, timeline, statistics)
 }

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -26,7 +26,7 @@ type TestRunner interface {
 	Name() string
 }
 
-func DetectRunner(cfg config.Config) (TestRunner, error) {
+func DetectRunner(cfg *config.Config) (TestRunner, error) {
 	var runnerConfig = RunnerConfig{
 		TestRunner:             cfg.TestRunner,
 		TestCommand:            cfg.TestCommand,

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 
-	return command.Run(ctx, cfg, cmd.String("files"))
+	return command.Run(ctx, &cfg, cmd.String("files"))
 }
 
 func plan(ctx context.Context, cmd *cli.Command) error {
@@ -280,7 +280,7 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 
-	return command.Plan(ctx, cfg, cmd.String("files"))
+	return command.Plan(ctx, &cfg, cmd.String("files"))
 }
 
 func printVersion(ctx context.Context, cmd *cli.Command, versionFlag bool) error {


### PR DESCRIPTION
This change passes the `config.Config` in `main` by reference to all methods, ensuring they are all referencing the same struct.

The config struct is quite large to be passing around by value.
