### PR TITLE
Add `/bktec` (binary) to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ internal/runner/testdata/cucumber/cucumber.json
 
 # Output binary with `go build`
 test-engine-client
+
+# Output binary with `go build -o bktec`
+/bktec


### PR DESCRIPTION
We were already ignoring `test-engine-client` but this command wants to be called `bktec` via `go build -o bktec`, so ignore that too.