### PR TITLE
[TE-5578] Auto-collect git metadata for plan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,45 @@ export BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY=percent
 Command-line flags:
 ```sh
 BKTEC_PREVIEW_SELECTION=true ./bktec plan --json --selection-strategy percent \
-  --selection-param percent=40 \
-  --metadata commit_message="fix flaky tests" \
-  --metadata git_diff="$(git diff --no-color)"
+  --selection-param percent=40
 ```
 
-Use repeated `--selection-param key=value` and `--metadata key=value` to pass multiple entries. Values can be large and multiline.  
+#### Automatic git metadata collection
+
+When `--selection-strategy` is set, the `plan` command automatically collects
+git metadata from the current repository and sends it with the API request.
+This includes commit information (SHA, author, committer, message), diff data
+(files changed, numstat, full diff), and context fields (branch name, base
+branch, pipeline slug, build UUID).
+
+The base branch for diff computation is resolved using a fallback chain:
+
+1. Explicit override via `--metadata base_branch=<branch>`
+2. `BUILDKITE_PULL_REQUEST_BASE_BRANCH` (auto-set by Buildkite on PR builds)
+3. Auto-detection via `<remote>/HEAD`, then `<remote>/main`, then `<remote>/master`
+
+Most users don't need to configure anything. Override `base_branch` only if
+your repository uses a non-standard default branch (for example, `develop` or `trunk`)
+and `<remote>/HEAD` isn't configured.
+
+The `--remote` flag (default `origin`) controls which git remote is used for
+base branch detection. You can also set `BUILDKITE_TEST_ENGINE_REMOTE`.
+
+Auto-collected values are merged with any explicit `--metadata` flags you
+provide. Your explicit values always take precedence.
+
+#### Manual metadata overrides
+
+Use `--metadata key=value` to pass additional metadata or override
+auto-collected values. Use `--selection-param key=value` to pass strategy
+parameters. Both flags are repeatable. Values can be large and multiline.
+
+```sh
+BKTEC_PREVIEW_SELECTION=true ./bktec plan --json --selection-strategy percent \
+  --selection-param percent=40 \
+  --metadata base_branch=develop
+```
+
 `--selection-param` and `--metadata` are only supported as repeatable CLI flags.
 
 ### Preview: Commit Metadata Backfill

--- a/cli.go
+++ b/cli.go
@@ -390,7 +390,20 @@ var remoteFlag = &cli.StringFlag{
 	Category:    "BACKFILL",
 	Usage:       "Git remote name for fetching missing commits and detecting default branch",
 	Value:       "origin",
-	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_BACKFILL_REMOTE"),
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_REMOTE", "BUILDKITE_TEST_ENGINE_BACKFILL_REMOTE"),
+	Destination: &cfg.Remote,
+}
+
+// planRemoteFlag is a selection-scoped variant of remoteFlag for the plan
+// command. It only reads BUILDKITE_TEST_ENGINE_REMOTE (not the backfill-
+// specific BUILDKITE_TEST_ENGINE_BACKFILL_REMOTE) to avoid the backfill
+// env var unexpectedly affecting plan behaviour.
+var planRemoteFlag = &cli.StringFlag{
+	Name:        "remote",
+	Category:    "PREVIEW: TEST SELECTION",
+	Usage:       "Git remote name for metadata auto-collection",
+	Value:       "origin",
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_REMOTE"),
 	Destination: &cfg.Remote,
 }
 
@@ -433,6 +446,7 @@ func previewSelectionFlags() []cli.Flag {
 		selectionStrategyFlag,
 		selectionParamFlag,
 		metadataFlag,
+		planRemoteFlag,
 	}
 }
 

--- a/docs/commit-metadata-backfill.md
+++ b/docs/commit-metadata-backfill.md
@@ -86,7 +86,7 @@ This is useful when you want to generate and upload in separate steps or when re
 | `BUILDKITE_TEST_ENGINE_BASE_URL` | `--base-url` | `https://api.buildkite.com` | Buildkite API base URL |
 | `BUILDKITE_TEST_ENGINE_SKIP_DIFFS` | `--skip-diffs` | `false` | Omit full git diffs from the export |
 | `BUILDKITE_TEST_ENGINE_BACKFILL_DAYS` | `--days` | `90` | Number of days of commit history to export (1-90) |
-| `BUILDKITE_TEST_ENGINE_BACKFILL_REMOTE` | `--remote` | `origin` | Git remote name for fetching and branch detection |
+| `BUILDKITE_TEST_ENGINE_REMOTE` or `BUILDKITE_TEST_ENGINE_BACKFILL_REMOTE` | `--remote` | `origin` | Git remote name for fetching and branch detection |
 | `BUILDKITE_TEST_ENGINE_BACKFILL_CONCURRENCY` | `--concurrency` | `10` | Number of concurrent git operations for diff collection |
 | `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` | `--debug` | `false` | Enable debug output |
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildkite/test-engine-client/internal/api"
 	"github.com/buildkite/test-engine-client/internal/config"
 	"github.com/buildkite/test-engine-client/internal/debug"
+	"github.com/buildkite/test-engine-client/internal/git"
 	"github.com/buildkite/test-engine-client/internal/plan"
 	"github.com/buildkite/test-engine-client/internal/runner"
 	"github.com/buildkite/test-engine-client/internal/version"
@@ -35,6 +36,11 @@ var (
 // This command creates a test plan via the API
 func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFormat PlanOutput, template string) error {
 	fmt.Fprintln(os.Stderr, "+++ Buildkite Test Engine Client: bktec "+version.Version+"\n")
+
+	// Auto-collect git metadata when selection is active
+	if cfg.SelectionStrategy != "" {
+		autoCollectGitMetadata(ctx, cfg, &git.ExecGitRunner{})
+	}
 
 	testRunner, err := runner.DetectRunner(cfg)
 	if err != nil {
@@ -145,6 +151,31 @@ func createTestPlan(ctx context.Context, cfg *config.Config, files []string, api
 	}
 
 	return testPlan, nil
+}
+
+// autoCollectGitMetadata collects git commit metadata and merges it into
+// cfg.Metadata. User-provided metadata values (from --metadata) take
+// precedence over auto-collected values.
+func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.GitRunner) {
+	// Check if we're in a git repo
+	if _, err := runner.Output(ctx, "rev-parse", "--git-dir"); err != nil {
+		fmt.Fprintln(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection")
+		return
+	}
+
+	// Use user-provided base_branch from --metadata if present
+	explicit := cfg.Metadata["base_branch"]
+	remote := cfg.Remote
+	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, remote)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
+			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")
+	} else {
+		debug.Printf("auto-detected base branch: %s", baseBranch)
+	}
+
+	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)
+	cfg.Metadata = git.MergeMetadata(cfg.Metadata, autoMetadata)
 }
 
 func handleError(err error) error {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -168,8 +168,8 @@ func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	remote := cfg.Remote
 	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, remote)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
-			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")
+		fmt.Fprintln(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
+			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.")
 	} else {
 		debug.Printf("auto-detected base branch: %s", baseBranch)
 	}

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -80,51 +80,14 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 		return
 	}
 
-	meta, ok := parseCommitRecord(output)
+	record := strings.TrimRight(output, recordSeparator+"\n ")
+	meta, ok := parseRecord(record)
 	if !ok {
+		debug.Printf("Warning: git log returned unparseable output; skipping commit metadata")
 		return
 	}
 
 	mergeNonEmpty(metadata, meta.ToMap())
-}
-
-// parseCommitRecord parses a single git log record (using MetadataFormat
-// separators) into a CommitMetadata struct. Returns false if the record
-// is empty or has too few fields. Reuses the same parsing logic as
-// FetchBulkMetadata.
-func parseCommitRecord(output string) (CommitMetadata, bool) {
-	record := strings.TrimRight(output, recordSeparator+"\n ")
-	if record == "" {
-		return CommitMetadata{}, false
-	}
-
-	fields := strings.SplitN(record, fieldSeparator, metadataFields)
-	if len(fields) < metadataFields {
-		debug.Printf("Warning: git log returned %d fields, expected %d; skipping commit metadata", len(fields), metadataFields)
-		return CommitMetadata{}, false
-	}
-
-	sha := strings.TrimSpace(fields[0])
-	if sha == "" {
-		return CommitMetadata{}, false
-	}
-
-	var parentSHAs []string
-	if parents := strings.TrimSpace(fields[1]); parents != "" {
-		parentSHAs = strings.Fields(parents)
-	}
-
-	return CommitMetadata{
-		CommitSHA:      sha,
-		ParentSHAs:     parentSHAs,
-		AuthorName:     strings.TrimSpace(fields[2]),
-		AuthorEmail:    strings.TrimSpace(fields[3]),
-		AuthorDate:     strings.TrimSpace(fields[4]),
-		CommitterName:  strings.TrimSpace(fields[5]),
-		CommitterEmail: strings.TrimSpace(fields[6]),
-		CommitterDate:  strings.TrimSpace(fields[7]),
-		Message:        strings.TrimSpace(fields[8]),
-	}, true
 }
 
 // collectDiffMetadata runs diff commands against the resolved base branch

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -71,7 +71,8 @@ func CollectPlanMetadata(ctx context.Context, runner GitRunner, baseBranch strin
 }
 
 // collectCommitMetadata extracts commit metadata for HEAD using a single
