### PR TITLE
[TE-5579] Add opt-in flag to collect git commit metadata without --selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ This includes commit information (SHA, author, committer, message), diff data
 branch, pipeline slug, build UUID).
 
 For pipelines that use `plan` without `--selection-strategy`, you can opt in
-to metadata collection with the `--collect-metadata` flag (or
-`BUILDKITE_TEST_ENGINE_COLLECT_METADATA=true`). This collects the same git
+to metadata collection with the `--collect-git-metadata` flag (or
+`BUILDKITE_TEST_ENGINE_COLLECT_GIT_METADATA=true`). This collects the same git
 metadata without requiring selection to be configured:
 
 ```sh
-BKTEC_PREVIEW_SELECTION=true ./bktec plan --json --collect-metadata
+BKTEC_PREVIEW_SELECTION=true ./bktec plan --json --collect-git-metadata
 ```
 
 The base branch for diff computation is resolved using a fallback chain:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ This includes commit information (SHA, author, committer, message), diff data
 (files changed, numstat, full diff), and context fields (branch name, base
 branch, pipeline slug, build UUID).
 
+For pipelines that use `plan` without `--selection-strategy`, you can opt in
+to metadata collection with the `--collect-metadata` flag (or
+`BUILDKITE_TEST_ENGINE_COLLECT_METADATA=true`). This collects the same git
+metadata without requiring selection to be configured:
+
+```sh
+BKTEC_PREVIEW_SELECTION=true ./bktec plan --json --collect-metadata
+```
+
 The base branch for diff computation is resolved using a fallback chain:
 
 1. Explicit override via `--metadata base_branch=<branch>`

--- a/cli.go
+++ b/cli.go
@@ -27,7 +27,7 @@ func applyPlanRequestContext(cmd *cli.Command) error {
 		cfg.SelectionStrategy = ""
 		cfg.SelectionParams = nil
 		cfg.Metadata = nil
-		cfg.CollectMetadata = false
+		cfg.CollectGitMetadata = false
 		return nil
 	}
 
@@ -187,12 +187,12 @@ var metadataFlag = &cli.StringSliceFlag{
 	Usage:    "Additional metadata key=value sent to the test plan API. Repeat for multiple entries.",
 }
 
