### PR TITLE
Allow release pipeline to create major release

### DIFF
--- a/.buildkite/steps/prepare-release.sh
+++ b/.buildkite/steps/prepare-release.sh
@@ -22,6 +22,8 @@ YAML
     # - 0.7.6-rc.1
     # - 0.8.0
     # - 0.8.0-rc.1
+    # - 1.0.0
+    # - 1.0.0-rc.1
     cat <<YAML
         - label: $(svu patch)
           value: $(svu patch)
@@ -31,6 +33,10 @@ YAML
           value: $(svu minor)
         - label: $(svu minor --pre-release rc).1
           value: $(svu minor --pre-release rc).1
+        - label: $(svu major)
+          value: $(svu major)
+        - label: $(svu major --pre-release rc).1
+          value: $(svu major --pre-release rc).1
 YAML
   fi
 }


### PR DESCRIPTION
Currently the release pipeline can only create patch or minor releases.  E.g. if the current release is `1.2.3` the pipeline can generate `1.2.4` or `1.3.0`.

This change allows the pipeline to generate a new major release, e.g. `2.0.0` in the example above.