-// git log call with the same format as FetchBulkMetadata.
+// git log call with the same format as FetchBulkMetadata, parses it into
+// a CommitMetadata struct, and flattens it into the metadata map via ToMap.
 func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[string]string) {
 	output, err := runner.Output(ctx, "log", "-1", fmt.Sprintf("--format=%s", MetadataFormat))
 	if err != nil {
@@ -79,31 +80,53 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 		return
 	}
 
-	// Strip the trailing record separator and any whitespace
+	meta, ok := parseCommitRecord(output)
+	if !ok {
+		return
+	}
+
+	for k, v := range meta.ToMap() {
+		metadata[k] = v
+	}
+}
+
+// parseCommitRecord parses a single git log record (using MetadataFormat
+// separators) into a CommitMetadata struct. Returns false if the record
+// is empty or has too few fields. Reuses the same parsing logic as
+// FetchBulkMetadata.
+func parseCommitRecord(output string) (CommitMetadata, bool) {
 	record := strings.TrimRight(output, recordSeparator+"\n ")
 	if record == "" {
-		return
+		return CommitMetadata{}, false
 	}
 
 	fields := strings.SplitN(record, fieldSeparator, metadataFields)
 	if len(fields) < metadataFields {
 		debug.Printf("Warning: git log returned %d fields, expected %d; skipping commit metadata", len(fields), metadataFields)
-		return
+		return CommitMetadata{}, false
 	}
 
-	metadata["commit_sha"] = strings.TrimSpace(fields[0])
+	sha := strings.TrimSpace(fields[0])
+	if sha == "" {
+		return CommitMetadata{}, false
+	}
 
+	var parentSHAs []string
 	if parents := strings.TrimSpace(fields[1]); parents != "" {
-		metadata["parent_shas"] = parents
+		parentSHAs = strings.Fields(parents)
 	}
 
-	metadata["author_name"] = strings.TrimSpace(fields[2])
-	metadata["author_email"] = strings.TrimSpace(fields[3])
-	metadata["author_date"] = strings.TrimSpace(fields[4])
-	metadata["committer_name"] = strings.TrimSpace(fields[5])
-	metadata["committer_email"] = strings.TrimSpace(fields[6])
-	metadata["committer_date"] = strings.TrimSpace(fields[7])
-	metadata["message"] = strings.TrimSpace(fields[8])
+	return CommitMetadata{
+		CommitSHA:      sha,
+		ParentSHAs:     parentSHAs,
+		AuthorName:     strings.TrimSpace(fields[2]),
+		AuthorEmail:    strings.TrimSpace(fields[3]),
+		AuthorDate:     strings.TrimSpace(fields[4]),
+		CommitterName:  strings.TrimSpace(fields[5]),
+		CommitterEmail: strings.TrimSpace(fields[6]),
+		CommitterDate:  strings.TrimSpace(fields[7]),
+		Message:        strings.TrimSpace(fields[8]),
+	}, true
 }
 
 // collectDiffMetadata runs diff commands against the resolved base branch

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -32,6 +32,9 @@ import (
 // git rev-parse --verify before being accepted.
 // Returns the resolved ref (e.g. "origin/main") or an error.
 func ResolveBaseBranch(ctx context.Context, runner GitRunner, explicit string, remote string) (string, error) {
+	if remote == "" {
+		return "", fmt.Errorf("remote must not be empty")
+	}
 	for _, candidate := range []string{explicit, os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")} {
 		if candidate == "" {
 			continue
@@ -96,6 +99,25 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 func collectDiffMetadata(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
 	diffs := runDiffCommands(ctx, runner, false, baseBranch+"...HEAD")
 	mergeNonEmpty(metadata, diffs.ToMap())
+}
+
+// MergeMetadata merges auto-collected metadata into existing user-provided
+// metadata. User-provided keys take precedence: auto-collected values only
+// fill in keys that are not already present. Empty auto-collected values
+// are skipped. If existing is nil, the auto map is returned as-is.
+func MergeMetadata(existing, auto map[string]string) map[string]string {
+	if existing == nil {
+		return auto
+	}
+	for k, v := range auto {
+		if v == "" {
+			continue
+		}
+		if _, exists := existing[k]; !exists {
+			existing[k] = v
+		}
+	}
+	return existing
 }
 
 // mergeNonEmpty copies entries from src into dst, skipping empty values.

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -157,14 +157,23 @@ func mergeNonEmpty(dst, src map[string]string) {
 
 // collectContextFields adds branch, base_branch, and Buildkite env var fields.
 func collectContextFields(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
-	// branch: current branch name (empty on detached HEAD, omitted)
+	// branch: current branch name, falling back to BUILDKITE_BRANCH
+	// for detached HEAD (common in CI where the agent checks out a commit SHA)
 	if out, err := runner.Output(ctx, "branch", "--show-current"); err == nil {
-		branch := strings.TrimSpace(out)
-		if branch != "" {
+		if branch := strings.TrimSpace(out); branch != "" {
 			metadata["branch"] = branch
+			debug.Printf("branch resolved via git branch --show-current: %s", branch)
 		}
 	} else {
 		debug.Printf("Warning: git branch --show-current failed: %v", err)
+	}
+	if _, ok := metadata["branch"]; !ok {
+		if branch := os.Getenv("BUILDKITE_BRANCH"); branch != "" {
+			metadata["branch"] = branch
+			debug.Printf("branch resolved via BUILDKITE_BRANCH env var: %s", branch)
+		} else {
+			debug.Printf("branch could not be determined (detached HEAD, no BUILDKITE_BRANCH)")
+		}
 	}
 
 	// base_branch: the resolved base ref (not a git command)

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -35,20 +35,35 @@ func ResolveBaseBranch(ctx context.Context, runner GitRunner, explicit string, r
 	if remote == "" {
 		return "", fmt.Errorf("remote must not be empty")
 	}
-	for _, candidate := range []string{explicit, os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")} {
-		if candidate == "" {
+
+	type candidate struct {
+		value  string
+		source string
+	}
+	candidates := []candidate{
+		{value: explicit, source: "explicit --metadata base_branch"},
+		{value: os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH"), source: "BUILDKITE_PULL_REQUEST_BASE_BRANCH"},
+	}
+
+	for _, c := range candidates {
+		if c.value == "" {
 			continue
 		}
-		ref := candidate
+		ref := c.value
 		if !strings.HasPrefix(ref, remote+"/") {
 			ref = remote + "/" + ref
 		}
 		if _, err := runner.Output(ctx, "rev-parse", "--verify", ref); err == nil {
+			debug.Printf("base branch resolved via %s: %q -> %s", c.source, c.value, ref)
 			return ref, nil
 		}
-		debug.Printf("base branch candidate %q (resolved to %q) not found, trying next", candidate, ref)
+		debug.Printf("base branch candidate %q (resolved to %q) from %s not found, trying next", c.value, ref, c.source)
 	}
-	return DetectDefaultBranch(ctx, runner, remote)
+	ref, err := DetectDefaultBranch(ctx, runner, remote)
+	if err == nil {
+		debug.Printf("base branch resolved via DetectDefaultBranch: %s", ref)
+	}
+	return ref, err
 }
 
 // CollectPlanMetadata collects git metadata for the current HEAD commit.

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -1,0 +1,169 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildkite/test-engine-client/internal/debug"
+)
+
+// ResolveBaseBranch determines the base branch ref to diff against.
+//
+// Resolution order:
+//  1. explicit (from --metadata base_branch=...) -- for repos with
+//     non-standard default branches (not main/master), or PRs targeting
+//     non-default branches outside Buildkite CI.
+//  2. $BUILDKITE_PULL_REQUEST_BASE_BRANCH -- auto-set by the Buildkite
+//     agent on PR builds.
+//  3. DetectDefaultBranch() -- tries remote/HEAD, remote/main, remote/master.
+//
+// Most users should NOT need to set base_branch explicitly. Override is
+// only needed when:
+//   - The repo uses a non-standard default branch (e.g. "develop", "trunk")
+//     AND remote/HEAD is not configured
+//   - The build targets a non-default branch (e.g. a PR into "release/v2")
+//     AND $BUILDKITE_PULL_REQUEST_BASE_BRANCH is not set (non-Buildkite CI
+//     or manual trigger)
+//
+// If a candidate is a bare branch name (e.g. "main"), it's prefixed with
+// "<remote>/" to form the remote ref. Each candidate is verified with
+// git rev-parse --verify before being accepted.
+// Returns the resolved ref (e.g. "origin/main") or an error.
+func ResolveBaseBranch(ctx context.Context, runner GitRunner, explicit string, remote string) (string, error) {
+	for _, candidate := range []string{explicit, os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")} {
+		if candidate == "" {
+			continue
+		}
+		ref := candidate
+		if !strings.HasPrefix(ref, remote+"/") {
+			ref = remote + "/" + ref
+		}
+		if _, err := runner.Output(ctx, "rev-parse", "--verify", ref); err == nil {
+			return ref, nil
+		}
+		debug.Printf("base branch candidate %q (resolved to %q) not found, trying next", candidate, ref)
+	}
+	return DetectDefaultBranch(ctx, runner, remote)
+}
+
+// CollectPlanMetadata collects git metadata for the current HEAD commit.
+// Returns a map of metadata keys to values. Skips keys that cannot be
+// collected (e.g. if not in a git repo). Does not error on git failures;
+// returns partial results with warnings logged via debug.Printf.
+func CollectPlanMetadata(ctx context.Context, runner GitRunner, baseBranch string) map[string]string {
+	metadata := make(map[string]string)
+
+	// Phase 1: Commit metadata via git log -1 --format=...
+	// Reuses MetadataFormat from metadata.go for consistency with backfill.
+	collectCommitMetadata(ctx, runner, metadata)
+
+	// Phase 2: Diff fields against base branch (only if base branch is resolved)
+	if baseBranch != "" {
+		collectDiffMetadata(ctx, runner, baseBranch, metadata)
+	}
+
+	// Phase 3: Context fields
+	collectContextFields(ctx, runner, baseBranch, metadata)
+
+	return metadata
+}
+
+// collectCommitMetadata extracts commit metadata for HEAD using a single
+// git log call with the same format as FetchBulkMetadata.
+func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[string]string) {
+	output, err := runner.Output(ctx, "log", "-1", fmt.Sprintf("--format=%s", MetadataFormat))
+	if err != nil {
+		debug.Printf("Warning: git log failed, skipping commit metadata: %v", err)
+		return
+	}
+
+	// Strip the trailing record separator and any whitespace
+	record := strings.TrimRight(output, recordSeparator+"\n ")
+	if record == "" {
+		return
+	}
+
+	fields := strings.SplitN(record, fieldSeparator, metadataFields)
+	if len(fields) < metadataFields {
+		debug.Printf("Warning: git log returned %d fields, expected %d; skipping commit metadata", len(fields), metadataFields)
+		return
+	}
+
+	metadata["commit_sha"] = strings.TrimSpace(fields[0])
+
+	if parents := strings.TrimSpace(fields[1]); parents != "" {
+		metadata["parent_shas"] = parents
+	}
+
+	metadata["author_name"] = strings.TrimSpace(fields[2])
+	metadata["author_email"] = strings.TrimSpace(fields[3])
+	metadata["author_date"] = strings.TrimSpace(fields[4])
+	metadata["committer_name"] = strings.TrimSpace(fields[5])
+	metadata["committer_email"] = strings.TrimSpace(fields[6])
+	metadata["committer_date"] = strings.TrimSpace(fields[7])
+	metadata["message"] = strings.TrimSpace(fields[8])
+}
+
+// collectDiffMetadata runs diff commands against the resolved base branch
+// using triple-dot syntax (<base>...HEAD).
+func collectDiffMetadata(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
+	diffRef := baseBranch + "...HEAD"
+
+	// files_changed: --name-only
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--name-only", diffRef); err == nil {
+		metadata["files_changed"] = strings.TrimRight(out, "\n")
+	} else {
+		debug.Printf("Warning: git diff --name-only failed: %v", err)
+	}
+
+	// diff_stat: --numstat
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--numstat", diffRef); err == nil {
+		metadata["diff_stat"] = strings.TrimRight(out, "\n")
+	} else {
+		debug.Printf("Warning: git diff --numstat failed: %v", err)
+	}
+
+	// git_diff: full diff
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", diffRef); err == nil {
+		metadata["git_diff"] = strings.TrimRight(out, "\n")
+	} else {
+		debug.Printf("Warning: git diff failed: %v", err)
+	}
+
+	// git_diff_raw: --raw
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--raw", diffRef); err == nil {
+		metadata["git_diff_raw"] = strings.TrimRight(out, "\n")
+	} else {
+		debug.Printf("Warning: git diff --raw failed: %v", err)
+	}
+}
+
+// collectContextFields adds branch, base_branch, and Buildkite env var fields.
+func collectContextFields(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
+	// branch: current branch name (empty on detached HEAD, omitted)
+	if out, err := runner.Output(ctx, "branch", "--show-current"); err == nil {
+		branch := strings.TrimSpace(out)
+		if branch != "" {
+			metadata["branch"] = branch
+		}
+	} else {
+		debug.Printf("Warning: git branch --show-current failed: %v", err)
+	}
+
+	// base_branch: the resolved base ref (not a git command)
+	if baseBranch != "" {
+		metadata["base_branch"] = baseBranch
+	}
+
+	// pipeline_slug from Buildkite env (omitted if not set)
+	if slug := os.Getenv("BUILDKITE_PIPELINE_SLUG"); slug != "" {
+		metadata["pipeline_slug"] = slug
+	}
+
+	// build_uuid from Buildkite env (omitted if not set)
+	if buildID := os.Getenv("BUILDKITE_BUILD_ID"); buildID != "" {
+		metadata["build_uuid"] = buildID
+	}
+}

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -130,36 +130,12 @@ func parseCommitRecord(output string) (CommitMetadata, bool) {
 }
 
 // collectDiffMetadata runs diff commands against the resolved base branch
-// using triple-dot syntax (<base>...HEAD).
+// using triple-dot syntax (<base>...HEAD) and merges the results into the
+// metadata map.
 func collectDiffMetadata(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
-	diffRef := baseBranch + "...HEAD"
-
-	// files_changed: --name-only
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--name-only", diffRef); err == nil {
-		metadata["files_changed"] = strings.TrimRight(out, "\n")
-	} else {
-		debug.Printf("Warning: git diff --name-only failed: %v", err)
-	}
-
-	// diff_stat: --numstat
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--numstat", diffRef); err == nil {
-		metadata["diff_stat"] = strings.TrimRight(out, "\n")
-	} else {
-		debug.Printf("Warning: git diff --numstat failed: %v", err)
-	}
-
-	// git_diff: full diff
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", diffRef); err == nil {
-		metadata["git_diff"] = strings.TrimRight(out, "\n")
-	} else {
-		debug.Printf("Warning: git diff failed: %v", err)
-	}
-
-	// git_diff_raw: --raw
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--raw", diffRef); err == nil {
-		metadata["git_diff_raw"] = strings.TrimRight(out, "\n")
-	} else {
-		debug.Printf("Warning: git diff --raw failed: %v", err)
+	diffs := runDiffCommands(ctx, runner, false, baseBranch+"...HEAD")
+	for k, v := range diffs.ToMap() {
+		metadata[k] = v
 	}
 }
 

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -27,9 +27,16 @@ import (
 //     AND $BUILDKITE_PULL_REQUEST_BASE_BRANCH is not set (non-Buildkite CI
 //     or manual trigger)
 //
-// If a candidate is a bare branch name (e.g. "main"), it's prefixed with
-// "<remote>/" to form the remote ref. Each candidate is verified with
-// git rev-parse --verify before being accepted.
+// Each candidate is probed against the repository using
+// git rev-parse --verify. We try the candidate verbatim first, then fall
+// back to "<remote>/<candidate>". This handles every common shape without
+// heuristics: bare branch names ("main") resolve via the fallback to
+// "origin/main"; refs from a different remote ("upstream/main"), fully-
+// qualified refs ("refs/heads/release"), and values already including the
+// configured remote ("origin/main") all resolve on the first probe.
+// Without the verbatim probe, prefixing a qualified ref would rewrite it
+// into an invalid value like "origin/upstream/main" and silently drop the
+// explicit override.
 // Returns the resolved ref (e.g. "origin/main") or an error.
 func ResolveBaseBranch(ctx context.Context, runner GitRunner, explicit string, remote string) (string, error) {
 	if remote == "" {
@@ -49,15 +56,26 @@ func ResolveBaseBranch(ctx context.Context, runner GitRunner, explicit string, r
 		if c.value == "" {
 			continue
 		}
-		ref := c.value
-		if !strings.HasPrefix(ref, remote+"/") {
-			ref = remote + "/" + ref
+
+		// Try the candidate verbatim first. This accepts qualified refs
+		// from a non-default remote ("upstream/main"), fully-qualified
+		// refs ("refs/heads/release"), and values already including the
+		// configured remote ("origin/main") without rewriting them.
+		if _, err := runner.Output(ctx, "rev-parse", "--verify", c.value); err == nil {
+			debug.Printf("base branch resolved via %s: %s", c.source, c.value)
+			return c.value, nil
 		}
-		if _, err := runner.Output(ctx, "rev-parse", "--verify", ref); err == nil {
-			debug.Printf("base branch resolved via %s: %q -> %s", c.source, c.value, ref)
-			return ref, nil
+
+		// Fall back to "<remote>/<candidate>" for bare branch names
+		// ("main" -> "origin/main") and release-style names with a "/"
+		// that are still relative to the configured remote ("release/v2"
+		// -> "origin/release/v2").
+		prefixed := remote + "/" + c.value
+		if _, err := runner.Output(ctx, "rev-parse", "--verify", prefixed); err == nil {
+			debug.Printf("base branch resolved via %s: %q -> %s", c.source, c.value, prefixed)
+			return prefixed, nil
 		}
-		debug.Printf("base branch candidate %q (resolved to %q) from %s not found, trying next", c.value, ref, c.source)
+		debug.Printf("base branch candidate %q from %s not found (also tried %q), trying next", c.value, c.source, prefixed)
 	}
 	ref, err := DetectDefaultBranch(ctx, runner, remote)
 	if err == nil {

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -85,9 +85,7 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 		return
 	}
 
-	for k, v := range meta.ToMap() {
-		metadata[k] = v
-	}
+	mergeNonEmpty(metadata, meta.ToMap())
 }
 
 // parseCommitRecord parses a single git log record (using MetadataFormat
@@ -134,8 +132,17 @@ func parseCommitRecord(output string) (CommitMetadata, bool) {
 // metadata map.
 func collectDiffMetadata(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
 	diffs := runDiffCommands(ctx, runner, false, baseBranch+"...HEAD")
-	for k, v := range diffs.ToMap() {
-		metadata[k] = v
+	mergeNonEmpty(metadata, diffs.ToMap())
+}
+
+// mergeNonEmpty copies entries from src into dst, skipping empty values.
+// This avoids sending meaningless keys (e.g. "git_diff":"") in the API
+// request, since json.Marshal does not omit empty strings within a map.
+func mergeNonEmpty(dst, src map[string]string) {
+	for k, v := range src {
+		if v != "" {
+			dst[k] = v
+		}
 	}
 }
 

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -98,7 +98,12 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 		return
 	}
 
-	record := strings.TrimSpace(strings.TrimSuffix(output, recordSeparator))
+	// Real git log output ends in "\x1e\n" (git always appends a trailing
+	// newline). TrimSpace must run first to strip the "\n", otherwise
+	// TrimSuffix("\x1e") sees the "\n" at the end and no-ops, leaving the
+	// record separator trapped inside the final field (the commit message).
+	// TrimSpace does not strip "\x1e" because it is not Unicode whitespace.
+	record := strings.TrimSuffix(strings.TrimSpace(output), recordSeparator)
 	meta, ok := parseRecord(record)
 	if !ok {
 		debug.Printf("Warning: git log returned unparseable output; skipping commit metadata")

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -93,11 +93,20 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 	mergeNonEmpty(metadata, meta.ToMap())
 }
 
-// collectDiffMetadata runs diff commands against the resolved base branch
-// using triple-dot syntax (<base>...HEAD) and merges the results into the
-// metadata map.
+// collectDiffMetadata computes the merge-base between baseBranch and HEAD,
+// then runs diff commands using two-arg form (merge-base, HEAD). This is
+// equivalent to git diff baseBranch...HEAD but makes the fork-point
+// resolution explicit and uses the same two-arg diff form as the backfill
+// path.
 func collectDiffMetadata(ctx context.Context, runner GitRunner, baseBranch string, metadata map[string]string) {
-	diffs := runDiffCommands(ctx, runner, false, baseBranch+"...HEAD")
+	forkPoint, err := runner.Output(ctx, "merge-base", baseBranch, "HEAD")
+	if err != nil {
+		debug.Printf("Warning: git merge-base failed: %v", err)
+		return
+	}
+	forkPoint = strings.TrimSpace(forkPoint)
+
+	diffs := runDiffCommands(ctx, runner, false, forkPoint, "HEAD")
 	mergeNonEmpty(metadata, diffs.ToMap())
 }
 

--- a/internal/git/auto_metadata.go
+++ b/internal/git/auto_metadata.go
@@ -80,7 +80,7 @@ func collectCommitMetadata(ctx context.Context, runner GitRunner, metadata map[s
 		return
 	}
 
-	record := strings.TrimRight(output, recordSeparator+"\n ")
+	record := strings.TrimSpace(strings.TrimSuffix(output, recordSeparator))
 	meta, ok := parseRecord(record)
 	if !ok {
 		debug.Printf("Warning: git log returned unparseable output; skipping commit metadata")

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -282,11 +282,11 @@ func TestCollectPlanMetadata_DiffFails(t *testing.T) {
 		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
 	}
 
-	// Diff fields should be absent (all failed)
+	// Diff fields should be present but empty (ToMap always includes all keys)
 	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
 	for _, key := range diffFields {
-		if _, ok := metadata[key]; ok {
-			t.Errorf("expected key %q to be absent when diff fails, but found value %q", key, metadata[key])
+		if metadata[key] != "" {
+			t.Errorf("expected key %q to be empty when diff fails, got %q", key, metadata[key])
 		}
 	}
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -423,8 +423,8 @@ func TestCommitMetadata_ToMap_NoParents(t *testing.T) {
 
 	got := meta.ToMap()
 
-	if _, ok := got["parent_shas"]; ok {
-		t.Errorf("expected parent_shas to be absent for root commit, got %q", got["parent_shas"])
+	if got["parent_shas"] != "" {
+		t.Errorf("parent_shas: got %q, want empty string for root commit", got["parent_shas"])
 	}
 	if got["commit_sha"] != "abc123" {
 		t.Errorf("commit_sha: got %q, want %q", got["commit_sha"], "abc123")

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -159,12 +159,13 @@ func TestCollectPlanMetadata_HappyPath(t *testing.T) {
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
-			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
-			"diff --no-ext-diff --name-only origin/main...HEAD": "file1.go\nfile2.go\n",
-			"diff --no-ext-diff --numstat origin/main...HEAD":   "10\t5\tfile1.go\n3\t0\tfile2.go\n",
-			"diff --no-ext-diff origin/main...HEAD":             "diff --git a/file1.go b/file1.go\n",
-			"diff --no-ext-diff --raw origin/main...HEAD":       ":100644 100644 aaa bbb M\tfile1.go\n",
-			"branch --show-current":                             "feature/my-branch\n",
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"merge-base origin/main HEAD":                     "aaa000\n",
+			"diff --no-ext-diff --name-only aaa000 HEAD":      "file1.go\nfile2.go\n",
+			"diff --no-ext-diff --numstat aaa000 HEAD":        "10\t5\tfile1.go\n3\t0\tfile2.go\n",
+			"diff --no-ext-diff aaa000 HEAD":                  "diff --git a/file1.go b/file1.go\n",
+			"diff --no-ext-diff --raw aaa000 HEAD":            ":100644 100644 aaa bbb M\tfile1.go\n",
+			"branch --show-current":                           "feature/my-branch\n",
 		},
 	}
 
@@ -317,11 +318,12 @@ func TestCollectPlanMetadata_LogFails(t *testing.T) {
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
 			// git log missing -> will error
-			"diff --no-ext-diff --name-only origin/main...HEAD": "file1.go\n",
-			"diff --no-ext-diff --numstat origin/main...HEAD":   "10\t5\tfile1.go\n",
-			"diff --no-ext-diff origin/main...HEAD":             "diff text\n",
-			"diff --no-ext-diff --raw origin/main...HEAD":       ":100644 raw\n",
-			"branch --show-current":                             "feature\n",
+			"merge-base origin/main HEAD":                "aaa000\n",
+			"diff --no-ext-diff --name-only aaa000 HEAD": "file1.go\n",
+			"diff --no-ext-diff --numstat aaa000 HEAD":   "10\t5\tfile1.go\n",
+			"diff --no-ext-diff aaa000 HEAD":             "diff text\n",
+			"diff --no-ext-diff --raw aaa000 HEAD":       ":100644 raw\n",
+			"branch --show-current":                      "feature\n",
 		},
 	}
 
@@ -484,12 +486,13 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
-			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
-			"diff --no-ext-diff --name-only origin/main...HEAD": "\n",
-			"diff --no-ext-diff --numstat origin/main...HEAD":   "\n",
-			"diff --no-ext-diff origin/main...HEAD":             "\n",
-			"diff --no-ext-diff --raw origin/main...HEAD":       "\n",
-			"branch --show-current":                             "main\n",
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"merge-base origin/main HEAD":                     "aaa000\n",
+			"diff --no-ext-diff --name-only aaa000 HEAD":      "\n",
+			"diff --no-ext-diff --numstat aaa000 HEAD":        "\n",
+			"diff --no-ext-diff aaa000 HEAD":                  "\n",
+			"diff --no-ext-diff --raw aaa000 HEAD":            "\n",
+			"branch --show-current":                           "main\n",
 		},
 	}
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -132,14 +132,21 @@ func TestResolveBaseBranch_ExplicitFailsEnvVarSucceeds(t *testing.T) {
 	}
 }
 
+// --- Helpers ---
+
+// buildRecord joins fields with fieldSeparator and appends recordSeparator,
+// matching the output format of git log --format=MetadataFormat.
+func buildRecord(fields ...string) string {
+	return strings.Join(fields, fieldSeparator) + recordSeparator
+}
+
 // --- CollectPlanMetadata tests ---
 
 func TestCollectPlanMetadata_HappyPath(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-pipeline")
 	t.Setenv("BUILDKITE_BUILD_ID", "build-uuid-123")
 
-	record := "abc123\x1fdef456 ghi789\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fGitHub\x1fnoreply@github.com\x1f2026-03-15T10:00:00+00:00\x1fFix the thing"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "def456 ghi789", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "GitHub", "noreply@github.com", "2026-03-15T10:00:00+00:00", "Fix the thing")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -213,8 +220,7 @@ func TestCollectPlanMetadata_NoBaseBranch(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
 
-	record := "abc123\x1f\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fInitial commit"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Initial commit")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -264,8 +270,7 @@ func TestCollectPlanMetadata_DiffFails(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
 
-	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fSome commit"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Some commit")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -340,8 +345,7 @@ func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
 
-	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fCommit msg"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Commit msg")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -422,8 +426,7 @@ func TestCollectPlanMetadata_MultilineMessage(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
 
-	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fFix the thing\n\nThis is a longer description\nwith multiple lines."
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Fix the thing\n\nThis is a longer description\nwith multiple lines.")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -444,8 +447,7 @@ func TestCollectPlanMetadata_EnvVarsPopulated(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-org/my-pipeline")
 	t.Setenv("BUILDKITE_BUILD_ID", "abc-def-123")
 
-	record := "abc123\x1f\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fMsg"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Msg")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{
@@ -469,8 +471,7 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
 
-	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fMerge commit"
-	gitLogOutput := record + "\x1e"
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Merge commit")
 
 	runner := &FakeGitRunner{
 		Responses: map[string]string{

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -141,6 +141,72 @@ func TestResolveBaseBranch_EmptyRemote(t *testing.T) {
 	}
 }
 
+// TestResolveBaseBranch_ExplicitQualifiedDifferentRemote locks in the fix
+// for the multi-remote case: when the user passes a qualified ref from a
+// remote other than the configured one ("upstream/main" with remote=origin),
+// the resolver must accept it verbatim instead of rewriting it to
+// "origin/upstream/main" (which would fail rev-parse and silently drop the
+// override).
+func TestResolveBaseBranch_ExplicitQualifiedDifferentRemote(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify upstream/main": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "upstream/main", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "upstream/main" {
+		t.Errorf("got %q, want %q (must not be re-prefixed to origin/upstream/main)", ref, "upstream/main")
+	}
+}
+
+// TestResolveBaseBranch_ExplicitFullyQualifiedRef covers the fully-
+// qualified ref case ("refs/heads/release"), which would otherwise be
+// rewritten to "origin/refs/heads/release".
+func TestResolveBaseBranch_ExplicitFullyQualifiedRef(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify refs/heads/release": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "refs/heads/release", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "refs/heads/release" {
+		t.Errorf("got %q, want %q (must not be re-prefixed)", ref, "refs/heads/release")
+	}
+}
+
+// TestResolveBaseBranch_EnvVarQualifiedRef asserts the same qualified-ref
+// handling applies to values sourced from BUILDKITE_PULL_REQUEST_BASE_BRANCH,
+// since the env var is subject to the same prefixing logic as --metadata.
+func TestResolveBaseBranch_EnvVarQualifiedRef(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "upstream/develop")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify upstream/develop": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "upstream/develop" {
+		t.Errorf("got %q, want %q", ref, "upstream/develop")
+	}
+}
+
 // --- Helpers ---
 
 // buildRecord joins fields with fieldSeparator and appends recordSeparator,

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -1,0 +1,500 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// --- ResolveBaseBranch tests ---
+
+func TestResolveBaseBranch_ExplicitFromMetadata(t *testing.T) {
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify origin/develop": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "develop", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/develop" {
+		t.Errorf("got %q, want %q", ref, "origin/develop")
+	}
+}
+
+func TestResolveBaseBranch_ExplicitWithRemotePrefix(t *testing.T) {
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify origin/main": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "origin/main", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/main" {
+		t.Errorf("got %q, want %q", ref, "origin/main")
+	}
+}
+
+func TestResolveBaseBranch_EnvVar(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"rev-parse --verify origin/main": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/main" {
+		t.Errorf("got %q, want %q", ref, "origin/main")
+	}
+}
+
+func TestResolveBaseBranch_DetectDefault(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			"symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/main" {
+		t.Errorf("got %q, want %q", ref, "origin/main")
+	}
+}
+
+func TestResolveBaseBranch_AllFail(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{},
+	}
+
+	_, err := ResolveBaseBranch(context.Background(), runner, "", "origin")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not detect default branch") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestResolveBaseBranch_ExplicitRefNotFound(t *testing.T) {
+	// Explicit ref doesn't exist, falls through to DetectDefaultBranch
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			// rev-parse --verify origin/nonexistent is missing -> error
+			"symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "nonexistent", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/main" {
+		t.Errorf("got %q, want %q", ref, "origin/main")
+	}
+}
+
+func TestResolveBaseBranch_ExplicitFailsEnvVarSucceeds(t *testing.T) {
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "release/v2")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			// explicit "nonexistent" fails (no response)
+			"rev-parse --verify origin/release/v2": "abc123\n",
+		},
+	}
+
+	ref, err := ResolveBaseBranch(context.Background(), runner, "nonexistent", "origin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "origin/release/v2" {
+		t.Errorf("got %q, want %q", ref, "origin/release/v2")
+	}
+}
+
+// --- CollectPlanMetadata tests ---
+
+func TestCollectPlanMetadata_HappyPath(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-pipeline")
+	t.Setenv("BUILDKITE_BUILD_ID", "build-uuid-123")
+
+	record := "abc123\x1fdef456 ghi789\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fGitHub\x1fnoreply@github.com\x1f2026-03-15T10:00:00+00:00\x1fFix the thing"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
+			"diff --no-ext-diff --name-only origin/main...HEAD": "file1.go\nfile2.go\n",
+			"diff --no-ext-diff --numstat origin/main...HEAD":   "10\t5\tfile1.go\n3\t0\tfile2.go\n",
+			"diff --no-ext-diff origin/main...HEAD":             "diff --git a/file1.go b/file1.go\n",
+			"diff --no-ext-diff --raw origin/main...HEAD":       ":100644 100644 aaa bbb M\tfile1.go\n",
+			"branch --show-current":                             "feature/my-branch\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+
+	// All 15 fields should be populated (parent_shas counted as 1 field)
+	expectedKeys := []string{
+		"commit_sha", "parent_shas", "author_name", "author_email", "author_date",
+		"committer_name", "committer_email", "committer_date", "message",
+		"files_changed", "diff_stat", "git_diff", "git_diff_raw",
+		"branch", "base_branch", "pipeline_slug", "build_uuid",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := metadata[key]; !ok {
+			t.Errorf("expected key %q in metadata, but not found", key)
+		}
+	}
+
+	// Spot-check values
+	if metadata["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+	if metadata["parent_shas"] != "def456 ghi789" {
+		t.Errorf("parent_shas: got %q, want %q", metadata["parent_shas"], "def456 ghi789")
+	}
+	if metadata["author_name"] != "Alice" {
+		t.Errorf("author_name: got %q, want %q", metadata["author_name"], "Alice")
+	}
+	if metadata["author_email"] != "alice@example.com" {
+		t.Errorf("author_email: got %q, want %q", metadata["author_email"], "alice@example.com")
+	}
+	if metadata["message"] != "Fix the thing" {
+		t.Errorf("message: got %q, want %q", metadata["message"], "Fix the thing")
+	}
+	if metadata["files_changed"] != "file1.go\nfile2.go" {
+		t.Errorf("files_changed: got %q, want %q", metadata["files_changed"], "file1.go\nfile2.go")
+	}
+	if metadata["diff_stat"] != "10\t5\tfile1.go\n3\t0\tfile2.go" {
+		t.Errorf("diff_stat: got %q", metadata["diff_stat"])
+	}
+	if metadata["git_diff"] != "diff --git a/file1.go b/file1.go" {
+		t.Errorf("git_diff: got %q", metadata["git_diff"])
+	}
+	if metadata["git_diff_raw"] != ":100644 100644 aaa bbb M\tfile1.go" {
+		t.Errorf("git_diff_raw: got %q", metadata["git_diff_raw"])
+	}
+	if metadata["branch"] != "feature/my-branch" {
+		t.Errorf("branch: got %q, want %q", metadata["branch"], "feature/my-branch")
+	}
+	if metadata["base_branch"] != "origin/main" {
+		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
+	}
+	if metadata["pipeline_slug"] != "my-pipeline" {
+		t.Errorf("pipeline_slug: got %q, want %q", metadata["pipeline_slug"], "my-pipeline")
+	}
+	if metadata["build_uuid"] != "build-uuid-123" {
+		t.Errorf("build_uuid: got %q, want %q", metadata["build_uuid"], "build-uuid-123")
+	}
+}
+
+func TestCollectPlanMetadata_NoBaseBranch(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1f\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fInitial commit"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "main\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "")
+
+	// Commit metadata should still be present
+	if metadata["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+	if metadata["author_name"] != "Alice" {
+		t.Errorf("author_name: got %q, want %q", metadata["author_name"], "Alice")
+	}
+
+	// Diff fields should be absent (no base branch)
+	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
+	for _, key := range diffFields {
+		if _, ok := metadata[key]; ok {
+			t.Errorf("expected key %q to be absent when no base branch, but found value %q", key, metadata[key])
+		}
+	}
+
+	// base_branch should be absent
+	if _, ok := metadata["base_branch"]; ok {
+		t.Errorf("expected base_branch to be absent when empty")
+	}
+
+	// parent_shas should be absent (empty parents)
+	if _, ok := metadata["parent_shas"]; ok {
+		t.Errorf("expected parent_shas to be absent for root commit")
+	}
+
+	// Env var fields should be absent (unset)
+	if _, ok := metadata["pipeline_slug"]; ok {
+		t.Errorf("expected pipeline_slug to be absent when env var unset")
+	}
+	if _, ok := metadata["build_uuid"]; ok {
+		t.Errorf("expected build_uuid to be absent when env var unset")
+	}
+}
+
+func TestCollectPlanMetadata_DiffFails(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fSome commit"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			// All diff commands missing -> will error
+			"branch --show-current": "feature\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+
+	// Commit metadata should be present
+	if metadata["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+
+	// Diff fields should be absent (all failed)
+	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
+	for _, key := range diffFields {
+		if _, ok := metadata[key]; ok {
+			t.Errorf("expected key %q to be absent when diff fails, but found value %q", key, metadata[key])
+		}
+	}
+
+	// base_branch should still be present (set from input, not from git)
+	if metadata["base_branch"] != "origin/main" {
+		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
+	}
+}
+
+func TestCollectPlanMetadata_LogFails(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			// git log missing -> will error
+			"diff --no-ext-diff --name-only origin/main...HEAD": "file1.go\n",
+			"diff --no-ext-diff --numstat origin/main...HEAD":   "10\t5\tfile1.go\n",
+			"diff --no-ext-diff origin/main...HEAD":             "diff text\n",
+			"diff --no-ext-diff --raw origin/main...HEAD":       ":100644 raw\n",
+			"branch --show-current":                             "feature\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+
+	// Commit metadata should be absent
+	commitFields := []string{"commit_sha", "author_name", "author_email", "author_date",
+		"committer_name", "committer_email", "committer_date", "message"}
+	for _, key := range commitFields {
+		if _, ok := metadata[key]; ok {
+			t.Errorf("expected key %q to be absent when git log fails, but found value %q", key, metadata[key])
+		}
+	}
+
+	// Diff fields should still be present
+	if metadata["files_changed"] != "file1.go" {
+		t.Errorf("files_changed: got %q, want %q", metadata["files_changed"], "file1.go")
+	}
+
+	// Context fields should still be present
+	if metadata["branch"] != "feature" {
+		t.Errorf("branch: got %q, want %q", metadata["branch"], "feature")
+	}
+	if metadata["base_branch"] != "origin/main" {
+		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
+	}
+}
+
+func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fCommit msg"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "\n", // empty on detached HEAD
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "")
+
+	// branch key should be omitted when empty
+	if _, ok := metadata["branch"]; ok {
+		t.Errorf("expected branch key to be absent on detached HEAD, but found %q", metadata["branch"])
+	}
+
+	// Commit metadata should still work
+	if metadata["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+}
+
+func TestCollectPlanMetadata_AllFieldsMatchBackfillFormat(t *testing.T) {
+	// Verify that the key names in the metadata map match the JSON tags
+	// of CommitMetadata and CommitDiffs structs (the backfill format).
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fGitHub\x1fnoreply@github.com\x1f2026-03-15T10:00:00+00:00\x1fFix bug"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
+			"diff --no-ext-diff --name-only origin/main...HEAD": "file.go\n",
+			"diff --no-ext-diff --numstat origin/main...HEAD":   "1\t0\tfile.go\n",
+			"diff --no-ext-diff origin/main...HEAD":             "diff content\n",
+			"diff --no-ext-diff --raw origin/main...HEAD":       ":raw content\n",
+			"branch --show-current":                             "feat\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+
+	// These key names must match the JSON tags in CommitMetadata struct
+	commitMetadataKeys := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "GitHub",
+		"committer_email": "noreply@github.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Fix bug",
+	}
+
+	for key, want := range commitMetadataKeys {
+		got, ok := metadata[key]
+		if !ok {
+			t.Errorf("key %q missing from metadata", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("key %q: got %q, want %q", key, got, want)
+		}
+	}
+
+	// These key names must match the JSON tags in CommitDiffs struct
+	diffKeys := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
+	for _, key := range diffKeys {
+		if _, ok := metadata[key]; !ok {
+			t.Errorf("diff key %q missing from metadata", key)
+		}
+	}
+}
+
+func TestCollectPlanMetadata_MultilineMessage(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fFix the thing\n\nThis is a longer description\nwith multiple lines."
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "main\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "")
+
+	want := "Fix the thing\n\nThis is a longer description\nwith multiple lines."
+	if diff := cmp.Diff(want, metadata["message"]); diff != "" {
+		t.Errorf("message mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCollectPlanMetadata_EnvVarsPopulated(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-org/my-pipeline")
+	t.Setenv("BUILDKITE_BUILD_ID", "abc-def-123")
+
+	record := "abc123\x1f\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fMsg"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "main\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "")
+
+	if metadata["pipeline_slug"] != "my-org/my-pipeline" {
+		t.Errorf("pipeline_slug: got %q, want %q", metadata["pipeline_slug"], "my-org/my-pipeline")
+	}
+	if metadata["build_uuid"] != "abc-def-123" {
+		t.Errorf("build_uuid: got %q, want %q", metadata["build_uuid"], "abc-def-123")
+	}
+}
+
+func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
+	// Simulates builds on the default branch where diff is empty
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fMerge commit"
+	gitLogOutput := record + "\x1e"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
+			"diff --no-ext-diff --name-only origin/main...HEAD": "\n",
+			"diff --no-ext-diff --numstat origin/main...HEAD":   "\n",
+			"diff --no-ext-diff origin/main...HEAD":             "\n",
+			"diff --no-ext-diff --raw origin/main...HEAD":       "\n",
+			"branch --show-current":                             "main\n",
+		},
+	}
+
+	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+
+	// Empty diffs should result in empty string values (not absent keys)
+	if metadata["files_changed"] != "" {
+		t.Errorf("files_changed: got %q, want empty", metadata["files_changed"])
+	}
+	if metadata["diff_stat"] != "" {
+		t.Errorf("diff_stat: got %q, want empty", metadata["diff_stat"])
+	}
+
+	// Commit metadata should still be fully populated
+	if metadata["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+}

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -132,6 +132,15 @@ func TestResolveBaseBranch_ExplicitFailsEnvVarSucceeds(t *testing.T) {
 	}
 }
 
