### PR TITLE
Add Windows CI test support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 env:
   AWS_DEFAULT_REGION: us-east-1
+  BKTEC_RUNNERS_WINDOWS_QUEUE: "${BKTEC_RUNNERS_WINDOWS_QUEUE:-agent-runners-windows-amd64}"
 
 steps:
   - name: ":golangci-lint: Lint"
@@ -41,6 +42,19 @@ steps:
           format: "junit"
           # This is to prevent the test runner as part of our test fixture trigger test collection
           # such as pytest + python test collector
+          api-token-env-name: "BUILDKITE_TEST_ENGINE_SUITE_TOKEN"
+
+  - name: ":windows: Windows AMD64 Tests"
+    command: "bash .buildkite\\steps\\tests.sh"
+    parallelism: 2
+    artifact_paths:
+      - junit-*.xml
+    agents:
+      queue: $BKTEC_RUNNERS_WINDOWS_QUEUE
+    plugins:
+      - test-collector#v1.11.0:
+          files: "junit-*.xml"
+          format: "junit"
           api-token-env-name: "BUILDKITE_TEST_ENGINE_SUITE_TOKEN"
 
   - wait

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -6,16 +6,18 @@ echo arch is "$(uname -m)"
 
 go install gotest.tools/gotestsum@v1.8.0
 
-# Install pact-go
-go install github.com/pact-foundation/pact-go/v2@latest
-pact-go -l DEBUG install
+if [[ "$(go env GOOS)" != "windows" ]]; then
+  # Install pact-go (not supported on Windows)
+  go install github.com/pact-foundation/pact-go/v2@latest
+  pact-go -l DEBUG install
 
-# Install dependencies for js runner tests
-cd internal/runner/testdata
-yarn install
-cd playwright
-yarn playwright install
-cd ../../../..
+  # Install dependencies for js runner tests
+  cd internal/runner/testdata
+  yarn install
+  cd playwright
+  yarn playwright install
+  cd ../../../..
+fi
 
 echo '+++ Running tests'
 
@@ -23,9 +25,16 @@ export BUILDKITE_TEST_ENGINE_SUITE_SLUG=bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
 export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
-export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
+
+if [[ "$(go env GOOS)" == "windows" ]]; then
+  export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 {{packages}}'
+else
+  export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
+fi
 
 bktec
 
-echo 'Producing coverage report'
-go tool cover -html cover.out -o cover.html
+if [[ "$(go env GOOS)" != "windows" ]]; then
+  echo 'Producing coverage report'
+  go tool cover -html cover.out -o cover.html
+fi

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package api
 
 import (

--- a/internal/api/fetch_files_timing_test.go
+++ b/internal/api/fetch_files_timing_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package api
 
 import (

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package api
 
 import (

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package api
 
 import (

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package api
 
 import (

--- a/internal/runner/command_test.go
+++ b/internal/runner/command_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -19,6 +20,9 @@ func TestRunAndForwardSignal(t *testing.T) {
 }
 
 func TestRunAndForwardSignal_CommandExitsWithNonZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: requires Unix 'false' command")
+	}
 	cmd := exec.Command("false")
 
 	err := runAndForwardSignal(cmd)
@@ -32,6 +36,9 @@ func TestRunAndForwardSignal_CommandExitsWithNonZero(t *testing.T) {
 }
 
 func TestRunAndForwardSignal_SignalReceivedInMainProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: requires Unix signals")
+	}
 	cmd := exec.Command("sleep", "10")
 
 	// Send a SIGTERM signal to the main process.
@@ -57,6 +64,9 @@ func TestRunAndForwardSignal_SignalReceivedInMainProcess(t *testing.T) {
 }
 
 func TestRunAndForwardSignal_SignalReceivedInSubProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: requires Unix signals")
+	}
 	cmd := exec.Command("./testdata/segv.sh")
 
 	err := runAndForwardSignal(cmd)

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/internal/plan"
@@ -54,6 +55,9 @@ func TestCustom_GetExamples(t *testing.T) {
 }
 
 func TestCustom_GetFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: test fixture requires bash")
+	}
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "./test {{testExamples}}",
@@ -126,6 +130,9 @@ func TestCustom_CommandNameAndArgs(t *testing.T) {
 }
 
 func TestCustom_Run(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: test fixture requires bash")
+	}
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "./test {{testExamples}}",
@@ -153,6 +160,9 @@ func TestCustom_Run(t *testing.T) {
 }
 
 func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: test fixture requires bash")
+	}
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "./test {{testExamples}}",
@@ -178,6 +188,9 @@ func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
 }
 
 func TestCustom_Run_TestFailedWithResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: test fixture requires bash")
+	}
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "./test {{testExamples}}",


### PR DESCRIPTION
### Description

Add a native Windows AMD64 test step to the Buildkite pipeline so the Go test suite runs on Windows in CI. This follows the same pattern as the agent repo: run on a Windows queue without Docker, invoke `bash .buildkite\steps\tests.sh` directly on the native agent.

Pact-based tests are excluded on Windows (pact-go native code does not compile there), and Unix-only runner tests are skipped at runtime. The Windows test command omits coverage/race flags to start with a minimal passing baseline.

### Context

- [TE-5508](https://linear.app/buildkite/issue/TE-5508/bktec-windows-testing-in-ci)
- Modeled after `buildkite/agent` Windows CI pattern

### Changes

- **Pipeline**: New `:windows: Windows AMD64 Tests` step on `$BKTEC_RUNNERS_WINDOWS_QUEUE` (defaults to `agent-runners-windows-amd64`), parallelism 2, no Docker, no AWS role/SSM plugins
- **Test script**: `tests.sh` conditionally skips pact-go install, yarn/Playwright setup, coverage/race flags, and coverage report on Windows (`go env GOOS` check)
- **Pact test files**: Added `//go:build !windows` build tag to all 5 pact-based test files in `internal/api/` — these do not compile on Windows
- **Runner tests**: Added `runtime.GOOS == "windows"` skip guards to 3 signal/Unix tests in `command_test.go` and 4 bash-fixture tests in `custom_test.go`

### Testing

- Verified `GOOS=windows GOARCH=amd64 go test -exec=true ./...` passes (all packages compile)
- Verified `go vet ./...` passes
- Existing Linux tests unaffected (build tags and skips are Windows-only)

### Related

- Resolves TE-5508