### PR TITLE
Create separate validation for run and plan

### DIFF
--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -56,7 +56,7 @@ func TestPlan(t *testing.T) {
 	cfg.TestFilePattern = "testdata/rspec/spec/**/*_spec.rb"
 	cfg.ServerBaseUrl = svr.URL
 
-	if err := cfg.Validate(config.ValidationOpts{}); err != nil {
+	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -263,8 +263,7 @@ func main() {
 func run(ctx context.Context, cmd *cli.Command) error {
 	debug.SetDebug(cmd.Bool("debug"))
 
-	err := cfg.Validate(config.ValidationOpts{})
-	if err != nil {
+	if err := cfg.ValidateForRun(); err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 
@@ -275,8 +274,7 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 	debug.SetDebug(cmd.Bool("debug"))
 	debug.SetOutput(os.Stderr)
 
-	err := cfg.Validate(config.ValidationOpts{SkipParallelism: true})
-	if err != nil {
+	if err := cfg.ValidateForPlan(); err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 


### PR DESCRIPTION
Refactor configuration into 3 methods.
- A method for validation common to all commands
- A method for validation specific to `bktec run`
- A method for validation specific to `bktec plan`