### PR TITLE
Add configuration env var for `--files` flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -111,6 +111,7 @@ var filesFlag = &cli.StringFlag{
 	Category: "TEST RUNNER",
 	Value:    "",
 	Usage:    "Override the default test file discovery by providing a path to a file containing a list of test files (one per line)",
+	Sources:  cli.EnvVars("BUILDKITE_TEST_ENGINE_FILES"),
 }
 
 var testCommandFlag = &cli.StringFlag{


### PR DESCRIPTION
Adds support for specifying `--files` as `BUILDKITE_TEST_ENGINE_FILES`:

```
$ bktec run --help
--8<--
  --files string                      Override the default test file discovery by providing a path to a file containing a list of test files (one per line) [$BUILDKITE_TEST_ENGINE_FILES]
--8<--
```