### PR TITLE
Update internal docs to use `bktec run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To parallelize your tests in your Buildkite build, you can amend your pipeline s
 ```
 steps:
   - name: "Rspec"
-    command: ./bktec
+    command: ./bktec run
     parallelism: 10
     env:
       BUILDKITE_TEST_ENGINE_SUITE_SLUG: my-suite

--- a/docs/gotest.md
+++ b/docs/gotest.md
@@ -15,7 +15,7 @@ export BUILDKITE_TEST_ENGINE_SUITE_SLUG=your-suite-slug
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=your-token
 
 # Run the test engine client
-bktec
+bktec run
 ```
 
 > [!IMPORTANT]
@@ -51,7 +51,7 @@ Using `bktec` allows you to manage test states, such as muting flaky tests, dire
 ```yaml
   - name: "Go test :golang:"
     commands:
-      - bktec
+      - bktec run
     env:
       ...
     parallelism: 2 # This activate test splitting!
@@ -75,7 +75,7 @@ export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 ```yaml
 - name: "Go test :golang:"
   commands:
-    - bktec
+    - bktec run
   env:
     BUILDKITE_ANALYTICS_TOKEN: your-suite-token # For test collector
     BUILDKITE_TEST_ENGINE_SUITE_SLUG: your-suite-slug

--- a/docs/pytest-pants.md
+++ b/docs/pytest-pants.md
@@ -31,7 +31,7 @@ Only running `pants test` with `python_test` targets is supported at this time.
 ```sh
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=pytest-pants
 export BUILDKITE_TEST_ENGINE_TEST_CMD="pants --filter-target-type=python_test --changed-since=HEAD~1 test -- --json={{resultPath}} --merge-json"
-bktec
+bktec run
 ```
 
 ## Configure test command


### PR DESCRIPTION
Running `bktec` is no longer supported in 2.x.x and is replaced by `bktec run`.