### PR TITLE
[TE-5669] Consolidate duplicate handleError implementations in bktec

### DIFF
--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -1,0 +1,27 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/buildkite/test-engine-client/internal/api"
+)
+
+// handleError classifies API errors and prints user-facing warnings to stderr.
+// Returns nil for recoverable errors (caller should fall back to non-intelligent splitting),
+// or the original error for unrecoverable failures.
+func handleError(err error) error {
+	if errors.Is(err, api.ErrRetryTimeout) {
+		fmt.Fprintln(os.Stderr, "⚠️ Could not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.")
+		return nil
+	}
+
+	if billingError := new(api.BillingError); errors.As(err, &billingError) {
+		fmt.Fprintln(os.Stderr, billingError.Message+"\n")
+		fmt.Fprintln(os.Stderr, "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
+		return nil
+	}
+
+	return err
+}

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/buildkite/test-engine-client/internal/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleError_RetryTimeout(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	err := handleError(api.ErrRetryTimeout)
+
+	assert.Nil(t, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Could not fetch or create plan from server")
+	assert.Contains(t, stderr, "falling back to non-intelligent splitting")
+}
+
+func TestHandleError_BillingError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	billingErr := &api.BillingError{Message: "Billing Error: please update your plan"}
+	err := handleError(billingErr)
+
+	assert.Nil(t, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Billing Error: please update your plan")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
+func TestHandleError_UnknownError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	originalErr := fmt.Errorf("something unexpected")
+	err := handleError(originalErr)
+
+	assert.Equal(t, originalErr, err)
+
+	stderr := getStderr()
+	assert.Empty(t, stderr)
+}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -178,17 +177,4 @@ func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	cfg.Metadata = git.MergeMetadata(cfg.Metadata, autoMetadata)
 }
 
-func handleError(err error) error {
-	if errors.Is(err, api.ErrRetryTimeout) {
-		fmt.Fprintln(os.Stderr, "⚠️ Could not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.")
-		return nil
-	}
 
-	if billingError := new(api.BillingError); errors.As(err, &billingError) {
-		fmt.Fprintln(os.Stderr, billingError.Message+"\n")
-		fmt.Fprintln(os.Stderr, "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
-		return nil
-	}
-
-	return err
-}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -176,5 +176,3 @@ func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	autoMetadata := git.CollectPlanMetadata(ctx, runner, baseBranch)
 	cfg.Metadata = git.MergeMetadata(cfg.Metadata, autoMetadata)
 }
-
-

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -313,25 +313,11 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	// Fetch the plan from the server's cache.
 	cachedPlan, err := apiClient.FetchTestPlan(ctx, cfg.SuiteSlug, cfg.Identifier, cfg.JobRetryCount)
 
-	handleError := func(err error) (plan.TestPlan, error) {
-		if errors.Is(err, api.ErrRetryTimeout) {
-			fmt.Println("⚠️ Could not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.")
-			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
-			return p, nil
-		}
-
-		if billingError := new(api.BillingError); errors.As(err, &billingError) {
-			fmt.Println(billingError.Message)
-			fmt.Println("⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
-			p := plan.CreateFallbackPlan(files, cfg.Parallelism)
-			return p, nil
-		}
-
-		return plan.TestPlan{}, err
-	}
-
 	if err != nil {
-		return handleError(err)
+		if handledErr := handleError(err); handledErr != nil {
+			return plan.TestPlan{}, handledErr
+		}
+		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
 	}
 
 	if cachedPlan != nil {
@@ -351,14 +337,20 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	// If the cache is empty, create a new plan.
 	params, err := createRequestParam(ctx, cfg, files, *apiClient, testRunner)
 	if err != nil {
-		return handleError(err)
+		if handledErr := handleError(err); handledErr != nil {
+			return plan.TestPlan{}, handledErr
+		}
+		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
 	}
 
 	debug.Println("Creating test plan")
 	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
 
 	if err != nil {
-		return handleError(err)
+		if handledErr := handleError(err); handledErr != nil {
+			return plan.TestPlan{}, handledErr
+		}
+		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).


### PR DESCRIPTION
### Description

`run.go` and `plan.go` each had their own handleError implementation with the same error-classification logic (retry timeout → fallback, billing error → fallback, everything else → hard fail). This PR extracts a single shared handleError into errors.go so future error branches only need to be added once.

This PR also updates all errors to be `stderr`, where previously it was a mix of `stdout` and `stderr`. I don't think this should be a problem as the job logs output both `stdout` and `stderr` so nothing should change

### Context

[TE-5669](https://linear.app/buildkite/issue/TE-5669/consolidate-duplicate-handleerror-implementations-in-bktec)

### Changes

- `errors.go` (new): shared `handleError(err error)` error — classifies API errors and prints warnings to stderr. Returns `nil` for recoverable errors (caller falls back), or the original error for hard failures.
- `errors_test.go` (new): direct unit tests covering all three branches (retry timeout, billing error, unknown error).
- `plan.go`: removed duplicate `handleError`, removed unused errors import.
- `run.go`: replaced inline closure with calls to the shared function. Callers construct fallback plans themselves when handleError returns `nil`.

### Testing

- `errors_test.go` (new): direct unit tests covering all three branches — retry timeout returns nil with stderr warning, billing error returns nil with `stderr` warning, unknown error passes through unchanged with no stderr output.
- Existing integration tests (`TestFetchOrCreateTestPlan_*`, `TestPlanJSON_*`) continue to pass and cover the end-to-end behaviour.
