### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.0 - 2026-04-17
+- Automatically collect git commit metadata on `bktec plan` when `--selection-strategy` is set. Commit info, diff stats, and context fields are sent with the plan request so test selection has the signal it needs without the caller shelling out to git. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.
+- Add `--collect-git-metadata` flag (env: `BUILDKITE_TEST_ENGINE_COLLECT_GIT_METADATA`) to `bktec plan` so pipelines can opt in to git metadata collection without using test selection. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.
+- Add `--remote` flag (env: `BUILDKITE_TEST_ENGINE_REMOTE`, default `origin`) to `bktec plan` to control which git remote is used for base-branch detection.
+
 ## 2.3.2 - 2026-04-02
 - Add built-in NUnit test runner for .NET test splitting
 


### PR DESCRIPTION
## Summary

- v2.4.0 contains [TE-5578](https://linear.app/buildkite/issue/TE-5578/automatically-collect-git-commit-metadata-in-bktec-plan-selection) (auto-collect git metadata on `bktec plan --selection-strategy`) and [TE-5579](https://linear.app/buildkite/issue/TE-5579/add-opt-in-flag-to-collect-git-commit-metadata-without-selection) (`--collect-git-metadata` opt-in flag).
- Both features are gated behind `BKTEC_PREVIEW_SELECTION`, so existing behaviour is unchanged for all current consumers.
- Tracking: [TE-5619](https://linear.app/buildkite/issue/TE-5619).

## Release steps

After merging this PR:

1. Trigger the release pipeline.
2. On the block step, select `v2.4.0`.
3. Verify artefacts land in Buildkite Packages, Docker Hub, ECR Public, and GitHub releases.