### PR TITLE
Implement `bktec plan --pipeline-upload`

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -6,29 +6,32 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strconv"
 
 	"github.com/buildkite/test-engine-client/internal/api"
 	"github.com/buildkite/test-engine-client/internal/config"
 	"github.com/buildkite/test-engine-client/internal/runner"
+	"github.com/buildkite/test-engine-client/internal/version"
+)
+
+type PlanOutput int
+
+const (
+	PlanOutputJSON PlanOutput = iota
+	PlanOutputPipelineUpload
 )
 
 var planWriter io.Writer = os.Stdout
 
-// Structure of the JSON that is output when running `bktec plan`.
-type TestPlanSummary struct {
-	Identifier string `json:"BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"`
+var pipelineUploadCommand = "buildkite-agent"
+var pipelineUploadArgs = []string{"pipeline", "upload"}
 
-	// Parallelism is strictly an int not a string. It's represented as a string
-	// here because when this struct is Marshaled to JSON it's intended to be
-	// piped into buildkite-agent env set --input-format=json -, which requires
-	// string keys and string values.
-	Parallelism string `json:"BUILDKITE_TEST_ENGINE_PARALLELISM"`
-}
+// This command creates a test plan via the API
+func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFormat PlanOutput, template string) error {
 
-// This command creates a test plan via the API and returns the plan identifier
-// and parallelism of the plan in JSON format to STDOUT.
-func Plan(ctx context.Context, cfg *config.Config, testFileList string) error {
+	fmt.Fprintln(os.Stderr, "+++ Buildkite Test Engine Client: bktec "+version.Version+"\n")
+
 	testRunner, err := runner.DetectRunner(cfg)
 	if err != nil {
 		return fmt.Errorf("unsupported value for BUILDKITE_TEST_ENGINE_TEST_RUNNER: %w", err)
@@ -55,19 +58,53 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string) error {
 		return fmt.Errorf("create test plan failed: %w", err)
 	}
 
-	enc := json.NewEncoder(planWriter)
-	data := &TestPlanSummary{
-		Identifier:  testPlan.Identifier,
-		Parallelism: strconv.Itoa(testPlan.Parallelism),
-	}
-	if err = enc.Encode(data); err != nil {
-		return err
+	switch outputFormat {
+
+	case PlanOutputJSON:
+		summary := struct {
+			Identifier string `json:"BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"`
+
+			// Parallelism is strictly an int not a string. It's represented as a
+			// string here because this JSON is primarily intended to be piped into
+			// buildkite-agent env set --input-format=json -, which requires string
+			// keys and string values.
+			Parallelism string `json:"BUILDKITE_TEST_ENGINE_PARALLELISM"`
+		}{
+			Identifier:  testPlan.Identifier,
+			Parallelism: strconv.Itoa(testPlan.Parallelism),
+		}
+
+		enc := json.NewEncoder(planWriter)
+		if err = enc.Encode(summary); err != nil {
+			return err
+		}
+
+	case PlanOutputPipelineUpload:
+		cmd := makePipelineUploadCommand(template)
+
+		env := os.Environ()
+		identifierEnv := fmt.Sprintf("BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER=%s", testPlan.Identifier)
+		parallelismEnv := fmt.Sprintf("BUILDKITE_TEST_ENGINE_PARALLELISM=%d", testPlan.Parallelism)
+		env = append(env, identifierEnv, parallelismEnv)
+		cmd.Env = env
+
+		fmt.Println("Executing buildkite-agent pipeline upload with", identifierEnv, parallelismEnv)
+
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unknown plan format %v", outputFormat)
 	}
 
 	return nil
 }
 
-// By default command.Plan writes to os.Stdout but the output can be changed here.
-func SetPlanWriter(writer io.Writer) {
-	planWriter = writer
+func makePipelineUploadCommand(template string) *exec.Cmd {
+	args := append(pipelineUploadArgs, template)
+	cmd := exec.Command(pipelineUploadCommand, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = planWriter
+	return cmd
 }


### PR DESCRIPTION
Adds two new mutually exclusive flags, `--json` and `--pipeline-upload` to `bktec plan`.  One of the 2 flags must be specified when running `bktec plan`

`bktec plan --json` outputs the plan summary on stdout in JSON format. This is the existing behaviour before this change.

`bktec plan --pipeline-upload template.yml` executes `buildkite-agent pipeline upload template.yml`.

The execution env is the same as the one in which `bktec` was invoked, but 2 additional env vars relevant for the dynamic pipeline generation are added - `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER` and `BUILDKITE_TEST_ENGINE_PARALLELISM`.

The template.yml can contain references to
`${BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER}` and
`${BUILDKITE_TEST_ENGINE_PARALLELISM}`, along with any other build env vars.  `buildkite-agent` will substitue these tokens with the relevant variables from the execution env.

## Example pipeline

```yaml
steps:
 - name: ":testengine: bktec plan"
    key: "dynamic-pipeline"
    commands:
      - bktec plan --max-parallelism=10 --files selected-files.txt --pipeline-upload .buildkite/dynamic-template.yml
```

---

```yaml
# .buildkite/dynamic-template.yml
steps:
- command: "bktec run"
  name: ":rspec: bktec run"
  depends_on: "dynamic-pipeline"
  parallelism: ${BUILDKITE_TEST_ENGINE_PARALLELISM}
```

---

<img width="1006" height="720" alt="image" src="https://github.com/user-attachments/assets/68e837fb-df7f-4034-82b9-9a7c57fb8031" />


