### PR TITLE
Codify runner feature support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Buildkite Test Engine Client (bktec) is an open source tool to orchestrate your 
 
 bktec supports multiple test runners and offers various features to enhance your testing workflow. Below is a comparison of the features supported by each test runner:
 
-| Feature                                            | RSpec | Jest | Playwright | Cypress | pytest | pants (pytest) | Go test | Cucumber | NUnit | Custom |
-| -------------------------------------------------- | :---: | :--: | :--------: | :-----: | :----: | :------------: | :-----: | :------: | :---: | :-----: |
-| Split tests by file[^1]                                |   ✅  |   ✅  |    ✅      |    ✅   |   ✅   |       ❌       |   ❌    |    ✅    |  ✅   | ✅      |
-| [Split slow files by individual test example](https://github.com/buildkite/test-engine-client/blob/main/docs/rspec.md#split-slow-files-by-individual-test-example)        |   ✅  |   ❌  |    ❌      |    ❌   |   ✅   |       ❌       |   ❌    |    ✅    |  ❌   |    ❌   |
-| Filter test files                                  |   ✅  |   ✅  |    ✅      |    ✅   |   ✅   |       ❌       |   ❌    |    ✅    |  ✅   |    ✅   |
-| Filter test by tags                               |   ❌  |   ❌  |    ❌      |    ❌   |   ✅   |       ❌       |   ❌    |    ❌    |  ❌   |    ❌  |
-| Automatically retry failed test                    |   ✅  |   ✅  |    ✅      |    ❌   |   ✅   |       ✅       |   ✅    |    ✅    |  ✅   |    ❌   |
-| Mute tests (ignore test failures)                  |   ✅  |   ✅  |    ✅      |    ❌   |   ✅   |       ✅       |   ✅    |    ✅    |  ✅   |    ✅   |
-| Skip tests                                         |   ✅  |   ❌  |    ❌      |    ❌   |   ❌   |       ❌       |   ❌    |    ✅    |  ❌   |    ❌   |
+<!-- DO NOT MANUALLY EDIT THE TABLE BELOW. The contents can be generate with `go run util/supported_features/main.go` -->
+
+| Feature | RSpec | Jest | Playwright | Cypress | pytest | pytest-pants | gotest | Cucumber | NUnit | Custom test runner |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Split tests by file[^1] | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [Split slow files by individual test example](https://github.com/buildkite/test-engine-client/blob/main/docs/rspec.md#split-slow-files-by-individual-test-example) | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Filter test files | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Filter tests by tag | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Automatically retry failed test | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Mute tests (ignore test failures) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Skip tests | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 ## Installation
 The latest version of bktec can be downloaded from https://github.com/buildkite/test-engine-client/releases

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -32,8 +32,8 @@ func createRequestParam(ctx context.Context, cfg *config.Config, files []string,
 		})
 	}
 
-	// Splitting files by example is only supported for rspec, cucumber, pytest, and playwright runners
-	if runner.Name() != "RSpec" && runner.Name() != "Cucumber" && runner.Name() != "pytest" && runner.Name() != "Playwright" {
+	// Short circuit here if the runner doesn't support split by example
+	if !runner.SupportedFeatures().SplitByExample {
 		params := api.TestPlanParams{
 			Identifier:     cfg.Identifier,
 			Parallelism:    cfg.Parallelism,

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -357,6 +357,12 @@ type metadataTestRunner struct {
 	examples []plan.TestCase
 }
 
+func (r metadataTestRunner) SupportedFeatures() runner.SupportedFeatures {
+	return runner.SupportedFeatures{
+		SplitByExample: true,
+	}
+}
+
 func (r metadataTestRunner) Name() string {
 	return r.name
 }

--- a/internal/runner/cucumber.go
+++ b/internal/runner/cucumber.go
@@ -44,6 +44,18 @@ func NewCucumber(c RunnerConfig) Cucumber {
 	}
 }
 
+func (c Cucumber) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  true,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            true,
+	}
+}
+
 func (c Cucumber) Name() string {
 	return "Cucumber"
 }

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -32,6 +32,18 @@ func NewCustom(r RunnerConfig) (Custom, error) {
 	}, nil
 }
 
+func (c Custom) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  false,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       false,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (r Custom) Name() string {
 	return "Custom test runner"
 }

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -36,6 +36,18 @@ func NewCypress(c RunnerConfig) Cypress {
 	}
 }
 
+func (c Cypress) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  false,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       false,
+		Mute:            false,
+		Skip:            false,
+	}
+}
+
 func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	cmd, err := buildCommand(c, testCases, retry)
 	if err != nil {

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -32,6 +32,18 @@ func NewGoTest(c RunnerConfig) GoTest {
 	}
 }
 
+func (g GoTest) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     false,
+		SplitByExample:  false,
+		FilterTestFiles: false,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (g GoTest) Name() string {
 	return "gotest"
 }

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -36,6 +36,18 @@ func NewJest(j RunnerConfig) Jest {
 	}
 }
 
