### PR TITLE
[TE-5641] Treat "none"/"off"/"false" as empty in buildSelectionParams

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/buildkite/test-engine-client/internal/api"
 	"github.com/buildkite/test-engine-client/internal/config"
@@ -93,8 +94,21 @@ func createRequestParam(ctx context.Context, cfg *config.Config, files []string,
 	}, nil
 }
 
+// buildSelectionParams returns the selection payload sent to the Test Engine
+// API, or nil when no strategy was requested.
+//
+// Beyond the empty string, a handful of human-intuitive sentinel values
+// ("none", "off", "false", "disabled", "no", plus whitespace and case
+// variants) are also coerced to nil. This is defence-in-depth against a
+// recurring foot-gun: pipelines that set BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY
+// to a human-readable "turn it off" value get a confusing 400 from the
+// server, which only accepts the strict allowlist (random, manual,
+// rspec_changed_files, xgboost). See TE-5641 / TE-5638 for context. Every
+// other value, including typos, is still forwarded verbatim so the backend
+// remains authoritative for strategy validation.
 func buildSelectionParams(strategy string, params map[string]string) *api.SelectionParams {
-	if strategy == "" {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", "none", "off", "false", "disabled", "no":
 		return nil
 	}
 

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -671,6 +671,52 @@ func TestCreateRequestParams_WithLocationPrefix(t *testing.T) {
 	}
 }
 
+func TestBuildSelectionParams(t *testing.T) {
+	params := map[string]string{"top": "100"}
+
+	t.Run("forwards real strategies verbatim", func(t *testing.T) {
+		for _, strategy := range []string{"random", "manual", "rspec_changed_files", "xgboost", "least-reliable"} {
+			got := buildSelectionParams(strategy, params)
+			want := &api.SelectionParams{Strategy: strategy, Params: params}
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("buildSelectionParams(%q) diff (-got +want):\n%s", strategy, diff)
+			}
+		}
+	})
+
+	// Defence-in-depth for TE-5641: coerce human-intuitive "no selection"
+	// sentinels to nil instead of forwarding them to the Test Engine API,
+	// which only accepts the strict allowlist. Covers case and whitespace
+	// variants too.
+	t.Run("coerces sentinel values to nil", func(t *testing.T) {
+		sentinels := []string{
+			"",
+			"none", "NONE", "None",
+			"off", "OFF",
+			"false", "FALSE", "False",
+			"disabled", "DISABLED",
+			"no", "NO",
+			" none ", "\tnone\n", "  ", "\t",
+			" off", "false ", " disabled\t",
+		}
+		for _, strategy := range sentinels {
+			if got := buildSelectionParams(strategy, params); got != nil {
+				t.Errorf("buildSelectionParams(%q) = %+v, want nil", strategy, got)
+			}
+		}
+	})
+
+	// Unknown values are still forwarded so the backend stays authoritative
+	// for strategy validation; that's by design (see TE-5641 notes).
+	t.Run("forwards unknown strategies verbatim", func(t *testing.T) {
+		got := buildSelectionParams("not-a-real-strategy", params)
+		want := &api.SelectionParams{Strategy: "not-a-real-strategy", Params: params}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("buildSelectionParams diff (-got +want):\n%s", diff)
+		}
+	})
+}
+
 func TestCreateRequestParams_WithLocationPrefix_SplitByExample(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `


### PR DESCRIPTION
## Description

`bktec`'s `buildSelectionParams` (`internal/command/request_param.go`) only treats the empty string as "no test selection". Anything else — including the human-intuitive sentinels `"none"`, `"off"`, `"false"`, `"disabled"`, `"no"` — is passed verbatim to the Test Engine API, which rejects it because `SUPPORTED_STRATEGIES` is the strict allowlist `random | manual | rspec_changed_files | xgboost`.

This is the foot-gun that landed [TE-5638][1]. `buildkite/buildkite`'s pipeline had `BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY: "none"` for months; it only started failing once [TE-5622][2] enabled `BKTEC_PREVIEW_SELECTION=1`, because the preview gate was (incidentally) also clearing `SelectionStrategy` to empty when disabled. Without client-side defence, the next pipeline author can step on the same rake.

This PR widens the empty-string check to coerce the common sentinel values (and their whitespace/case variants) to `nil`. The change is strictly additive:

- Every existing valid strategy (`random`, `manual`, `rspec_changed_files`, `xgboost`) is unaffected.
- Every invalid strategy outside the sentinel list still produces the same backend error it always has — the backend stays authoritative for strategy validation.
- Typos like `"randmo"` are still forwarded, so users still get fast feedback on mistakes.

Deliberately *not* included, per the ticket's decisions table:

- No server-side change (would dilute `SUPPORTED_STRATEGIES` for every consumer and wouldn't address whitespace).
- No debug log on coercion (minimise noise; can be added later if discoverability matters).
- No hard error on unknown strategies (breaking change for anyone with a typo).

[1]: https://linear.app/buildkite/issue/TE-5638
[2]: https://linear.app/buildkite/issue/TE-5622

## Context

Resolves [TE-5641](https://linear.app/buildkite/issue/TE-5641/bktec-defence-in-depth-treat-noneofffalse-as-empty-in).

Related:

- [TE-5638](https://linear.app/buildkite/issue/TE-5638) — the bk/bk pipeline fix that motivated this. Client-side defence would have prevented that outage entirely.
- [TE-5622](https://linear.app/buildkite/issue/TE-5622) — the bktec preview-gate change that exposed bk/bk's stale `"none"` value.

## Changes

Single commit:

- `[TE-5641] Treat "none"/"off"/"false" as empty in buildSelectionParams`

## Verification

Backed by specs. A new `TestBuildSelectionParams` in `internal/command/request_param_test.go` covers:

- Real strategies are forwarded verbatim (`random`, `manual`, `rspec_changed_files`, `xgboost`, plus an off-allowlist value to prove we don't over-filter).
- Every sentinel (`""`, `none`, `off`, `false`, `disabled`, `no`) is coerced to `nil`, across case and whitespace variants.
- Unknown strategies (e.g. `"not-a-real-strategy"`) are still forwarded, preserving the backend as the authoritative validator.

```bash
go test ./internal/command/ -run 'TestBuildSelectionParams|TestCreateRequestParams' -v
```

Manual: with this change, `BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY=none BKTEC_PREVIEW_SELECTION=1 bktec` no longer produces a `400 Invalid parameters: Selection strategy must be one of ...` from the Test Engine API.

## Deployment

Low risk. Strictly additive behaviour change — the only observable difference is that a handful of obvious "turn it off" spellings now succeed where they previously failed. Cut a new `bktec` patch release (e.g. `v2.4.1`) once merged; `buildkite/buildkite`'s Dockerfile can pick it up opportunistically — no forcing function because [TE-5638](https://linear.app/buildkite/issue/TE-5638) already resolved bk/bk's specific case.

## Rollback

Yes.

AI assisted.