### PR TITLE
Fix TestCommand cli flag binding

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -124,10 +124,11 @@ var tagFiltersFlag = &cli.StringFlag{
 }
 
 var testCommandFlag = &cli.StringFlag{
-	Name:     "test-command",
-	Category: "TEST RUNNER",
-	Usage:    "Test command",
-	Sources:  cli.EnvVars("BUILDKITE_TEST_ENGINE_TEST_CMD"),
+	Name:        "test-command",
+	Category:    "TEST RUNNER",
+	Usage:       "Test command",
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_TEST_CMD"),
+	Destination: &cfg.TestCommand,
 }
 
 var testFilePatternFlag = &cli.StringFlag{


### PR DESCRIPTION
### Description

Saw that in https://github.com/buildkite/test-engine-client/blob/ed434c07128a384f7954425fce01159bcb4ee1eb/cli.go#L122

we were binding the env `BUILDKITE_TEST_ENGINE_TEST_CMD` to the TestCommand config value for custom test runners, but this was removed in #431. Attempting to run `bktec` with the `custom` test runner will result in an error despite setting that value.

### Context
https://github.com/buildkite/test-engine-client/blob/ed434c07128a384f7954425fce01159bcb4ee1eb/cli.go#L122
### Changes

Re-adds the binding

### Testing
Manually tested running a custom test runner with the binary from [v2.1.0-rc2](https://github.com/buildkite/test-engine-client/releases/tag/v2.1.0-rc.2) to verify, as well as with #431 to validate the config change.
