### PR TITLE
Return error when no command is passed

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -344,7 +344,12 @@ var cliCommand = &cli.Command{
 		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		cli.ShowRootCommandHelp(cmd)
+		err := cli.ShowRootCommandHelp(cmd)
+		// This is unlikely to ever error, but if it does, we want to know.
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("failed to show help: %v", err), 16)
+		}
+
 		fmt.Println("")
 
 		if cmd.NArg() > 0 {


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
`bktec` requires a command (`run` or `plan`) from version `2.0.0`.  Currently, running `bktec` without a command prints help text and exits with `0`.  

```
$ bktec
NAME:
   bktec - Buildkite Test Engine Client

USAGE:
   bktec [global options] [command [command options]]

COMMANDS:
   run      Run tests
   plan     Generate test plan without running tests
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --version   print version information and exit
   --debug     Enable debug output [$BUILDKITE_TEST_ENGINE_DEBUG_ENABLED]
   --help, -h  show help
$ echo $?
0
```

Users upgrading from `1.x.x` to `2.x.x` without specifying the command will see their build pass even though no tests are being run.  Therefore, we should return a non-zero exit code when no command is provided to let users know they need to set the command.

### Testing

<!--
Call out any additional testing (beyond the automated tests) you felt was necessary and the results, e.g. running it manually, or running as part of another pipeline.
-->
I've tested locally without subcommand and an invalid command.
```
$ bktec
NAME:
   bktec - Buildkite Test Engine Client

USAGE:
   bktec [global options] [command [command options]]

COMMANDS:
   run      Run tests
   plan     Generate test plan without running tests
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --version   print version information and exit
   --debug     Enable debug output [$BUILDKITE_TEST_ENGINE_DEBUG_ENABLED]
   --help, -h  show help

command is required
$ echo $?
16
```

```
$ bktec foo
NAME:
   bktec - Buildkite Test Engine Client

USAGE:
   bktec [global options] [command [command options]]

COMMANDS:
   run      Run tests
   plan     Generate test plan without running tests
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --version   print version information and exit
   --debug     Enable debug output [$BUILDKITE_TEST_ENGINE_DEBUG_ENABLED]
   --help, -h  show help

invalid command: "foo"
$ echo $?
16
```
