### PR TITLE
Change playwright port to 8987

### DIFF
--- a/internal/runner/testdata/playwright/package.json
+++ b/internal/runner/testdata/playwright/package.json
@@ -8,7 +8,7 @@
     "@playwright/test": "^1.48.0"
   },
   "scripts": {
-    "start": "yarn run http-server -p 8080",
+    "start": "yarn run http-server -p 8987",
     "test": "yarn run playwright test"
   }
 }

--- a/internal/runner/testdata/playwright/playwright.config.js
+++ b/internal/runner/testdata/playwright/playwright.config.js
@@ -11,10 +11,10 @@ module.exports = defineConfig({
   ],
   webServer: {
     command: 'yarn start',
-    url: 'http://127.0.0.1:8080',
+    url: 'http://127.0.0.1:8987',
   },
   use: {
-    baseURL: 'http://localhost:8080/',
+    baseURL: 'http://localhost:8987/',
   },
   projects: [
     {


### PR DESCRIPTION
Port 8080 is often in use by other processes. Use a (hopefully) less well known port instead.