### PR TITLE
There is no longer a default sub-command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -261,7 +261,7 @@ var cliCommand = &cli.Command{
 	Commands: []*cli.Command{
 		{
 			Name:   "run",
-			Usage:  "Run tests (default)",
+			Usage:  "Run tests",
 			Action: run,
 			Flags: []cli.Flag{
 				filesFlag,


### PR DESCRIPTION
Running the `run` sub-command by default was removed in #401 but we forgot to remove it from the CLI help text.