### PR TITLE
merge v2.0.x back to main

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/urfave/cli/v3"
 )
@@ -341,5 +342,20 @@ var cliCommand = &cli.Command{
 				},
 			},
 		},
+	},
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		err := cli.ShowRootCommandHelp(cmd)
+		// This is unlikely to ever error, but if it does, we want to know.
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("failed to show help: %v", err), 16)
+		}
+
+		fmt.Println("")
+
+		if cmd.NArg() > 0 {
+			return cli.Exit(fmt.Sprintf("invalid command: %q", cmd.Args().Get(0)), 16)
+		}
+
+		return cli.Exit("command is required", 16)
 	},
 }


### PR DESCRIPTION
### Description

<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->
We've made a hotfix release [v2.0.1](https://github.com/buildkite/test-engine-client/releases/tag/v2.0.1) on top of `v2.0.0` tag. This PR merge the fix back t o`main` so it will be included in the next minor release `v2.1.0`
