### PR TITLE
[TE-4801] Add fail-on-no-tests configuration option for over-provisioned parallelism

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	JobRetryCount int `json:"BUILDKITE_RETRY_COUNT"`
 	// Enable debug output
 	DebugEnabled bool `json:"BUILDKITE_TEST_ENGINE_DEBUG_ENABLED"`
+	// FailOnNoTests causes the client to exit with an error if no tests are assigned to the node
+	FailOnNoTests bool `json:"BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS"`
 	// errs is a map of environment variables name and the validation errors associated with them.
 	errs InvalidConfigError
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ var cliCommand = &cli.Command{
 			Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_DEBUG_ENABLED"),
 			Destination: &cfg.DebugEnabled,
 		},
+		&cli.BoolFlag{
+			Name:        "fail-on-no-tests",
+			Usage:       "Exit with an error if no tests are assigned to this node",
+			Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS"),
+			Destination: &cfg.FailOnNoTests,
+		},
 
 		// Values from the Buildkite build env
 		&cli.StringFlag{


### PR DESCRIPTION
### Description

When parallelism is over-provisioned (more nodes than tests), some nodes may receive no tests to run. Previously, the test runner would be invoked with an empty test list, which could cause issues depending on the test framework. This PR adds graceful handling for this scenario.

This change introduces a new configuration option `BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS` that controls the behavior when no tests are assigned to a node:
- When `false` (default): The client skips test execution and exits successfully with a log message
- When `true`: The client exits with an error to make the over-provisioning explicit

The check is performed before invoking the test runner, preventing potential framework-specific errors when executing with an empty test list.

This change was heavily assisted by AI/LLM

### Context

https://linear.app/buildkite/issue/TE-4801

### Changes

- Add `FailOnNoTests` config field and `--fail-on-no-tests` CLI flag
- Add early return in `runTestsWithRetry` when test cases list is empty
- Add tests for both success and error scenarios with no test cases
- Update all existing test calls to `runTestsWithRetry` with new parameter

### Testing

Backed by specs covering both the default behavior (success) and error mode.

Manual testing can be done by over-provisioning parallelism and observing the node behavior with and without the flag.