+func TestResolveBaseBranch_EmptyRemote(t *testing.T) {
+	runner := &FakeGitRunner{}
+
+	_, err := ResolveBaseBranch(context.Background(), runner, "main", "")
+	if err == nil {
+		t.Fatal("expected error for empty remote, got nil")
+	}
+}
+
 // --- Helpers ---
 
 // buildRecord joins fields with fieldSeparator and appends recordSeparator,
@@ -497,5 +506,68 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 	// Commit metadata should still be fully populated
 	if metadata["commit_sha"] != "abc123" {
 		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	}
+}
+
+// --- MergeMetadata tests ---
+
+func TestMergeMetadata_UserPrecedence(t *testing.T) {
+	existing := map[string]string{
+		"commit_sha": "user-provided-sha",
+		"branch":     "user-branch",
+	}
+	auto := map[string]string{
+		"commit_sha":  "auto-sha",
+		"branch":      "auto-branch",
+		"author_name": "Alice",
+	}
+
+	result := MergeMetadata(existing, auto)
+
+	// User-provided values should win
+	if result["commit_sha"] != "user-provided-sha" {
+		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "user-provided-sha")
+	}
+	if result["branch"] != "user-branch" {
+		t.Errorf("branch: got %q, want %q", result["branch"], "user-branch")
+	}
+	// Auto-collected values should fill gaps
+	if result["author_name"] != "Alice" {
+		t.Errorf("author_name: got %q, want %q", result["author_name"], "Alice")
+	}
+}
+
+func TestMergeMetadata_NilExisting(t *testing.T) {
+	auto := map[string]string{
+		"commit_sha":  "abc123",
+		"author_name": "Alice",
+	}
+
+	result := MergeMetadata(nil, auto)
+
+	if result["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "abc123")
+	}
+	if result["author_name"] != "Alice" {
+		t.Errorf("author_name: got %q, want %q", result["author_name"], "Alice")
+	}
+}
+
+func TestMergeMetadata_SkipsEmptyAutoValues(t *testing.T) {
+	existing := map[string]string{
+		"branch": "main",
+	}
+	auto := map[string]string{
+		"commit_sha": "abc123",
+		"git_diff":   "",
+	}
+
+	result := MergeMetadata(existing, auto)
+
+	if result["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "abc123")
+	}
+	if _, ok := result["git_diff"]; ok {
+		t.Errorf("expected git_diff to be absent for empty auto value, got %q", result["git_diff"])
 	}
 }

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -209,40 +209,24 @@ func TestCollectPlanMetadata_NoBaseBranch(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "")
+	got := CollectPlanMetadata(context.Background(), runner, "")
 
