### PR TITLE
fix(jest): use --runTestsByPath for literal file path matching

### DIFF
--- a/docs/jest.md
+++ b/docs/jest.md
@@ -10,7 +10,7 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH=tmp/jest-result.json
 By default, bktec runs Jest with the following command:
 
 ```sh
-npx jest {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}
+npx jest --runTestsByPath {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}
 ```
 
 In this command, `{{testExamples}}` is replaced by bktec with the list of test files or tests to run, and `{{resultPath}}` is replaced with the value set in `BUILDKITE_TEST_ENGINE_RESULT_PATH`. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.


### PR DESCRIPTION
## Summary

Add `--runTestsByPath` to the default Jest `TestCommand` so that file path arguments are treated as literal paths instead of regex patterns.

Fixes #416

## Problem

Jest interprets positional CLI arguments as regex patterns by default. When test file paths contain characters like `(main)` or `[catalogId]`, Jest treats them as regex metacharacters and fails to match any files.

This commonly affects Next.js App Router projects which use:
- `(folderName)` for route groups
- `[param]` for dynamic route segments

## Solution

The default `TestCommand` now includes `--runTestsByPath`:

```
npx jest --runTestsByPath {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}
```

This tells Jest to treat positional arguments as literal file paths rather than regex patterns. Per [Jest docs](https://jestjs.io/docs/cli#--runtestsbypath), this is the recommended approach for CI pipelines and is more performant when provided with multiple patterns.

The `RetryTestCommand` is unchanged because:
- Its default does not pass file paths as positional arguments
- Test names use `--testNamePattern` which intentionally accepts regex (already properly escaped with `regexp.QuoteMeta`)

## Changes

- Updated default `TestCommand` in `jest.go` to include `--runTestsByPath`
- Updated default command in `docs/jest.md`
- Added test case `TestJestCommandNameAndArgs_WithSpecialCharactersInPath` verifying Next.js style paths are passed through as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)