### PR TITLE
[TE-4910] Remove automatic parallelism assignment when max_parallelism is set

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -21,10 +21,6 @@ func createRequestParam(ctx context.Context, cfg *config.Config, files []string,
 		})
 	}
 
-	if cfg.MaxParallelism != 0 && cfg.Parallelism == 0 {
-		cfg.Parallelism = 1
-	}
-
 	// Splitting files by example is only supported for rspec runner & cucumber
 	if runner.Name() != "RSpec" && runner.Name() != "Cucumber" {
 		params := api.TestPlanParams{


### PR DESCRIPTION
## Description

Removes the logic that automatically sets `parallelism` to 1 when `max_parallelism` is configured but `parallelism` is 0.    We updated the API to allow parallelism to be absent when creating a plan.

Reference https://github.com/buildkite/test-engine-client/pull/388/files#r2488593466

## Context

Ticket: TE-4910

## Verification

- Confirm that when `max_parallelism` is set and `parallelism` is 0, the value is not modified before being sent to the API
- Verify no regression in test splitting behavior

## Deployment

Low risk

## Rollback

Yes