-	// Commit metadata should still be present
-	if metadata["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
-	}
-	if metadata["author_name"] != "Alice" {
-		t.Errorf("author_name: got %q, want %q", metadata["author_name"], "Alice")
-	}
-
-	// Diff fields should be absent (no base branch)
-	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
-	for _, key := range diffFields {
-		if _, ok := metadata[key]; ok {
-			t.Errorf("expected key %q to be absent when no base branch, but found value %q", key, metadata[key])
-		}
+	// No base branch: diff fields, base_branch, parent_shas (root commit),
+	// pipeline_slug, and build_uuid should all be absent.
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Initial commit",
+		"branch":          "main",
 	}
 
-	// base_branch should be absent
-	if _, ok := metadata["base_branch"]; ok {
-		t.Errorf("expected base_branch to be absent when empty")
-	}
-
-	// parent_shas should be absent (empty parents)
-	if _, ok := metadata["parent_shas"]; ok {
-		t.Errorf("expected parent_shas to be absent for root commit")
-	}
-
-	// Env var fields should be absent (unset)
-	if _, ok := metadata["pipeline_slug"]; ok {
-		t.Errorf("expected pipeline_slug to be absent when env var unset")
-	}
-	if _, ok := metadata["build_uuid"]; ok {
-		t.Errorf("expected build_uuid to be absent when env var unset")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -169,60 +169,30 @@ func TestCollectPlanMetadata_HappyPath(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+	got := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// All 17 keys should be populated
-	expectedKeys := []string{
-		"commit_sha", "parent_shas", "author_name", "author_email", "author_date",
-		"committer_name", "committer_email", "committer_date", "message",
-		"files_changed", "diff_stat", "git_diff", "git_diff_raw",
-		"branch", "base_branch", "pipeline_slug", "build_uuid",
-	}
-	for _, key := range expectedKeys {
-		if _, ok := metadata[key]; !ok {
-			t.Errorf("expected key %q in metadata, but not found", key)
-		}
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456 ghi789",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "GitHub",
+		"committer_email": "noreply@github.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Fix the thing",
+		"files_changed":   "file1.go\nfile2.go",
+		"diff_stat":       "10\t5\tfile1.go\n3\t0\tfile2.go",
+		"git_diff":        "diff --git a/file1.go b/file1.go",
+		"git_diff_raw":    ":100644 100644 aaa bbb M\tfile1.go",
+		"branch":          "feature/my-branch",
+		"base_branch":     "origin/main",
+		"pipeline_slug":   "my-pipeline",
+		"build_uuid":      "build-uuid-123",
 	}
 
-	// Spot-check values
-	if metadata["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
-	}
-	if metadata["parent_shas"] != "def456 ghi789" {
-		t.Errorf("parent_shas: got %q, want %q", metadata["parent_shas"], "def456 ghi789")
-	}
-	if metadata["author_name"] != "Alice" {
-		t.Errorf("author_name: got %q, want %q", metadata["author_name"], "Alice")
-	}
-	if metadata["author_email"] != "alice@example.com" {
-		t.Errorf("author_email: got %q, want %q", metadata["author_email"], "alice@example.com")
-	}
-	if metadata["message"] != "Fix the thing" {
-		t.Errorf("message: got %q, want %q", metadata["message"], "Fix the thing")
-	}
-	if metadata["files_changed"] != "file1.go\nfile2.go" {
-		t.Errorf("files_changed: got %q, want %q", metadata["files_changed"], "file1.go\nfile2.go")
-	}
-	if metadata["diff_stat"] != "10\t5\tfile1.go\n3\t0\tfile2.go" {
-		t.Errorf("diff_stat: got %q", metadata["diff_stat"])
-	}
-	if metadata["git_diff"] != "diff --git a/file1.go b/file1.go" {
-		t.Errorf("git_diff: got %q", metadata["git_diff"])
-	}
-	if metadata["git_diff_raw"] != ":100644 100644 aaa bbb M\tfile1.go" {
-		t.Errorf("git_diff_raw: got %q", metadata["git_diff_raw"])
-	}
-	if metadata["branch"] != "feature/my-branch" {
-		t.Errorf("branch: got %q, want %q", metadata["branch"], "feature/my-branch")
-	}
-	if metadata["base_branch"] != "origin/main" {
-		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
-	}
-	if metadata["pipeline_slug"] != "my-pipeline" {
-		t.Errorf("pipeline_slug: got %q, want %q", metadata["pipeline_slug"], "my-pipeline")
-	}
-	if metadata["build_uuid"] != "build-uuid-123" {
-		t.Errorf("build_uuid: got %q, want %q", metadata["build_uuid"], "build-uuid-123")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -301,9 +301,10 @@ func TestCollectPlanMetadata_LogFails(t *testing.T) {
 	}
 }
 
-func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
+func TestCollectPlanMetadata_DetachedHeadFallsToBuildkiteBranch(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")
+	t.Setenv("BUILDKITE_BRANCH", "feature/from-env")
 
 	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Commit msg")
 
@@ -311,6 +312,40 @@ func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
 		Responses: map[string]string{
 			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
 			"branch --show-current":                           "\n", // empty on detached HEAD
+		},
+	}
+
+	got := CollectPlanMetadata(context.Background(), runner, "")
+
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Commit msg",
+		"branch":          "feature/from-env",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCollectPlanMetadata_DetachedHeadNoBuildkiteBranch(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+	t.Setenv("BUILDKITE_BRANCH", "")
+
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Commit msg")
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "\n",
 		},
 	}
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -244,24 +244,26 @@ func TestCollectPlanMetadata_DiffFails(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+	got := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// Commit metadata should be present
-	if metadata["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	// Diff commands all fail (missing from FakeGitRunner), so diff fields
+	// are absent. Commit metadata and context fields should still be present.
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Some commit",
+		"branch":          "feature",
+		"base_branch":     "origin/main",
 	}
 
-	// Diff fields should be absent (empty values filtered at merge)
-	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
-	for _, key := range diffFields {
-		if _, ok := metadata[key]; ok {
-			t.Errorf("expected key %q to be absent when diff fails, but found value %q", key, metadata[key])
-		}
-	}
-
-	// base_branch should still be present (set from input, not from git)
-	if metadata["base_branch"] != "origin/main" {
-		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -281,28 +283,21 @@ func TestCollectPlanMetadata_LogFails(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+	got := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// Commit metadata should be absent
-	commitFields := []string{"commit_sha", "author_name", "author_email", "author_date",
-		"committer_name", "committer_email", "committer_date", "message"}
-	for _, key := range commitFields {
-		if _, ok := metadata[key]; ok {
-			t.Errorf("expected key %q to be absent when git log fails, but found value %q", key, metadata[key])
-		}
+	// Git log fails, so commit metadata is absent. Diff and context fields
+	// should still be present.
+	want := map[string]string{
+		"files_changed": "file1.go",
+		"diff_stat":     "10\t5\tfile1.go",
+		"git_diff":      "diff text",
+		"git_diff_raw":  ":100644 raw",
+		"branch":        "feature",
+		"base_branch":   "origin/main",
 	}
 
-	// Diff fields should still be present
-	if metadata["files_changed"] != "file1.go" {
-		t.Errorf("files_changed: got %q, want %q", metadata["files_changed"], "file1.go")
-	}
-
-	// Context fields should still be present
-	if metadata["branch"] != "feature" {
-		t.Errorf("branch: got %q, want %q", metadata["branch"], "feature")
-	}
-	if metadata["base_branch"] != "origin/main" {
-		t.Errorf("base_branch: got %q, want %q", metadata["base_branch"], "origin/main")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -319,16 +314,22 @@ func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "")
+	got := CollectPlanMetadata(context.Background(), runner, "")
 
-	// branch key should be omitted when empty
-	if _, ok := metadata["branch"]; ok {
-		t.Errorf("expected branch key to be absent on detached HEAD, but found %q", metadata["branch"])
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Commit msg",
 	}
 
-	// Commit metadata should still work
-	if metadata["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -379,11 +380,20 @@ func TestCommitMetadata_ToMap_NoParents(t *testing.T) {
 
 	got := meta.ToMap()
 
-	if got["parent_shas"] != "" {
-		t.Errorf("parent_shas: got %q, want empty string for root commit", got["parent_shas"])
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Initial commit",
 	}
-	if got["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", got["commit_sha"], "abc123")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ToMap() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -400,11 +410,23 @@ func TestCollectPlanMetadata_MultilineMessage(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "")
+	got := CollectPlanMetadata(context.Background(), runner, "")
 
-	want := "Fix the thing\n\nThis is a longer description\nwith multiple lines."
-	if diff := cmp.Diff(want, metadata["message"]); diff != "" {
-		t.Errorf("message mismatch (-want +got):\n%s", diff)
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Fix the thing\n\nThis is a longer description\nwith multiple lines.",
+		"branch":          "main",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -421,13 +443,24 @@ func TestCollectPlanMetadata_EnvVarsPopulated(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "")
+	got := CollectPlanMetadata(context.Background(), runner, "")
 
-	if metadata["pipeline_slug"] != "my-org/my-pipeline" {
-		t.Errorf("pipeline_slug: got %q, want %q", metadata["pipeline_slug"], "my-org/my-pipeline")
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Msg",
+		"branch":          "main",
+		"pipeline_slug":   "my-org/my-pipeline",
+		"build_uuid":      "abc-def-123",
 	}
-	if metadata["build_uuid"] != "abc-def-123" {
-		t.Errorf("build_uuid: got %q, want %q", metadata["build_uuid"], "abc-def-123")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -450,19 +483,26 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 		},
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+	got := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// Empty diffs should be omitted (mergeNonEmpty skips empty values)
-	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
-	for _, key := range diffFields {
-		if _, ok := metadata[key]; ok {
-			t.Errorf("expected key %q to be absent for empty diff, but found value %q", key, metadata[key])
-		}
+	// Empty diffs are omitted by mergeNonEmpty. Commit metadata and context
+	// fields should still be present.
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Merge commit",
+		"branch":          "main",
+		"base_branch":     "origin/main",
 	}
 
-	// Commit metadata should still be fully populated
-	if metadata["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -479,18 +519,16 @@ func TestMergeMetadata_UserPrecedence(t *testing.T) {
 		"author_name": "Alice",
 	}
 
-	result := MergeMetadata(existing, auto)
+	got := MergeMetadata(existing, auto)
 
-	// User-provided values should win
-	if result["commit_sha"] != "user-provided-sha" {
-		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "user-provided-sha")
+	want := map[string]string{
+		"commit_sha":  "user-provided-sha",
+		"branch":      "user-branch",
+		"author_name": "Alice",
 	}
-	if result["branch"] != "user-branch" {
-		t.Errorf("branch: got %q, want %q", result["branch"], "user-branch")
-	}
-	// Auto-collected values should fill gaps
-	if result["author_name"] != "Alice" {
-		t.Errorf("author_name: got %q, want %q", result["author_name"], "Alice")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("MergeMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -500,13 +538,10 @@ func TestMergeMetadata_NilExisting(t *testing.T) {
 		"author_name": "Alice",
 	}
 
-	result := MergeMetadata(nil, auto)
+	got := MergeMetadata(nil, auto)
 
-	if result["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "abc123")
-	}
-	if result["author_name"] != "Alice" {
-		t.Errorf("author_name: got %q, want %q", result["author_name"], "Alice")
+	if diff := cmp.Diff(auto, got); diff != "" {
+		t.Errorf("MergeMetadata mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -519,12 +554,14 @@ func TestMergeMetadata_SkipsEmptyAutoValues(t *testing.T) {
 		"git_diff":   "",
 	}
 
-	result := MergeMetadata(existing, auto)
+	got := MergeMetadata(existing, auto)
 
-	if result["commit_sha"] != "abc123" {
-		t.Errorf("commit_sha: got %q, want %q", result["commit_sha"], "abc123")
+	want := map[string]string{
+		"branch":     "main",
+		"commit_sha": "abc123",
 	}
-	if _, ok := result["git_diff"]; ok {
-		t.Errorf("expected git_diff to be absent for empty auto value, got %q", result["git_diff"])
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("MergeMetadata mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -363,32 +363,24 @@ func TestCollectPlanMetadata_DetachedHead(t *testing.T) {
 	}
 }
 
-func TestCollectPlanMetadata_AllFieldsMatchBackfillFormat(t *testing.T) {
-	// Verify that the key names in the metadata map match the JSON tags
-	// of CommitMetadata and CommitDiffs structs (the backfill format).
-	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
-	t.Setenv("BUILDKITE_BUILD_ID", "")
-
-	record := "abc123\x1fdef456\x1fAlice\x1falice@example.com\x1f2026-03-15T10:00:00+00:00\x1fGitHub\x1fnoreply@github.com\x1f2026-03-15T10:00:00+00:00\x1fFix bug"
-	gitLogOutput := record + "\x1e"
-
-	runner := &FakeGitRunner{
-		Responses: map[string]string{
-			fmt.Sprintf("log -1 --format=%s", MetadataFormat):   gitLogOutput,
-			"diff --no-ext-diff --name-only origin/main...HEAD": "file.go\n",
-			"diff --no-ext-diff --numstat origin/main...HEAD":   "1\t0\tfile.go\n",
-			"diff --no-ext-diff origin/main...HEAD":             "diff content\n",
-			"diff --no-ext-diff --raw origin/main...HEAD":       ":raw content\n",
-			"branch --show-current":                             "feat\n",
-		},
+func TestCommitMetadata_ToMap(t *testing.T) {
+	meta := CommitMetadata{
+		CommitSHA:      "abc123",
+		ParentSHAs:     []string{"def456", "ghi789"},
+		AuthorName:     "Alice",
+		AuthorEmail:    "alice@example.com",
+		AuthorDate:     "2026-03-15T10:00:00+00:00",
+		CommitterName:  "GitHub",
+		CommitterEmail: "noreply@github.com",
+		CommitterDate:  "2026-03-15T10:00:00+00:00",
+		Message:        "Fix bug",
 	}
 
-	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
+	got := meta.ToMap()
 
-	// These key names must match the JSON tags in CommitMetadata struct
-	commitMetadataKeys := map[string]string{
+	want := map[string]string{
 		"commit_sha":      "abc123",
-		"parent_shas":     "def456",
+		"parent_shas":     "def456 ghi789",
 		"author_name":     "Alice",
 		"author_email":    "alice@example.com",
 		"author_date":     "2026-03-15T10:00:00+00:00",
@@ -398,23 +390,31 @@ func TestCollectPlanMetadata_AllFieldsMatchBackfillFormat(t *testing.T) {
 		"message":         "Fix bug",
 	}
 
-	for key, want := range commitMetadataKeys {
-		got, ok := metadata[key]
-		if !ok {
-			t.Errorf("key %q missing from metadata", key)
-			continue
-		}
-		if got != want {
-			t.Errorf("key %q: got %q, want %q", key, got, want)
-		}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ToMap() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCommitMetadata_ToMap_NoParents(t *testing.T) {
+	meta := CommitMetadata{
+		CommitSHA:      "abc123",
+		ParentSHAs:     nil,
+		AuthorName:     "Alice",
+		AuthorEmail:    "alice@example.com",
+		AuthorDate:     "2026-03-15T10:00:00+00:00",
+		CommitterName:  "Alice",
+		CommitterEmail: "alice@example.com",
+		CommitterDate:  "2026-03-15T10:00:00+00:00",
+		Message:        "Initial commit",
 	}
 
-	// These key names must match the JSON tags in CommitDiffs struct
-	diffKeys := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
-	for _, key := range diffKeys {
-		if _, ok := metadata[key]; !ok {
-			t.Errorf("diff key %q missing from metadata", key)
-		}
+	got := meta.ToMap()
+
+	if _, ok := got["parent_shas"]; ok {
+		t.Errorf("expected parent_shas to be absent for root commit, got %q", got["parent_shas"])
+	}
+	if got["commit_sha"] != "abc123" {
+		t.Errorf("commit_sha: got %q, want %q", got["commit_sha"], "abc123")
 	}
 }
 

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -432,6 +432,61 @@ func TestCommitMetadata_ToMap_NoParents(t *testing.T) {
 	}
 }
 
+// TestCollectPlanMetadata_TrailingNewline reproduces the exact output shape
+// of real `git log -1 --format=...%x1e` invocations, which git always
+// terminates with a trailing "\n" after the record separator. Earlier code
+// applied TrimSuffix before TrimSpace: TrimSuffix saw the "\n" at the end
+// and no-oped on the "\x1e", then TrimSpace stripped the "\n" and left
+// "\x1e" inside the last field (the commit message). Because "\x1e" is not
+// Unicode whitespace, the per-field TrimSpace in parseRecord did not remove
+// it either, so every commit message collected on the plan path carried a
+// trailing "\x1e" into the API payload (observed in Kafka as "\u001e").
+//
+// This test locks in the fix by using a fixture that matches real git
+// output; any regression would reintroduce the trailing "\x1e" in the
+// message value and fail the cmp.Diff below.
+func TestCollectPlanMetadata_TrailingNewline(t *testing.T) {
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	// Note the trailing "\n" appended after buildRecord's "\x1e": this is
+	// what real git log output looks like.
+	gitLogOutput := buildRecord("abc123", "def456", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Alice", "alice@example.com", "2026-03-15T10:00:00+00:00", "Fix the thing\n\nLonger description.") + "\n"
+
+	runner := &FakeGitRunner{
+		Responses: map[string]string{
+			fmt.Sprintf("log -1 --format=%s", MetadataFormat): gitLogOutput,
+			"branch --show-current":                           "main\n",
+		},
+	}
+
+	got := CollectPlanMetadata(context.Background(), runner, "")
+
+	want := map[string]string{
+		"commit_sha":      "abc123",
+		"parent_shas":     "def456",
+		"author_name":     "Alice",
+		"author_email":    "alice@example.com",
+		"author_date":     "2026-03-15T10:00:00+00:00",
+		"committer_name":  "Alice",
+		"committer_email": "alice@example.com",
+		"committer_date":  "2026-03-15T10:00:00+00:00",
+		"message":         "Fix the thing\n\nLonger description.",
+		"branch":          "main",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CollectPlanMetadata mismatch (-want +got):\n%s", diff)
+	}
+
+	// Belt-and-braces assertion: the trailing record separator must not
+	// survive into any field value. This catches the exact regression
+	// without relying on cmp.Diff's failure mode being easy to read.
+	if strings.Contains(got["message"], recordSeparator) {
+		t.Errorf("message field contains stray record separator %q: %q", recordSeparator, got["message"])
+	}
+}
+
 func TestCollectPlanMetadata_MultilineMessage(t *testing.T) {
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "")
 	t.Setenv("BUILDKITE_BUILD_ID", "")

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -282,11 +282,11 @@ func TestCollectPlanMetadata_DiffFails(t *testing.T) {
 		t.Errorf("commit_sha: got %q, want %q", metadata["commit_sha"], "abc123")
 	}
 
-	// Diff fields should be present but empty (ToMap always includes all keys)
+	// Diff fields should be absent (empty values filtered at merge)
 	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
 	for _, key := range diffFields {
-		if metadata[key] != "" {
-			t.Errorf("expected key %q to be empty when diff fails, got %q", key, metadata[key])
+		if _, ok := metadata[key]; ok {
+			t.Errorf("expected key %q to be absent when diff fails, but found value %q", key, metadata[key])
 		}
 	}
 
@@ -485,12 +485,12 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 
 	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// Empty diffs should result in empty string values (not absent keys)
-	if metadata["files_changed"] != "" {
-		t.Errorf("files_changed: got %q, want empty", metadata["files_changed"])
-	}
-	if metadata["diff_stat"] != "" {
-		t.Errorf("diff_stat: got %q, want empty", metadata["diff_stat"])
+	// Empty diffs should be omitted (ToMap skips empty values)
+	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
+	for _, key := range diffFields {
+		if _, ok := metadata[key]; ok {
+			t.Errorf("expected key %q to be absent for empty diff, but found value %q", key, metadata[key])
+		}
 	}
 
 	// Commit metadata should still be fully populated

--- a/internal/git/auto_metadata_test.go
+++ b/internal/git/auto_metadata_test.go
@@ -161,7 +161,7 @@ func TestCollectPlanMetadata_HappyPath(t *testing.T) {
 
 	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// All 15 fields should be populated (parent_shas counted as 1 field)
+	// All 17 keys should be populated
 	expectedKeys := []string{
 		"commit_sha", "parent_shas", "author_name", "author_email", "author_date",
 		"committer_name", "committer_email", "committer_date", "message",
@@ -486,7 +486,7 @@ func TestCollectPlanMetadata_EmptyDiffOutput(t *testing.T) {
 
 	metadata := CollectPlanMetadata(context.Background(), runner, "origin/main")
 
-	// Empty diffs should be omitted (ToMap skips empty values)
+	// Empty diffs should be omitted (mergeNonEmpty skips empty values)
 	diffFields := []string{"files_changed", "diff_stat", "git_diff", "git_diff_raw"}
 	for _, key := range diffFields {
 		if _, ok := metadata[key]; ok {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -105,6 +105,17 @@ func CollectDiffs(
 	return results, nil
 }
 
+// ToMap returns the diff fields as a flat string map using the same key
+// names as the JSON tags.
+func (d CommitDiffs) ToMap() map[string]string {
+	return map[string]string{
+		"files_changed": d.FilesChanged,
+		"diff_stat":     d.DiffStat,
+		"git_diff":      d.GitDiff,
+		"git_diff_raw":  d.GitDiffRaw,
+	}
+}
+
 // extractCommitDiffs extracts diff information for a single commit.
 func extractCommitDiffs(
 	ctx context.Context,
@@ -119,37 +130,50 @@ func extractCommitDiffs(
 	}
 	debug.Printf("commit %s fork-point %s (strategy: %s)", commit, fp.Base, fp.Strategy)
 
+	return runDiffCommands(ctx, runner, skipDiffs, fp.Base, commit), nil
+}
+
+// runDiffCommands runs the 4 git diff commands against the given ref args
+// and returns the results as a CommitDiffs struct. The refArgs are passed
+// directly to git diff (e.g. ["base", "commit"] for two-arg form, or
+// ["base...HEAD"] for triple-dot form). Each command is independent; failures
+// log a debug warning and leave the field empty.
+func runDiffCommands(ctx context.Context, runner GitRunner, skipDiffs bool, refArgs ...string) CommitDiffs {
 	var diffs CommitDiffs
 
 	// files_changed: --name-only
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--name-only", fp.Base, commit); err == nil {
+	args := append([]string{"diff", "--no-ext-diff", "--name-only"}, refArgs...)
+	if out, err := runner.Output(ctx, args...); err == nil {
 		diffs.FilesChanged = strings.TrimRight(out, "\n")
 	} else {
-		debug.Printf("Warning: diff --name-only failed for %s: %v", commit, err)
+		debug.Printf("Warning: diff --name-only failed: %v", err)
 	}
 
 	// diff_stat: --numstat
-	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--numstat", fp.Base, commit); err == nil {
+	args = append([]string{"diff", "--no-ext-diff", "--numstat"}, refArgs...)
+	if out, err := runner.Output(ctx, args...); err == nil {
 		diffs.DiffStat = strings.TrimRight(out, "\n")
 	} else {
-		debug.Printf("Warning: diff --numstat failed for %s: %v", commit, err)
+		debug.Printf("Warning: diff --numstat failed: %v", err)
 	}
 
 	if !skipDiffs {
 		// git_diff: full diff
-		if out, err := runner.Output(ctx, "diff", "--no-ext-diff", fp.Base, commit); err == nil {
+		args = append([]string{"diff", "--no-ext-diff"}, refArgs...)
+		if out, err := runner.Output(ctx, args...); err == nil {
 			diffs.GitDiff = strings.TrimRight(out, "\n")
 		} else {
-			debug.Printf("Warning: diff failed for %s: %v", commit, err)
+			debug.Printf("Warning: diff failed: %v", err)
 		}
 
 		// git_diff_raw: --raw
-		if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--raw", fp.Base, commit); err == nil {
+		args = append([]string{"diff", "--no-ext-diff", "--raw"}, refArgs...)
+		if out, err := runner.Output(ctx, args...); err == nil {
 			diffs.GitDiffRaw = strings.TrimRight(out, "\n")
 		} else {
-			debug.Printf("Warning: diff --raw failed for %s: %v", commit, err)
+			debug.Printf("Warning: diff --raw failed: %v", err)
 		}
 	}
 
-	return diffs, nil
+	return diffs
 }

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -133,47 +133,35 @@ func extractCommitDiffs(
 	return runDiffCommands(ctx, runner, skipDiffs, fp.Base, commit), nil
 }
 
-// runDiffCommands runs the 4 git diff commands against the given ref args
-// and returns the results as a CommitDiffs struct. The refArgs are passed
-// directly to git diff (e.g. ["base", "commit"] for two-arg form, or
-// ["base...HEAD"] for triple-dot form). Each command is independent; failures
-// log a debug warning and leave the field empty.
-func runDiffCommands(ctx context.Context, runner GitRunner, skipDiffs bool, refArgs ...string) CommitDiffs {
-	// diffArgs builds the full argument list for a git diff command.
-	// flags are inserted between "diff --no-ext-diff" and the ref args.
-	diffArgs := func(flags ...string) []string {
-		args := make([]string, 0, 2+len(flags)+len(refArgs))
-		args = append(args, "diff", "--no-ext-diff")
-		args = append(args, flags...)
-		args = append(args, refArgs...)
-		return args
-	}
-
+// runDiffCommands runs the 4 git diff commands between base and commit,
+// returning the results as a CommitDiffs struct. Each command is independent;
+// failures log a debug warning and leave the field empty.
+func runDiffCommands(ctx context.Context, runner GitRunner, skipDiffs bool, base, commit string) CommitDiffs {
 	var diffs CommitDiffs
 
-	if out, err := runner.Output(ctx, diffArgs("--name-only")...); err == nil {
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--name-only", base, commit); err == nil {
 		diffs.FilesChanged = strings.TrimRight(out, "\n")
 	} else {
-		debug.Printf("Warning: diff --name-only failed: %v", err)
+		debug.Printf("Warning: diff --name-only failed for %s: %v", commit, err)
 	}
 
-	if out, err := runner.Output(ctx, diffArgs("--numstat")...); err == nil {
+	if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--numstat", base, commit); err == nil {
 		diffs.DiffStat = strings.TrimRight(out, "\n")
 	} else {
-		debug.Printf("Warning: diff --numstat failed: %v", err)
+		debug.Printf("Warning: diff --numstat failed for %s: %v", commit, err)
 	}
 
 	if !skipDiffs {
-		if out, err := runner.Output(ctx, diffArgs()...); err == nil {
+		if out, err := runner.Output(ctx, "diff", "--no-ext-diff", base, commit); err == nil {
 			diffs.GitDiff = strings.TrimRight(out, "\n")
 		} else {
-			debug.Printf("Warning: diff failed: %v", err)
+			debug.Printf("Warning: diff failed for %s: %v", commit, err)
 		}
 
-		if out, err := runner.Output(ctx, diffArgs("--raw")...); err == nil {
+		if out, err := runner.Output(ctx, "diff", "--no-ext-diff", "--raw", base, commit); err == nil {
 			diffs.GitDiffRaw = strings.TrimRight(out, "\n")
 		} else {
-			debug.Printf("Warning: diff --raw failed: %v", err)
+			debug.Printf("Warning: diff --raw failed for %s: %v", commit, err)
 		}
 	}
 

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -142,7 +142,7 @@ func runDiffCommands(ctx context.Context, runner GitRunner, skipDiffs bool, refA
 	// diffArgs builds the full argument list for a git diff command.
 	// flags are inserted between "diff --no-ext-diff" and the ref args.
 	diffArgs := func(flags ...string) []string {
-		args := make([]string, 0, 3+len(flags)+len(refArgs))
+		args := make([]string, 0, 2+len(flags)+len(refArgs))
 		args = append(args, "diff", "--no-ext-diff")
 		args = append(args, flags...)
 		args = append(args, refArgs...)

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -139,36 +139,38 @@ func extractCommitDiffs(
 // ["base...HEAD"] for triple-dot form). Each command is independent; failures
 // log a debug warning and leave the field empty.
 func runDiffCommands(ctx context.Context, runner GitRunner, skipDiffs bool, refArgs ...string) CommitDiffs {
+	// diffArgs builds the full argument list for a git diff command.
+	// flags are inserted between "diff --no-ext-diff" and the ref args.
+	diffArgs := func(flags ...string) []string {
+		args := make([]string, 0, 3+len(flags)+len(refArgs))
+		args = append(args, "diff", "--no-ext-diff")
+		args = append(args, flags...)
+		args = append(args, refArgs...)
+		return args
+	}
+
 	var diffs CommitDiffs
 
-	// files_changed: --name-only
-	args := append([]string{"diff", "--no-ext-diff", "--name-only"}, refArgs...)
-	if out, err := runner.Output(ctx, args...); err == nil {
+	if out, err := runner.Output(ctx, diffArgs("--name-only")...); err == nil {
 		diffs.FilesChanged = strings.TrimRight(out, "\n")
 	} else {
 		debug.Printf("Warning: diff --name-only failed: %v", err)
 	}
 
-	// diff_stat: --numstat
-	args = append([]string{"diff", "--no-ext-diff", "--numstat"}, refArgs...)
-	if out, err := runner.Output(ctx, args...); err == nil {
+	if out, err := runner.Output(ctx, diffArgs("--numstat")...); err == nil {
 		diffs.DiffStat = strings.TrimRight(out, "\n")
 	} else {
 		debug.Printf("Warning: diff --numstat failed: %v", err)
 	}
 
 	if !skipDiffs {
-		// git_diff: full diff
-		args = append([]string{"diff", "--no-ext-diff"}, refArgs...)
-		if out, err := runner.Output(ctx, args...); err == nil {
+		if out, err := runner.Output(ctx, diffArgs()...); err == nil {
 			diffs.GitDiff = strings.TrimRight(out, "\n")
 		} else {
 			debug.Printf("Warning: diff failed: %v", err)
 		}
 
-		// git_diff_raw: --raw
-		args = append([]string{"diff", "--no-ext-diff", "--raw"}, refArgs...)
-		if out, err := runner.Output(ctx, args...); err == nil {
+		if out, err := runner.Output(ctx, diffArgs("--raw")...); err == nil {
 			diffs.GitDiffRaw = strings.TrimRight(out, "\n")
 		} else {
 			debug.Printf("Warning: diff --raw failed: %v", err)

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -50,6 +50,26 @@ var MetadataFormat = strings.Join([]string{
 	fmtBody,
 }, fmtFieldSep) + fmtRecordSep
 
+// ToMap returns the commit metadata as a flat string map using the same key
+// names as the JSON tags. ParentSHAs are stored as a space-separated string;
+// the key is omitted if there are no parents (root commit).
+func (m CommitMetadata) ToMap() map[string]string {
+	result := map[string]string{
+		"commit_sha":      m.CommitSHA,
+		"author_name":     m.AuthorName,
+		"author_email":    m.AuthorEmail,
+		"author_date":     m.AuthorDate,
+		"committer_name":  m.CommitterName,
+		"committer_email": m.CommitterEmail,
+		"committer_date":  m.CommitterDate,
+		"message":         m.Message,
+	}
+	if len(m.ParentSHAs) > 0 {
+		result["parent_shas"] = strings.Join(m.ParentSHAs, " ")
+	}
+	return result
+}
+
 // FetchBulkMetadata fetches metadata for all given commits in a single git call.
 // Uses --no-walk with --stdin to process only the specified commits (not ancestors).
 // Returns a map from commit SHA to CommitMetadata for O(1) lookup.

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -51,11 +51,12 @@ var MetadataFormat = strings.Join([]string{
 }, fmtFieldSep) + fmtRecordSep
 
 // ToMap returns the commit metadata as a flat string map using the same key
-// names as the JSON tags. ParentSHAs are stored as a space-separated string;
-// the key is omitted if there are no parents (root commit).
+// names as the JSON tags. All keys are always present; ParentSHAs are stored
+// as a space-separated string (empty string for root commits).
 func (m CommitMetadata) ToMap() map[string]string {
-	result := map[string]string{
+	return map[string]string{
 		"commit_sha":      m.CommitSHA,
+		"parent_shas":     strings.Join(m.ParentSHAs, " "),
 		"author_name":     m.AuthorName,
 		"author_email":    m.AuthorEmail,
 		"author_date":     m.AuthorDate,
@@ -64,10 +65,6 @@ func (m CommitMetadata) ToMap() map[string]string {
 		"committer_date":  m.CommitterDate,
 		"message":         m.Message,
 	}
-	if len(m.ParentSHAs) > 0 {
-		result["parent_shas"] = strings.Join(m.ParentSHAs, " ")
-	}
-	return result
 }
 
 // FetchBulkMetadata fetches metadata for all given commits in a single git call.

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -88,38 +88,48 @@ func FetchBulkMetadata(ctx context.Context, runner GitRunner, commits []string) 
 	result := make(map[string]CommitMetadata, len(commits))
 	records := strings.Split(output, recordSeparator)
 	for _, record := range records {
-		record = strings.TrimSpace(record)
-		if record == "" {
+		meta, ok := parseRecord(strings.TrimSpace(record))
+		if !ok {
 			continue
 		}
-		fields := strings.SplitN(record, fieldSeparator, metadataFields)
-		if len(fields) < metadataFields {
-			continue
-		}
-
-		sha := strings.TrimSpace(fields[0])
-		if sha == "" {
-			continue
-		}
-
-		var parentSHAs []string
-		if parents := strings.TrimSpace(fields[1]); parents != "" {
-			parentSHAs = strings.Fields(parents)
-		}
-
-		meta := CommitMetadata{
-			CommitSHA:      sha,
-			ParentSHAs:     parentSHAs,
-			AuthorName:     strings.TrimSpace(fields[2]),
-			AuthorEmail:    strings.TrimSpace(fields[3]),
-			AuthorDate:     strings.TrimSpace(fields[4]),
-			CommitterName:  strings.TrimSpace(fields[5]),
-			CommitterEmail: strings.TrimSpace(fields[6]),
-			CommitterDate:  strings.TrimSpace(fields[7]),
-			Message:        strings.TrimSpace(fields[8]),
-		}
-		result[sha] = meta
+		result[meta.CommitSHA] = meta
 	}
 
 	return result, nil
+}
+
+// parseRecord parses a single record (already split from the record-
+// separator-delimited output) into a CommitMetadata. Returns false if the
+// record is empty, has too few fields, or has an empty commit SHA.
+func parseRecord(record string) (CommitMetadata, bool) {
+	if record == "" {
+		return CommitMetadata{}, false
+	}
+
+	fields := strings.SplitN(record, fieldSeparator, metadataFields)
+	if len(fields) < metadataFields {
+		return CommitMetadata{}, false
+	}
+
+	sha := strings.TrimSpace(fields[0])
+	if sha == "" {
+		return CommitMetadata{}, false
+	}
+
+	var parentSHAs []string
+	if parents := strings.TrimSpace(fields[1]); parents != "" {
+		parentSHAs = strings.Fields(parents)
+	}
+
+	return CommitMetadata{
+		CommitSHA:      sha,
+		ParentSHAs:     parentSHAs,
+		AuthorName:     strings.TrimSpace(fields[2]),
+		AuthorEmail:    strings.TrimSpace(fields[3]),
+		AuthorDate:     strings.TrimSpace(fields[4]),
+		CommitterName:  strings.TrimSpace(fields[5]),
+		CommitterEmail: strings.TrimSpace(fields[6]),
+		CommitterDate:  strings.TrimSpace(fields[7]),
+		Message:        strings.TrimSpace(fields[8]),
+	}, true
 }

--- a/main.go
+++ b/main.go
@@ -47,11 +47,6 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	// Auto-collect git metadata when selection is active
-	if cfg.SelectionStrategy != "" {
-		autoCollectGitMetadata(ctx)
-	}
-
 	if err := cfg.ValidateForPlan(); err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
@@ -61,33 +56,6 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 	} else {
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputPipelineUpload, cmd.String("pipeline-upload"))
 	}
-}
-
-// autoCollectGitMetadata collects git commit metadata and merges it into
-// cfg.Metadata. User-provided metadata values (from --metadata) take
-// precedence over auto-collected values.
-func autoCollectGitMetadata(ctx context.Context) {
-	runner := &git.ExecGitRunner{}
-
-	// Check if we're in a git repo
-	if _, err := runner.Output(ctx, "rev-parse", "--git-dir"); err != nil {
-		fmt.Fprintln(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection")
-		return
-	}
-
-	// Use user-provided base_branch from --metadata if present
-	explicit := cfg.Metadata["base_branch"]
-	remote := cfg.Remote
-	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, remote)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
-			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")
-	} else {
-		debug.Printf("auto-detected base branch: %s", baseBranch)
-	}
-
-	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)
-	cfg.Metadata = git.MergeMetadata(cfg.Metadata, autoMetadata)
 }
 
 func backfillCommitMetadata(ctx context.Context, cmd *cli.Command) error {

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func autoCollectGitMetadata(ctx context.Context) {
 
 	// Check if we're in a git repo
 	if _, err := runner.Output(ctx, "rev-parse", "--git-dir"); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection\n")
+		fmt.Fprintln(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection")
 		return
 	}
 
@@ -82,7 +82,7 @@ func autoCollectGitMetadata(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
 			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")
 	} else {
-		fmt.Fprintf(os.Stderr, "Auto-detected base branch: %s\n", baseBranch)
+		debug.Printf("auto-detected base branch: %s", baseBranch)
 	}
 
 	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)

--- a/main.go
+++ b/main.go
@@ -47,6 +47,11 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	// Auto-collect git metadata when selection is active
+	if cfg.SelectionStrategy != "" {
+		autoCollectGitMetadata(ctx)
+	}
+
 	if err := cfg.ValidateForPlan(); err != nil {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
@@ -55,6 +60,42 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputJSON, "")
 	} else {
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputPipelineUpload, cmd.String("pipeline-upload"))
+	}
+}
+
+// autoCollectGitMetadata collects git commit metadata and merges it into
+// cfg.Metadata. User-provided metadata values (from --metadata) take
+// precedence over auto-collected values.
+func autoCollectGitMetadata(ctx context.Context) {
+	runner := &git.ExecGitRunner{}
+
+	// Check if we're in a git repo
+	if _, err := runner.Output(ctx, "rev-parse", "--git-dir"); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection\n")
+		return
+	}
+
+	// Use user-provided base_branch from --metadata if present
+	explicit := cfg.Metadata["base_branch"]
+	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, "origin")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
+			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "Auto-detected base branch: %s\n", baseBranch)
+	}
+
+	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)
+
+	// Merge: user-provided values take precedence
+	if cfg.Metadata == nil {
+		cfg.Metadata = autoMetadata
+	} else {
+		for k, v := range autoMetadata {
+			if _, exists := cfg.Metadata[k]; !exists {
+				cfg.Metadata[k] = v
+			}
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -87,17 +87,7 @@ func autoCollectGitMetadata(ctx context.Context) {
 	}
 
 	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)
-
-	// Merge: user-provided values take precedence
-	if cfg.Metadata == nil {
-		cfg.Metadata = autoMetadata
-	} else {
-		for k, v := range autoMetadata {
-			if _, exists := cfg.Metadata[k]; !exists {
-				cfg.Metadata[k] = v
-			}
-		}
-	}
+	cfg.Metadata = git.MergeMetadata(cfg.Metadata, autoMetadata)
 }
 
 func backfillCommitMetadata(ctx context.Context, cmd *cli.Command) error {

--- a/main.go
+++ b/main.go
@@ -77,7 +77,8 @@ func autoCollectGitMetadata(ctx context.Context) {
 
 	// Use user-provided base_branch from --metadata if present
 	explicit := cfg.Metadata["base_branch"]
-	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, "origin")
+	remote := cfg.Remote
+	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, remote)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
 			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.\n")


### PR DESCRIPTION
## Description

When the plan command runs with test selection enabled (`--selection-strategy`), it now automatically collects git commit metadata and sends it with the API request. This removes the need for customers to manually script metadata collection with `--metadata` flags.

The auto-collection gathers up to 17 fields in three phases:
- **Commit metadata** (single `git log` call): SHA, parents, author/committer name/email/date, message
- **Diff fields** (explicit `git merge-base` then 4 `git diff` commands): files changed, numstat, full diff, raw diff
- **Context fields**: branch name, base branch, pipeline slug, build UUID

Base branch resolution uses a 3-level fallback: explicit `--metadata base_branch=...`, `$BUILDKITE_PULL_REQUEST_BASE_BRANCH`, then auto-detection via remote/HEAD → main → master. The `--remote` flag (default `"origin"`, configurable via `BUILDKITE_TEST_ENGINE_REMOTE`) controls which git remote is used.

Each phase degrades gracefully — git failures log debug warnings and skip affected keys without blocking CI. User-provided `--metadata` values always take precedence over auto-collected values. Empty auto-collected values are filtered at the merge site to avoid sending meaningless keys in the API request.

This also DRYs up shared logic between the new plan path and the existing backfill command (TE-5476): record parsing (`parseRecord`), diff command execution (`runDiffCommands`), and struct-to-map conversion (`ToMap`) are now shared. Both paths use explicit two-arg diff (`base commit`) rather than triple-dot syntax.

## Context

Resolves [TE-5578](https://linear.app/buildkite/issue/TE-5578)

## Changes

- Add `ResolveBaseBranch` and `CollectPlanMetadata` for plan auto-collection
- Integrate git metadata auto-collection into `plan()`, gated on `--selection-strategy`
- Add `--remote` flag to plan command under "PREVIEW: TEST SELECTION" category
- Refactor `collectCommitMetadata` to parse into `CommitMetadata` struct via `ToMap`
- Extract shared `runDiffCommands` with two-arg diff form and `CommitDiffs.ToMap`
- Extract shared `parseRecord` from duplicated parsing logic in `metadata.go`
- Use explicit `git merge-base` instead of triple-dot syntax for diff collection
- Filter empty metadata values at the merge site via `mergeNonEmpty`
- Extract `MergeMetadata` with user-precedence semantics and tests
- Guard against empty remote in `ResolveBaseBranch`
- Route success log messages through `debug.Printf`, keep warnings on stderr
- Always include `parent_shas` in `CommitMetadata.ToMap` (empty string for root commits)
- Fix `TrimRight` → `TrimSuffix` for record separator stripping
- Use `buildRecord` test helper with package constants instead of hex escapes
- Use `cmp.Diff` with full expected maps across all tests
- Document auto-collection in README and update backfill docs with shared env var

## Verification

Backed by specs. AI assisted.

```bash
go test ./internal/git/ ./internal/command/ . -count=1
```

21 new tests covering `ResolveBaseBranch`, `CollectPlanMetadata`, `CommitMetadata.ToMap`, `CommitDiffs.ToMap`, and `MergeMetadata`. All tests use `cmp.Diff` against complete expected maps.

## Deployment

Low risk. Auto-collection is gated behind `BKTEC_PREVIEW_SELECTION` and only runs when `--selection-strategy` is set. No change to existing plan or backfill behaviour when selection is not enabled.

## Rollback

Yes