+func (j Jest) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  false,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (j Jest) Name() string {
 	return "Jest"
 }

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -17,6 +17,18 @@ type NUnit struct {
 // Compile-time check that NUnit implements TestRunner
 var _ TestRunner = (*NUnit)(nil)
 
+func (n NUnit) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  false,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func NewNUnit(c RunnerConfig) NUnit {
 	if c.TestCommand == "" {
 		c.TestCommand = "dotnet test --no-build --filter {{testFilter}} --logger junit;LogFilePath={{resultPath}}"

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -40,6 +40,18 @@ func NewPlaywright(p RunnerConfig) Playwright {
 	}
 }
 
+func (p Playwright) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  true,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -59,6 +59,18 @@ func NewPytest(c RunnerConfig) Pytest {
 	}
 }
 
+func (p Pytest) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  true,
+		FilterTestFiles: true,
+		FilterTestByTag: true,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -50,6 +50,18 @@ func NewPytestPants(c RunnerConfig) PytestPants {
 	}
 }
 
+func (p PytestPants) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     false,
+		SplitByExample:  false,
+		FilterTestFiles: false,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            false,
+	}
+}
+
 func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -42,6 +42,18 @@ func NewRspec(r RunnerConfig) Rspec {
 	}
 }
 
+func (r Rspec) SupportedFeatures() SupportedFeatures {
+	return SupportedFeatures{
+		SplitByFile:     true,
+		SplitByExample:  true,
+		FilterTestFiles: true,
+		FilterTestByTag: false,
+		AutoRetry:       true,
+		Mute:            true,
+		Skip:            true,
+	}
+}
+
 func (r Rspec) Name() string {
 	return "RSpec"
 }

--- a/internal/runner/supported_features.go
+++ b/internal/runner/supported_features.go
@@ -1,0 +1,11 @@
+package runner
+
+type SupportedFeatures struct {
+	SplitByFile     bool
+	SplitByExample  bool
+	FilterTestFiles bool
+	FilterTestByTag bool
+	AutoRetry       bool
+	Mute            bool
+	Skip            bool
+}

--- a/internal/runner/test_runner.go
+++ b/internal/runner/test_runner.go
@@ -9,5 +9,6 @@ type TestRunner interface {
 	Name() string
 	CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error)
 	LocationPrefix() string
+	SupportedFeatures() SupportedFeatures
 	UploadToken() string
 }

--- a/util/supported_features/main.go
+++ b/util/supported_features/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/buildkite/test-engine-client/v2/internal/runner"
+)
+
+func printTableRow(cols ...string) {
+	for _, col := range cols {
+		fmt.Printf("| %s ", col)
+	}
+	fmt.Printf("|\n")
+}
+
+func boolToEmoji(b bool) string {
+	if b {
+		return "✅"
+	} else {
+		return "❌"
+	}
+}
+
+func printRow(runners []runner.TestRunner, featureName string, featureValueFunc func(runner.TestRunner) bool) {
+	var values []string
+	values = append(values, featureName)
+	for _, runner := range runners {
+		values = append(values, boolToEmoji(featureValueFunc(runner)))
+	}
+	printTableRow(values...)
+}
+
+func main() {
+	runnerConfig := runner.RunnerConfig{
+		TestCommand: "foo",
+	}
+
+	// NewCustom() method signature is incompatible with the other runners,
+	// drop the second return value
+	custom, _ := runner.NewCustom(runnerConfig)
+
+	runners := []runner.TestRunner{
+		runner.NewRspec(runnerConfig),
+		runner.NewJest(runnerConfig),
+		runner.NewPlaywright(runnerConfig),
+		runner.NewCypress(runnerConfig),
+		runner.NewPytest(runnerConfig),
+		runner.NewPytestPants(runnerConfig),
+		runner.NewGoTest(runnerConfig),
+		runner.NewCucumber(runnerConfig),
+		runner.NewNUnit(runnerConfig),
+		custom,
+	}
+
+	headings := []string{"Feature"}
+	for _, runner := range runners {
+		headings = append(headings, runner.Name())
+	}
+	printTableRow(headings...)
+
+	separators := []string{"---"}
+	for range runners {
+		separators = append(separators, ":---:")
+	}
+	printTableRow(separators...)
+
+	printRow(
+		runners,
+		"Split tests by file[^1]",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().SplitByFile },
+	)
+
+	printRow(
+		runners,
+		"[Split slow files by individual test example](https://github.com/buildkite/test-engine-client/blob/main/docs/rspec.md#split-slow-files-by-individual-test-example)",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().SplitByExample },
+	)
+
+	printRow(
+		runners,
+		"Filter test files",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().FilterTestFiles },
+	)
+
+	printRow(
+		runners,
+		"Filter tests by tag",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().FilterTestByTag },
+	)
+
+	printRow(
+		runners,
+		"Automatically retry failed test",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().AutoRetry },
+	)
+
+	printRow(
+		runners,
+		"Mute tests (ignore test failures)",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().Mute },
+	)
+
+	printRow(
+		runners,
+		"Skip tests",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().Skip },
+	)
+}


### PR DESCRIPTION
This is a proof of concept of embedding the features supported by each runner in the runner implementation.

Aim here is to solve a few problems:

- Avoid "type switch" code. One example is fixed in this WIP, switching on split by example support base on runner name in `request_param.go`. There are others but I haven't implemented all of them in this WIP.
- Generate to feature support matrix in `README.md` from code. This has accumulated some drift over time in the past and required manual fixups. To prove the point there is fix for drift included in this PR :)
- This would give us a way to error when customers try to use a feature that is not supported in the runner, for example setting env vars or cli flags that are not supported by the runner. We've had confusion about this from users in the past.

Fixes TE-5965