### PR TITLE
feat: support comma-separated patterns in --test-file-pattern

### DIFF
--- a/internal/runner/discover_test.go
+++ b/internal/runner/discover_test.go
@@ -159,3 +159,26 @@ func TestDiscoverTestFiles_CommaSeparatedWithExclude(t *testing.T) {
 		t.Errorf("discoverTestFiles(%q, %q) diff (-got +want):\n%s", pattern, excludePattern, diff)
 	}
 }
+
+func TestSplitPatterns(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"**/*.js", []string{"**/*.js"}},
+		{"**/*.{js,ts}", []string{"**/*.{js,ts}"}},
+		{"**/*.cy.{js,jsx,ts,tsx}", []string{"**/*.cy.{js,jsx,ts,tsx}"}},
+		{"spec/**,test/**", []string{"spec/**", "test/**"}},
+		{"**/*.{js,ts},spec/**/*.rb", []string{"**/*.{js,ts}", "spec/**/*.rb"}},
+		{"a/{b,c},d/{e,f}", []string{"a/{b,c}", "d/{e,f}"}},
+		{"", nil},
+		{" a , b ", []string{" a ", " b "}},
+	}
+
+	for _, tt := range tests {
+		got := splitPatterns(tt.input)
+		if diff := cmp.Diff(got, tt.want); diff != "" {
+			t.Errorf("splitPatterns(%q) diff (-got +want):\n%s", tt.input, diff)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Quite often I want to be able to test multiple spec directories at once, e.g. 

```bash
bundle exec rspec --pattern 'spec/io/**,spec/inegrations/**,spec/orchetrators/**'
```

At the moment (as far as I can tell), `bktec` doesn't support comma separated patterns using the `--test-file-pattern` flag - if you want to pick up on a selection of folders, you would need to expand all glob file paths into a file and use the `--file` flag.

This PR teaches `--test-file-pattern` to work very similarly to RSpec's `--pattern`; the pattern string is split on commas, each pattern is processed independently, and results are deduplicated to handle overlapping patterns.

### Changes

- Modified `internal/runner/discover.go` to split pattern on commas
- Added deduplication map to prevent duplicate files when patterns overlap
- Added 3 new test cases for comma-separated patterns

### Testing

All existing tests pass (I've run `go test ./...`). Added tests for:
- Basic comma-separated patterns
- Overlapping patterns (deduplication)
- Comma-separated patterns with exclude pattern