-var collectMetadataFlag = &cli.BoolFlag{
-	Name:        "collect-metadata",
+var collectGitMetadataFlag = &cli.BoolFlag{
+	Name:        "collect-git-metadata",
 	Category:    "PREVIEW: TEST SELECTION",
 	Usage:       "Collect git commit metadata and include it in the plan request, even without --selection-strategy",
-	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_COLLECT_METADATA"),
-	Destination: &cfg.CollectMetadata,
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_COLLECT_GIT_METADATA"),
+	Destination: &cfg.CollectGitMetadata,
 }
 
 var baseURLFlag = &cli.StringFlag{
@@ -456,7 +456,7 @@ func previewSelectionFlags() []cli.Flag {
 		selectionParamFlag,
 		metadataFlag,
 		planRemoteFlag,
-		collectMetadataFlag,
+		collectGitMetadataFlag,
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -27,6 +27,7 @@ func applyPlanRequestContext(cmd *cli.Command) error {
 		cfg.SelectionStrategy = ""
 		cfg.SelectionParams = nil
 		cfg.Metadata = nil
+		cfg.CollectMetadata = false
 		return nil
 	}
 
@@ -184,6 +185,14 @@ var metadataFlag = &cli.StringSliceFlag{
 	Name:     "metadata",
 	Category: "PREVIEW: TEST SELECTION",
 	Usage:    "Additional metadata key=value sent to the test plan API. Repeat for multiple entries.",
+}
+
+var collectMetadataFlag = &cli.BoolFlag{
+	Name:        "collect-metadata",
+	Category:    "PREVIEW: TEST SELECTION",
+	Usage:       "Collect git commit metadata and include it in the plan request, even without --selection-strategy",
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_COLLECT_METADATA"),
+	Destination: &cfg.CollectMetadata,
 }
 
 var baseURLFlag = &cli.StringFlag{
@@ -447,6 +456,7 @@ func previewSelectionFlags() []cli.Flag {
 		selectionParamFlag,
 		metadataFlag,
 		planRemoteFlag,
+		collectMetadataFlag,
 	}
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -46,6 +46,43 @@ func TestSelectionFlagsAreGatedByPreviewEnv(t *testing.T) {
 	}
 }
 
+func TestCollectMetadataFlagIsGatedByPreviewEnv(t *testing.T) {
+	t.Setenv(previewSelectionEnvVar, "")
+	if hasFlag(planCommandFlags(), "collect-metadata") {
+		t.Fatalf("planCommandFlags() unexpectedly includes --collect-metadata when preview is disabled")
+	}
+
+	t.Setenv(previewSelectionEnvVar, "true")
+	if !hasFlag(planCommandFlags(), "collect-metadata") {
+		t.Fatalf("planCommandFlags() missing --collect-metadata when preview is enabled")
+	}
+}
+
+func TestApplyPlanRequestContext_ClearsCollectMetadataWhenPreviewDisabled(t *testing.T) {
+	t.Setenv(previewSelectionEnvVar, "")
+
+	cfg.CollectMetadata = true
+	cfg.SelectionStrategy = "percent"
+	cfg.Metadata = map[string]string{"key": "val"}
+
+	// Create a minimal command to satisfy the function signature.
+	cmd := &cli.Command{}
+
+	if err := applyPlanRequestContext(cmd); err != nil {
+		t.Fatalf("applyPlanRequestContext() error = %v", err)
+	}
+
+	if cfg.CollectMetadata {
+		t.Errorf("cfg.CollectMetadata = true, want false when preview is disabled")
+	}
+	if cfg.SelectionStrategy != "" {
+		t.Errorf("cfg.SelectionStrategy = %q, want empty when preview is disabled", cfg.SelectionStrategy)
+	}
+	if cfg.Metadata != nil {
+		t.Errorf("cfg.Metadata = %v, want nil when preview is disabled", cfg.Metadata)
+	}
+}
+
 func hasSelectionFlag(flags []cli.Flag) bool {
 	for _, flag := range flags {
 		for _, name := range flag.Names() {
@@ -55,5 +92,16 @@ func hasSelectionFlag(flags []cli.Flag) bool {
 		}
 	}
 
+	return false
+}
+
+func hasFlag(flags []cli.Flag, name string) bool {
+	for _, flag := range flags {
+		for _, n := range flag.Names() {
+			if n == name {
+				return true
+			}
+		}
+	}
 	return false
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -46,22 +46,22 @@ func TestSelectionFlagsAreGatedByPreviewEnv(t *testing.T) {
 	}
 }
 
-func TestCollectMetadataFlagIsGatedByPreviewEnv(t *testing.T) {
+func TestCollectGitMetadataFlagIsGatedByPreviewEnv(t *testing.T) {
 	t.Setenv(previewSelectionEnvVar, "")
-	if hasFlag(planCommandFlags(), "collect-metadata") {
-		t.Fatalf("planCommandFlags() unexpectedly includes --collect-metadata when preview is disabled")
+	if hasFlag(planCommandFlags(), "collect-git-metadata") {
+		t.Fatalf("planCommandFlags() unexpectedly includes --collect-git-metadata when preview is disabled")
 	}
 
 	t.Setenv(previewSelectionEnvVar, "true")
-	if !hasFlag(planCommandFlags(), "collect-metadata") {
-		t.Fatalf("planCommandFlags() missing --collect-metadata when preview is enabled")
+	if !hasFlag(planCommandFlags(), "collect-git-metadata") {
+		t.Fatalf("planCommandFlags() missing --collect-git-metadata when preview is enabled")
 	}
 }
 
-func TestApplyPlanRequestContext_ClearsCollectMetadataWhenPreviewDisabled(t *testing.T) {
+func TestApplyPlanRequestContext_ClearsCollectGitMetadataWhenPreviewDisabled(t *testing.T) {
 	t.Setenv(previewSelectionEnvVar, "")
 
-	cfg.CollectMetadata = true
+	cfg.CollectGitMetadata = true
 	cfg.SelectionStrategy = "percent"
 	cfg.Metadata = map[string]string{"key": "val"}
 
@@ -72,8 +72,8 @@ func TestApplyPlanRequestContext_ClearsCollectMetadataWhenPreviewDisabled(t *tes
 		t.Fatalf("applyPlanRequestContext() error = %v", err)
 	}
 
-	if cfg.CollectMetadata {
-		t.Errorf("cfg.CollectMetadata = true, want false when preview is disabled")
+	if cfg.CollectGitMetadata {
+		t.Errorf("cfg.CollectGitMetadata = true, want false when preview is disabled")
 	}
 	if cfg.SelectionStrategy != "" {
 		t.Errorf("cfg.SelectionStrategy = %q, want empty when preview is disabled", cfg.SelectionStrategy)

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -38,7 +38,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	fmt.Fprintln(os.Stderr, "+++ Buildkite Test Engine Client: bktec "+version.Version+"\n")
 
 	// Auto-collect git metadata when selection is active or explicitly requested
-	if cfg.SelectionStrategy != "" || cfg.CollectMetadata {
+	if cfg.SelectionStrategy != "" || cfg.CollectGitMetadata {
 		autoCollectGitMetadata(ctx, cfg, &git.ExecGitRunner{})
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -37,8 +37,8 @@ var (
 func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFormat PlanOutput, template string) error {
 	fmt.Fprintln(os.Stderr, "+++ Buildkite Test Engine Client: bktec "+version.Version+"\n")
 
-	// Auto-collect git metadata when selection is active
-	if cfg.SelectionStrategy != "" {
+	// Auto-collect git metadata when selection is active or explicitly requested
+	if cfg.SelectionStrategy != "" || cfg.CollectMetadata {
 		autoCollectGitMetadata(ctx, cfg, &git.ExecGitRunner{})
 	}
 

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -432,7 +432,7 @@ func setDebugEnabled(t *testing.T, w io.Writer) {
 	})
 }
 
-func TestPlan_CollectMetadataWithoutSelection(t *testing.T) {
+func TestPlan_CollectGitMetadataWithoutSelection(t *testing.T) {
 	// Capture the request body to verify metadata is sent
 	var requestBody []byte
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -460,7 +460,7 @@ func TestPlan_CollectMetadataWithoutSelection(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.ServerBaseUrl = svr.URL
-	cfg.CollectMetadata = true
+	cfg.CollectGitMetadata = true
 	cfg.SelectionStrategy = "" // no selection
 
 	ctx := context.Background()
@@ -498,7 +498,7 @@ func TestPlan_CollectMetadataWithoutSelection(t *testing.T) {
 	}
 }
 
-func TestPlan_NoCollectMetadataByDefault(t *testing.T) {
+func TestPlan_NoCollectGitMetadataByDefault(t *testing.T) {
 	// Capture the request body to verify no metadata is sent
 	var requestBody []byte
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -526,7 +526,7 @@ func TestPlan_NoCollectMetadataByDefault(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.ServerBaseUrl = svr.URL
-	cfg.CollectMetadata = false
+	cfg.CollectGitMetadata = false
 	cfg.SelectionStrategy = ""
 
 	ctx := context.Background()
@@ -548,7 +548,7 @@ func TestPlan_NoCollectMetadataByDefault(t *testing.T) {
 	if strings.Contains(stderrOutput, "not a git repository") ||
 		strings.Contains(stderrOutput, "auto-detected base branch") ||
 		strings.Contains(stderrOutput, "skipping metadata auto-collection") {
-		t.Errorf("auto-collection should not run when both SelectionStrategy and CollectMetadata are unset, stderr: %s", stderrOutput)
+		t.Errorf("auto-collection should not run when both SelectionStrategy and CollectGitMetadata are unset, stderr: %s", stderrOutput)
 	}
 
 	// Verify no metadata in request body

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -432,6 +432,136 @@ func setDebugEnabled(t *testing.T, w io.Writer) {
 	})
 }
 
+func TestPlan_CollectMetadataWithoutSelection(t *testing.T) {
+	// Capture the request body to verify metadata is sent
+	var requestBody []byte
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			enc.Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			requestBody, _ = io.ReadAll(r.Body)
+			enc.Encode(plan.TestPlan{
+				Identifier:  "facecafe",
+				Parallelism: 42,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseUrl = svr.URL
+	cfg.CollectMetadata = true
+	cfg.SelectionStrategy = "" // no selection
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	getStderr := captureStderr(t)
+
+	err := Plan(ctx, cfg, "", PlanOutputJSON, "")
+
+	stderrOutput := getStderr()
+
+	if err != nil {
+		t.Fatalf("command.Plan(...) error = %v", err)
+	}
+
+	// The auto-collection should have been triggered. In a test environment
+	// without a git repo, it will warn and skip, but the important thing is
+	// that the code path was entered (the warning proves the gate was passed).
+	if !strings.Contains(stderrOutput, "not a git repository") &&
+		!strings.Contains(stderrOutput, "auto-detected base branch") {
+		// If we're in a git repo (test runs inside a git checkout), we'll
+		// see metadata in the request body instead.
+		if len(requestBody) > 0 {
+			var params map[string]interface{}
+			if err := json.Unmarshal(requestBody, &params); err == nil {
+				if metadata, ok := params["metadata"]; ok && metadata != nil {
+					// Auto-collection ran and populated metadata -- gate worked
+					return
+				}
+			}
+		}
+		t.Errorf("expected auto-collection to run (either git warning or metadata in request), stderr: %s", stderrOutput)
+	}
+}
+
+func TestPlan_NoCollectMetadataByDefault(t *testing.T) {
+	// Capture the request body to verify no metadata is sent
+	var requestBody []byte
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			enc.Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			requestBody, _ = io.ReadAll(r.Body)
+			enc.Encode(plan.TestPlan{
+				Identifier:  "facecafe",
+				Parallelism: 42,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseUrl = svr.URL
+	cfg.CollectMetadata = false
+	cfg.SelectionStrategy = ""
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	getStderr := captureStderr(t)
+
+	err := Plan(ctx, cfg, "", PlanOutputJSON, "")
+
+	stderrOutput := getStderr()
+
+	if err != nil {
+		t.Fatalf("command.Plan(...) error = %v", err)
+	}
+
+	// Auto-collection should NOT have run -- no git warnings expected
+	if strings.Contains(stderrOutput, "not a git repository") ||
+		strings.Contains(stderrOutput, "auto-detected base branch") ||
+		strings.Contains(stderrOutput, "skipping metadata auto-collection") {
+		t.Errorf("auto-collection should not run when both SelectionStrategy and CollectMetadata are unset, stderr: %s", stderrOutput)
+	}
+
+	// Verify no metadata in request body
+	if len(requestBody) > 0 {
+		var params map[string]interface{}
+		if err := json.Unmarshal(requestBody, &params); err == nil {
+			if metadata, ok := params["metadata"]; ok && metadata != nil {
+				t.Errorf("expected no metadata in request, got: %v", metadata)
+			}
+		}
+	}
+}
+
 func TestPlanJSON_DebugLogging(t *testing.T) {
 	svr := getHttptestServer()
 	defer svr.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,8 @@ type Config struct {
 	// Branch is the string value of the git branch name, used by Buildkite only.
 	Branch  string `json:"BUILDKITE_BRANCH"`
 	BuildId string `json:"BUILDKITE_BUILD_ID"`
+	// CollectMetadata enables git metadata auto-collection on plan without requiring --selection-strategy to be set.
+	CollectMetadata bool `json:"-"`
 	// Concurrency is the number of concurrent git operations for diff collection (default 10).
 	Concurrency int `json:"-"`
 	// Days is the lookback window in days for the commit list API (1-90, default 90).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,8 @@ type Config struct {
 	// Branch is the string value of the git branch name, used by Buildkite only.
 	Branch  string `json:"BUILDKITE_BRANCH"`
 	BuildId string `json:"BUILDKITE_BUILD_ID"`
-	// CollectMetadata enables git metadata auto-collection on plan without requiring --selection-strategy to be set.
-	CollectMetadata bool `json:"-"`
+	// CollectGitMetadata enables git metadata auto-collection on plan without requiring --selection-strategy to be set.
+	CollectGitMetadata bool `json:"-"`
 	// Concurrency is the number of concurrent git operations for diff collection (default 10).
 	Concurrency int `json:"-"`
 	// Days is the lookback window in days for the commit list API (1-90, default 90).


### PR DESCRIPTION
## Description

Test selection is in preview, but we want customers — both internal (Preflight, bk/bk) and external — to start sending git commit metadata regardless of whether they are using test selection. The metadata pipeline and training models need real-world data flowing in now so that selection is well-trained by the time it's generally available. Gating metadata collection behind `--selection-strategy` (TE-5578) means we only get data from the small number of pipelines actively trialling selection.

This PR adds a `--collect-git-metadata` flag to `bktec plan` that triggers the same auto-collection machinery without requiring `--selection-strategy`. This lets us roll out metadata collection to any pipeline incrementally — just add the env var `BUILDKITE_TEST_ENGINE_COLLECT_GIT_METADATA=true`.

The implementation is minimal: a new bool flag widens the existing gate in `command.Plan()` from `cfg.SelectionStrategy != ""` to `cfg.SelectionStrategy != "" || cfg.CollectGitMetadata`. All collection logic from TE-5578 is reused unchanged.

## Context

[TE-5579](https://linear.app/buildkite/issue/TE-5579/add-opt-in-flag-to-collect-git-commit-metadata-without-selection)
Stacked on [TE-5578](https://linear.app/buildkite/issue/TE-5578/automatically-collect-git-commit-metadata-in-bktec-plan-selection) / [#480](https://github.com/buildkite/test-engine-client/pull/480)

## Changes

Best reviewed commit-by-commit:
- [TE-5579] Add `--collect-git-metadata` flag with preview gating
- [TE-5579] Widen auto-collection gate to include `CollectGitMetadata`
- [TE-5579] Add tests for `--collect-git-metadata` flag and gate logic
- [TE-5579] Document `--collect-git-metadata` in README
- [TE-5579] Rename `--collect-metadata` to `--collect-git-metadata`

## Verification

Backed by tests. To run:
```bash
go test ./... -run "TestCollectGitMetadata|TestApplyPlanRequestContext_Clears|TestPlan_CollectGitMetadata|TestPlan_NoCollectGitMetadata"
```

Key test coverage:
- `--collect-git-metadata` flag gated behind `BKTEC_PREVIEW_SELECTION`
- `applyPlanRequestContext()` clears `CollectGitMetadata` when preview disabled
- Auto-collection triggers with `CollectGitMetadata: true` and no `SelectionStrategy`
- No auto-collection when both `CollectGitMetadata` and `SelectionStrategy` are unset

## Deployment

Low risk. The flag is gated behind `BKTEC_PREVIEW_SELECTION` and defaults to `false`. No behavioural change for existing users.

## Rollback

Yes