### PR TITLE
[TE-5667] Replace generic fallback warning with differentiated failure messages

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -79,6 +79,38 @@ func (e *BillingError) Error() string {
 	return e.Message
 }
 
+type AuthError struct {
+	Message string
+}
+
+func (e *AuthError) Error() string {
+	return e.Message
+}
+
+type ForbiddenError struct {
+	Message string
+}
+
+func (e *ForbiddenError) Error() string {
+	return e.Message
+}
+
+type NotFoundError struct {
+	Message string
+}
+
+func (e *NotFoundError) Error() string {
+	return e.Message
+}
+
+type BadRequestError struct {
+	Message string
+}
+
+func (e *BadRequestError) Error() string {
+	return e.Message
+}
+
 type responseError struct {
 	Message string `json:"message"`
 }
@@ -186,11 +218,21 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 				return resp, fmt.Errorf("parsing response: %w", err)
 			}
 
-			if matched := regexp.MustCompile(`^Billing Error`).MatchString(respError.Message); matched && resp.StatusCode == 403 {
-				return resp, &BillingError{Message: respError.Message}
+			switch resp.StatusCode {
+			case http.StatusUnauthorized:
+				return resp, &AuthError{Message: respError.Message}
+			case http.StatusForbidden:
+				if matched := regexp.MustCompile(`^Billing Error`).MatchString(respError.Message); matched {
+					return resp, &BillingError{Message: respError.Message}
+				}
+				return resp, &ForbiddenError{Message: respError.Message}
+			case http.StatusNotFound:
+				return resp, &NotFoundError{Message: respError.Message}
+			case http.StatusBadRequest:
+				return resp, &BadRequestError{Message: respError.Message}
+			default:
+				return resp, &respError
 			}
-
-			return resp, &respError
 		}
 
 		// parse response

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -226,6 +226,8 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 				return resp, fmt.Errorf("parsing response: %w", err)
 			}
 
+			// 5xx and 429 are handled above and trigger retries; here we only
+			// classify 4xx responses into typed errors.
 			switch resp.StatusCode {
 			case http.StatusUnauthorized:
 				return resp, &AuthError{Message: respError.Message}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -111,6 +111,14 @@ func (e *BadRequestError) Error() string {
 	return e.Message
 }
 
+type UnprocessableEntityError struct {
+	Message string
+}
+
+func (e *UnprocessableEntityError) Error() string {
+	return e.Message
+}
+
 type responseError struct {
 	Message string `json:"message"`
 }
@@ -230,6 +238,8 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 				return resp, &NotFoundError{Message: respError.Message}
 			case http.StatusBadRequest:
 				return resp, &BadRequestError{Message: respError.Message}
+			case http.StatusUnprocessableEntity:
+				return resp, &UnprocessableEntityError{Message: respError.Message}
 			default:
 				return resp, &respError
 			}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildkite/roko"
@@ -232,7 +232,7 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 			case http.StatusUnauthorized:
 				return resp, &AuthError{Message: respError.Message}
 			case http.StatusForbidden:
-				if matched := regexp.MustCompile(`^Billing Error`).MatchString(respError.Message); matched {
+				if strings.HasPrefix(respError.Message, "Billing Error") {
 					return resp, &BillingError{Message: respError.Message}
 				}
 				return resp, &ForbiddenError{Message: respError.Message}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -346,9 +346,13 @@ func TestDoWithRetry_403(t *testing.T) {
 		URL:    svr.URL,
 	}, nil)
 
-	// it returns immediately with the 403 status code.
+	// it returns immediately with ForbiddenError and the 403 status code.
 	if requestCount > 1 {
 		t.Errorf("http request count = %v, want %d", requestCount, 1)
+	}
+
+	if forbiddenError := new(ForbiddenError); !errors.As(err, &forbiddenError) {
+		t.Errorf("DoWithRetry() error type = %T, want %T", err, ForbiddenError{})
 	}
 
 	if err.Error() != "forbidden" {
@@ -357,6 +361,120 @@ func TestDoWithRetry_403(t *testing.T) {
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestDoWithRetry_401(t *testing.T) {
+	requestCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message": "Unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "bad-token",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+		Method: http.MethodGet,
+		URL:    svr.URL,
+	}, nil)
+
+	if requestCount > 1 {
+		t.Errorf("http request count = %v, want %d", requestCount, 1)
+	}
+
+	if authError := new(AuthError); !errors.As(err, &authError) {
+		t.Errorf("DoWithRetry() error type = %T, want %T", err, AuthError{})
+	}
+
+	if err.Error() != "Unauthorized" {
+		t.Errorf("DoWithRetry() error = %v, want %v", err, "Unauthorized")
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestDoWithRetry_404(t *testing.T) {
+	requestCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message": "Not Found"}`, http.StatusNotFound)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+		Method: http.MethodGet,
+		URL:    svr.URL,
+	}, nil)
+
+	if requestCount > 1 {
+		t.Errorf("http request count = %v, want %d", requestCount, 1)
+	}
+
+	if notFoundError := new(NotFoundError); !errors.As(err, &notFoundError) {
+		t.Errorf("DoWithRetry() error type = %T, want %T", err, NotFoundError{})
+	}
+
+	if err.Error() != "Not Found" {
+		t.Errorf("DoWithRetry() error = %v, want %v", err, "Not Found")
+	}
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestDoWithRetry_400(t *testing.T) {
+	requestCount := 0
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, `{"message": "Bad Request"}`, http.StatusBadRequest)
+	}))
+	defer svr.Close()
+
+	cfg := ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "my-org",
+		ServerBaseUrl:    svr.URL,
+	}
+
+	c := NewClient(cfg)
+	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+		Method: http.MethodGet,
+		URL:    svr.URL,
+	}, nil)
+
+	if requestCount > 1 {
+		t.Errorf("http request count = %v, want %d", requestCount, 1)
+	}
+
+	if badRequestError := new(BadRequestError); !errors.As(err, &badRequestError) {
+		t.Errorf("DoWithRetry() error type = %T, want %T", err, BadRequestError{})
+	}
+
+	if err.Error() != "Bad Request" {
+		t.Errorf("DoWithRetry() error = %v, want %v", err, "Bad Request")
+	}
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -22,7 +22,8 @@ func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier 
 	}, &testPlan)
 
 	if err != nil {
-		if errors.As(err, new(*NotFoundError)) {
+		var notFoundErr *NotFoundError
+		if errors.As(err, &notFoundErr) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,13 +16,13 @@ func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier 
 
 	var testPlan plan.TestPlan
 
-	resp, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.DoWithRetry(ctx, httpRequest{
 		Method: http.MethodGet,
 		URL:    url,
 	}, &testPlan)
 
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if errors.As(err, new(*NotFoundError)) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -13,7 +13,7 @@ import (
 // or the original error for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		fmt.Fprintln(os.Stderr, "⚠️ Could not fetch or create plan from server, falling back to non-intelligent splitting. Your build may take longer than usual.")
+		fmt.Fprintln(os.Stderr, "⚠️ Test Engine API timed out after 130s. Falling back to non-intelligent splitting. Your build may take longer than usual.")
 		return nil
 	}
 
@@ -21,6 +21,26 @@ func handleError(err error) error {
 		fmt.Fprintln(os.Stderr, billingError.Message+"\n")
 		fmt.Fprintln(os.Stderr, "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
 		return nil
+	}
+
+	if authError := new(api.AuthError); errors.As(err, &authError) {
+		fmt.Fprintln(os.Stderr, "❌ Invalid API token. Check BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN is set and valid. See https://buildkite.com/docs/apis/managing-api-tokens")
+		return err
+	}
+
+	if forbiddenError := new(api.ForbiddenError); errors.As(err, &forbiddenError) {
+		fmt.Fprintf(os.Stderr, "❌ Access denied: %s. Check your API token has the required scopes and organization access. See https://buildkite.com/docs/apis/managing-api-tokens\n", forbiddenError.Message)
+		return err
+	}
+
+	if errors.As(err, new(*api.NotFoundError)) {
+		fmt.Fprintln(os.Stderr, "⚠️ Suite not found. Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. Falling back to non-intelligent splitting.")
+		return nil
+	}
+
+	if badRequestError := new(api.BadRequestError); errors.As(err, &badRequestError) {
+		fmt.Fprintf(os.Stderr, "❌ Invalid request: %s\n", badRequestError.Message)
+		return err
 	}
 
 	return err

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -25,19 +25,23 @@ func ansi(code string) string {
 	return code
 }
 
-// warn prints a recoverable warning to stderr followed by an optional hint
+// printWarn prints a recoverable warning to stderr followed by an optional hint
 // and the fallback notice.
-func warn(label, message string, hints ...string) {
-	fmt.Fprintf(os.Stderr, "%s⚠️ %s:%s %s\n", colorYellow+colorBold, label, colorReset, message)
+func printWarn(label, message string, hints ...string) {
+	fmt.Fprintf(os.Stderr, "%s⚠️ %s: %s\n", colorYellow+colorBold, label, message)
 	for _, h := range hints {
-		fmt.Fprintln(os.Stderr, h)
+		fmt.Fprintln(os.Stderr, colorYellow+h+colorReset)
 	}
 	fmt.Fprintf(os.Stderr, "%s%s%s\n", colorYellow, fallbackExtra, colorReset)
 }
 
 // fatal formats an unrecoverable error message with red bold styling.
-func fatal(label, message string) error {
-	return fmt.Errorf("%s❌ %s:%s %s", colorRed+colorBold, label, colorReset, message)
+// When a is an error, it is wrapped so callers can use errors.Is/As.
+func fatal(label string, a any) error {
+	if e, ok := a.(error); ok {
+		return fmt.Errorf("%s❌ %s: %w%s", colorRed+colorBold, label, e, colorReset)
+	}
+	return fmt.Errorf("%s❌ %s: %v%s", colorRed+colorBold, label, a, colorReset)
 }
 
 // handleError classifies API errors and prints user-facing messages to stderr.
@@ -45,22 +49,26 @@ func fatal(label, message string) error {
 // or a fatal error with a formatted message for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		warn("Timeout", "Test Engine API timed out")
+		printWarn("Timeout", "Test Engine API timed out")
 		return nil
 	}
 
 	if billingError := new(api.BillingError); errors.As(err, &billingError) {
-		warn("Billing Error", billingError.Message)
+		printWarn("Billing Error", billingError.Message)
 		return nil
 	}
 
+	// 422 from the Test Engine API on plan endpoints indicates the API is
+	// administratively disabled for the org (ANALYTICS_DISABLE_API feature flag).
+	// Surface it as "Unavailable" since it's a temporary, server-side disable
+	// rather than a client-side validation problem.
 	if unprocessableError := new(api.UnprocessableEntityError); errors.As(err, &unprocessableError) {
-		warn("Unavailable", unprocessableError.Message)
+		printWarn("Unavailable", unprocessableError.Message)
 		return nil
 	}
 
 	if notFoundError := new(api.NotFoundError); errors.As(err, &notFoundError) {
-		warn("Not Found", notFoundError.Message, "Check BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG are correct.")
+		printWarn("Not Found", notFoundError.Message, "Check BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG are correct.")
 		return nil
 	}
 
@@ -76,9 +84,9 @@ func handleError(err error) error {
 		return fatal("Invalid Request", badRequestError.Message)
 	}
 
-	return fmt.Errorf("%s❌ Unexpected error:%s %w", colorRed+colorBold, colorReset, err)
+	return fatal("Unexpected error", err)
 }
 
 func warnErrorPlan() {
-	warn("Error Plan", "The Test Engine API failed to generate a plan.")
+	printWarn("Error Plan", "The Test Engine API failed to generate a plan.")
 }

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -10,9 +10,34 @@ import (
 
 const fallbackExtra = "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual."
 
-// warn prints a recoverable warning to stderr followed by the fallback notice.
-func warn(label, message string) {
-	fmt.Fprintf(os.Stderr, "⚠️ %s: %s\n%s\n", label, message, fallbackExtra)
+// ANSI color codes. Disabled when NO_COLOR is set (https://no-color.org).
+var (
+	colorRed    = ansi("\033[31m")
+	colorYellow = ansi("\033[33m")
+	colorBold   = ansi("\033[1m")
+	colorReset  = ansi("\033[0m")
+)
+
+func ansi(code string) string {
+	if os.Getenv("NO_COLOR") != "" {
+		return ""
+	}
+	return code
+}
+
+// warn prints a recoverable warning to stderr followed by an optional hint
+// and the fallback notice.
+func warn(label, message string, hints ...string) {
+	fmt.Fprintf(os.Stderr, "%s⚠️ %s:%s %s\n", colorYellow+colorBold, label, colorReset, message)
+	for _, h := range hints {
+		fmt.Fprintln(os.Stderr, h)
+	}
+	fmt.Fprintf(os.Stderr, "%s%s%s\n", colorYellow, fallbackExtra, colorReset)
+}
+
+// fatal formats an unrecoverable error message with red bold styling.
+func fatal(label, message string) error {
+	return fmt.Errorf("%s❌ %s:%s %s", colorRed+colorBold, label, colorReset, message)
 }
 
 // handleError classifies API errors and prints user-facing messages to stderr.
@@ -35,25 +60,25 @@ func handleError(err error) error {
 	}
 
 	if notFoundError := new(api.NotFoundError); errors.As(err, &notFoundError) {
-		fmt.Fprintf(os.Stderr, "⚠️ Not Found: %s\nCheck BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG are correct.\n%s\n", notFoundError.Message, fallbackExtra)
+		warn("Not Found", notFoundError.Message, "Check BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG are correct.")
 		return nil
 	}
 
 	if authError := new(api.AuthError); errors.As(err, &authError) {
-		return fmt.Errorf("❌ Authentication Failed: %s", authError.Message)
+		return fatal("Authentication Failed", authError.Message)
 	}
 
 	if forbiddenError := new(api.ForbiddenError); errors.As(err, &forbiddenError) {
-		return fmt.Errorf("❌ Access Denied: %s", forbiddenError.Message)
+		return fatal("Access Denied", forbiddenError.Message)
 	}
 
 	if badRequestError := new(api.BadRequestError); errors.As(err, &badRequestError) {
-		return fmt.Errorf("❌ Invalid Request: %s", badRequestError.Message)
+		return fatal("Invalid Request", badRequestError.Message)
 	}
 
-	return err
+	return fmt.Errorf("%s❌ Unexpected error:%s %w", colorRed+colorBold, colorReset, err)
 }
 
 func warnErrorPlan() {
-	fmt.Fprintf(os.Stderr, "⚠️ Error Plan: The Test Engine API failed to generate a plan.\n%s\n", fallbackExtra)
+	warn("Error Plan", "The Test Engine API failed to generate a plan.")
 }

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -8,69 +8,52 @@ import (
 	"github.com/buildkite/test-engine-client/internal/api"
 )
 
-type errorSeverity int
-
-const (
-	severityWarning errorSeverity = iota
-	severityFatal
-)
-
-func (s errorSeverity) icon() string {
-	if s == severityFatal {
-		return "❌"
-	}
-	return "⚠️"
-}
-
-// printError formats and prints a categorized error to stderr.
-// Format: icon error_type: message. fallbackMessage
-func printError(severity errorSeverity, errorType string, message string, fallbackMessage string) {
-	out := fmt.Sprintf("%s %s: %s", severity.icon(), errorType, message)
-	if fallbackMessage != "" {
-		out += "\n" + fallbackMessage
-	}
-	fmt.Fprintln(os.Stderr, out)
-}
-
 const fallbackExtra = "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual."
+
+// warn prints a recoverable warning to stderr followed by the fallback notice.
+func warn(label, message string) {
+	fmt.Fprintf(os.Stderr, "⚠️ %s: %s\n%s\n", label, message, fallbackExtra)
+}
 
 // handleError classifies API errors and prints user-facing messages to stderr.
 // Returns nil for recoverable errors (caller should fall back to non-intelligent splitting),
-// or the original error for unrecoverable failures.
+// or a fatal error with a formatted message for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		printError(severityWarning, "Timeout", "Test Engine API timed out", fallbackExtra)
+		warn("Timeout", "Test Engine API timed out")
 		return nil
 	}
 
 	if billingError := new(api.BillingError); errors.As(err, &billingError) {
-		printError(severityWarning, "Billing Error", billingError.Message, fallbackExtra)
+		warn("Billing Error", billingError.Message)
+		return nil
+	}
+
+	if unprocessableError := new(api.UnprocessableEntityError); errors.As(err, &unprocessableError) {
+		warn("Unavailable", unprocessableError.Message)
 		return nil
 	}
 
 	if notFoundError := new(api.NotFoundError); errors.As(err, &notFoundError) {
-		printError(severityWarning, "Not Found", notFoundError.Message, "Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. "+fallbackExtra)
+		fmt.Fprintf(os.Stderr, "⚠️ Not Found: %s\nCheck BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG are correct.\n%s\n", notFoundError.Message, fallbackExtra)
 		return nil
 	}
 
 	if authError := new(api.AuthError); errors.As(err, &authError) {
-		printError(severityFatal, "Authentication Failed", authError.Message, "")
-		return err
+		return fmt.Errorf("❌ Authentication Failed: %s", authError.Message)
 	}
 
 	if forbiddenError := new(api.ForbiddenError); errors.As(err, &forbiddenError) {
-		printError(severityFatal, "Access Denied", forbiddenError.Message, "")
-		return err
+		return fmt.Errorf("❌ Access Denied: %s", forbiddenError.Message)
 	}
 
 	if badRequestError := new(api.BadRequestError); errors.As(err, &badRequestError) {
-		printError(severityFatal, "Invalid Request", badRequestError.Message, "")
-		return err
+		return fmt.Errorf("❌ Invalid Request: %s", badRequestError.Message)
 	}
 
 	return err
 }
 
 func warnErrorPlan() {
-	printError(severityWarning, "Error Plan", "Server returned an error plan (possibly missing suite data or a server-side issue)", "Upload test results first to enable intelligent splitting. "+fallbackExtra)
+	fmt.Fprintf(os.Stderr, "⚠️ Error Plan: The Test Engine API failed to generate a plan.\n%s\n", fallbackExtra)
 }

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -13,7 +13,7 @@ import (
 // or the original error for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		fmt.Fprintln(os.Stderr, "⚠️ Test Engine API timed out after 130s. Falling back to non-intelligent splitting. Your build may take longer than usual.")
+		fmt.Fprintln(os.Stderr, "⚠️ Test Engine API timed out. Falling back to non-intelligent splitting. Your build may take longer than usual.")
 		return nil
 	}
 
@@ -23,19 +23,19 @@ func handleError(err error) error {
 		return nil
 	}
 
+	if notFoundError := new(api.NotFoundError); errors.As(err, &notFoundError) {
+		fmt.Fprintf(os.Stderr, "⚠️ Not found: %s. Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. Falling back to non-intelligent splitting.\n", notFoundError.Message)
+		return nil
+	}
+
 	if authError := new(api.AuthError); errors.As(err, &authError) {
-		fmt.Fprintln(os.Stderr, "❌ Invalid API token. Check BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN is set and valid. See https://buildkite.com/docs/apis/managing-api-tokens")
+		fmt.Fprintf(os.Stderr, "❌ Authentication failed: %s\n", authError.Message)
 		return err
 	}
 
 	if forbiddenError := new(api.ForbiddenError); errors.As(err, &forbiddenError) {
-		fmt.Fprintf(os.Stderr, "❌ Access denied: %s. Check your API token has the required scopes and organization access. See https://buildkite.com/docs/apis/managing-api-tokens\n", forbiddenError.Message)
+		fmt.Fprintf(os.Stderr, "❌ Access denied: %s\n", forbiddenError.Message)
 		return err
-	}
-
-	if errors.As(err, new(*api.NotFoundError)) {
-		fmt.Fprintln(os.Stderr, "⚠️ Suite not found. Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. Falling back to non-intelligent splitting.")
-		return nil
 	}
 
 	if badRequestError := new(api.BadRequestError); errors.As(err, &badRequestError) {
@@ -44,4 +44,8 @@ func handleError(err error) error {
 	}
 
 	return err
+}
+
+func warnErrorPlan() {
+	fmt.Fprintln(os.Stderr, "⚠️ Server returned an error plan (possibly missing suite data or a server-side issue). Falling back to non-intelligent splitting. Upload test results first to enable intelligent splitting.")
 }

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -8,38 +8,63 @@ import (
 	"github.com/buildkite/test-engine-client/internal/api"
 )
 
-// handleError classifies API errors and prints user-facing warnings to stderr.
+type errorSeverity int
+
+const (
+	severityWarning errorSeverity = iota
+	severityFatal
+)
+
+func (s errorSeverity) icon() string {
+	if s == severityFatal {
+		return "❌"
+	}
+	return "⚠️"
+}
+
+// printError formats and prints a categorized error to stderr.
+// Format: icon error_type: message. fallbackMessage
+func printError(severity errorSeverity, errorType string, message string, fallbackMessage string) {
+	out := fmt.Sprintf("%s %s: %s", severity.icon(), errorType, message)
+	if fallbackMessage != "" {
+		out += "\n" + fallbackMessage
+	}
+	fmt.Fprintln(os.Stderr, out)
+}
+
+const fallbackExtra = "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual."
+
+// handleError classifies API errors and prints user-facing messages to stderr.
 // Returns nil for recoverable errors (caller should fall back to non-intelligent splitting),
 // or the original error for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		fmt.Fprintln(os.Stderr, "⚠️ Test Engine API timed out. Falling back to non-intelligent splitting. Your build may take longer than usual.")
+		printError(severityWarning, "Timeout", "Test Engine API timed out", fallbackExtra)
 		return nil
 	}
 
 	if billingError := new(api.BillingError); errors.As(err, &billingError) {
-		fmt.Fprintln(os.Stderr, billingError.Message+"\n")
-		fmt.Fprintln(os.Stderr, "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual.")
+		printError(severityWarning, "Billing Error", billingError.Message, fallbackExtra)
 		return nil
 	}
 
 	if notFoundError := new(api.NotFoundError); errors.As(err, &notFoundError) {
-		fmt.Fprintf(os.Stderr, "⚠️ Not found: %s. Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. Falling back to non-intelligent splitting.\n", notFoundError.Message)
+		printError(severityWarning, "Not Found", notFoundError.Message, "Check BUILDKITE_TEST_ENGINE_SUITE_SLUG is correct. "+fallbackExtra)
 		return nil
 	}
 
 	if authError := new(api.AuthError); errors.As(err, &authError) {
-		fmt.Fprintf(os.Stderr, "❌ Authentication failed: %s\n", authError.Message)
+		printError(severityFatal, "Authentication Failed", authError.Message, "")
 		return err
 	}
 
 	if forbiddenError := new(api.ForbiddenError); errors.As(err, &forbiddenError) {
-		fmt.Fprintf(os.Stderr, "❌ Access denied: %s\n", forbiddenError.Message)
+		printError(severityFatal, "Access Denied", forbiddenError.Message, "")
 		return err
 	}
 
 	if badRequestError := new(api.BadRequestError); errors.As(err, &badRequestError) {
-		fmt.Fprintf(os.Stderr, "❌ Invalid request: %s\n", badRequestError.Message)
+		printError(severityFatal, "Invalid Request", badRequestError.Message, "")
 		return err
 	}
 
@@ -47,5 +72,5 @@ func handleError(err error) error {
 }
 
 func warnErrorPlan() {
-	fmt.Fprintln(os.Stderr, "⚠️ Server returned an error plan (possibly missing suite data or a server-side issue). Falling back to non-intelligent splitting. Upload test results first to enable intelligent splitting.")
+	printError(severityWarning, "Error Plan", "Server returned an error plan (possibly missing suite data or a server-side issue)", "Upload test results first to enable intelligent splitting. "+fallbackExtra)
 }

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -16,6 +16,7 @@ func TestHandleError_RetryTimeout(t *testing.T) {
 	assert.Nil(t, err)
 
 	stderr := getStderr()
+	assert.Contains(t, stderr, "⚠️ Timeout:")
 	assert.Contains(t, stderr, "Test Engine API timed out")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
@@ -29,6 +30,7 @@ func TestHandleError_BillingError(t *testing.T) {
 	assert.Nil(t, err)
 
 	stderr := getStderr()
+	assert.Contains(t, stderr, "⚠️ Billing Error:")
 	assert.Contains(t, stderr, "Billing Error: please update your plan")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
@@ -42,7 +44,7 @@ func TestHandleError_AuthError(t *testing.T) {
 	assert.Equal(t, authErr, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Authentication failed")
+	assert.Contains(t, stderr, "❌ Authentication Failed:")
 	assert.Contains(t, stderr, "Authentication required. Please supply a valid API Access Token")
 }
 
@@ -55,7 +57,7 @@ func TestHandleError_ForbiddenError(t *testing.T) {
 	assert.Equal(t, forbiddenErr, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Access denied")
+	assert.Contains(t, stderr, "❌ Access Denied:")
 	assert.Contains(t, stderr, "Your access token doesn't have the read_suites scope")
 }
 
@@ -68,7 +70,8 @@ func TestHandleError_NotFoundError(t *testing.T) {
 	assert.Nil(t, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Not found: No suite found")
+	assert.Contains(t, stderr, "⚠️ Not Found:")
+	assert.Contains(t, stderr, "No suite found")
 	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_SUITE_SLUG")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
@@ -82,7 +85,7 @@ func TestHandleError_BadRequestError(t *testing.T) {
 	assert.Equal(t, badReqErr, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Invalid request")
+	assert.Contains(t, stderr, "❌ Invalid Request:")
 	assert.Contains(t, stderr, "Invalid parameters")
 }
 
@@ -96,4 +99,16 @@ func TestHandleError_UnknownError(t *testing.T) {
 
 	stderr := getStderr()
 	assert.Empty(t, stderr)
+}
+
+func TestWarnErrorPlan(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	warnErrorPlan()
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "⚠️ Error Plan:")
+	assert.Contains(t, stderr, "Server returned an error plan")
+	assert.Contains(t, stderr, "Upload test results first")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -83,7 +83,10 @@ func TestHandleError_UnknownError(t *testing.T) {
 	originalErr := fmt.Errorf("something unexpected")
 	err := handleError(originalErr)
 
-	assert.Equal(t, originalErr, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Unexpected error:")
+	assert.Contains(t, err.Error(), "something unexpected")
+	assert.ErrorIs(t, err, originalErr)
 
 	stderr := getStderr()
 	assert.Empty(t, stderr)

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -16,8 +16,8 @@ func TestHandleError_RetryTimeout(t *testing.T) {
 	assert.Nil(t, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Could not fetch or create plan from server")
-	assert.Contains(t, stderr, "falling back to non-intelligent splitting")
+	assert.Contains(t, stderr, "Test Engine API timed out after 130s")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
 
 func TestHandleError_BillingError(t *testing.T) {
@@ -31,6 +31,61 @@ func TestHandleError_BillingError(t *testing.T) {
 	stderr := getStderr()
 	assert.Contains(t, stderr, "Billing Error: please update your plan")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
+func TestHandleError_AuthError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	authErr := &api.AuthError{Message: "Unauthorized"}
+	err := handleError(authErr)
+
+	assert.Equal(t, authErr, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Invalid API token")
+	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
+	assert.Contains(t, stderr, "https://buildkite.com/docs/apis/managing-api-tokens")
+}
+
+func TestHandleError_ForbiddenError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	forbiddenErr := &api.ForbiddenError{Message: "Your access token doesn't have the read_suites scope"}
+	err := handleError(forbiddenErr)
+
+	assert.Equal(t, forbiddenErr, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Access denied")
+	assert.Contains(t, stderr, "Your access token doesn't have the read_suites scope")
+	assert.Contains(t, stderr, "https://buildkite.com/docs/apis/managing-api-tokens")
+}
+
+func TestHandleError_NotFoundError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	notFoundErr := &api.NotFoundError{Message: "Not Found"}
+	err := handleError(notFoundErr)
+
+	assert.Nil(t, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Suite not found")
+	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_SUITE_SLUG")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
+func TestHandleError_BadRequestError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	badReqErr := &api.BadRequestError{Message: "Invalid parameters"}
+	err := handleError(badReqErr)
+
+	assert.Equal(t, badReqErr, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Invalid request")
+	assert.Contains(t, stderr, "Invalid parameters")
 }
 
 func TestHandleError_UnknownError(t *testing.T) {

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -16,7 +16,7 @@ func TestHandleError_RetryTimeout(t *testing.T) {
 	assert.Nil(t, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Test Engine API timed out after 130s")
+	assert.Contains(t, stderr, "Test Engine API timed out")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
 
@@ -36,15 +36,14 @@ func TestHandleError_BillingError(t *testing.T) {
 func TestHandleError_AuthError(t *testing.T) {
 	getStderr := captureStderr(t)
 
-	authErr := &api.AuthError{Message: "Unauthorized"}
+	authErr := &api.AuthError{Message: "Authentication required. Please supply a valid API Access Token: https://buildkite.com/docs/apis/rest-api#authentication"}
 	err := handleError(authErr)
 
 	assert.Equal(t, authErr, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Invalid API token")
-	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN")
-	assert.Contains(t, stderr, "https://buildkite.com/docs/apis/managing-api-tokens")
+	assert.Contains(t, stderr, "Authentication failed")
+	assert.Contains(t, stderr, "Authentication required. Please supply a valid API Access Token")
 }
 
 func TestHandleError_ForbiddenError(t *testing.T) {
@@ -58,19 +57,18 @@ func TestHandleError_ForbiddenError(t *testing.T) {
 	stderr := getStderr()
 	assert.Contains(t, stderr, "Access denied")
 	assert.Contains(t, stderr, "Your access token doesn't have the read_suites scope")
-	assert.Contains(t, stderr, "https://buildkite.com/docs/apis/managing-api-tokens")
 }
 
 func TestHandleError_NotFoundError(t *testing.T) {
 	getStderr := captureStderr(t)
 
-	notFoundErr := &api.NotFoundError{Message: "Not Found"}
+	notFoundErr := &api.NotFoundError{Message: "No suite found"}
 	err := handleError(notFoundErr)
 
 	assert.Nil(t, err)
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Suite not found")
+	assert.Contains(t, stderr, "Not found: No suite found")
 	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_SUITE_SLUG")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -36,29 +36,21 @@ func TestHandleError_BillingError(t *testing.T) {
 }
 
 func TestHandleError_AuthError(t *testing.T) {
-	getStderr := captureStderr(t)
-
 	authErr := &api.AuthError{Message: "Authentication required. Please supply a valid API Access Token: https://buildkite.com/docs/apis/rest-api#authentication"}
 	err := handleError(authErr)
 
-	assert.Equal(t, authErr, err)
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "❌ Authentication Failed:")
-	assert.Contains(t, stderr, "Authentication required. Please supply a valid API Access Token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Authentication Failed:")
+	assert.Contains(t, err.Error(), "Authentication required. Please supply a valid API Access Token")
 }
 
 func TestHandleError_ForbiddenError(t *testing.T) {
-	getStderr := captureStderr(t)
-
 	forbiddenErr := &api.ForbiddenError{Message: "Your access token doesn't have the read_suites scope"}
 	err := handleError(forbiddenErr)
 
-	assert.Equal(t, forbiddenErr, err)
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "❌ Access Denied:")
-	assert.Contains(t, stderr, "Your access token doesn't have the read_suites scope")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Access Denied:")
+	assert.Contains(t, err.Error(), "Your access token doesn't have the read_suites scope")
 }
 
 func TestHandleError_NotFoundError(t *testing.T) {
@@ -72,21 +64,17 @@ func TestHandleError_NotFoundError(t *testing.T) {
 	stderr := getStderr()
 	assert.Contains(t, stderr, "⚠️ Not Found:")
 	assert.Contains(t, stderr, "No suite found")
-	assert.Contains(t, stderr, "BUILDKITE_TEST_ENGINE_SUITE_SLUG")
+	assert.Contains(t, stderr, "BUILDKITE_ORGANIZATION_SLUG and BUILDKITE_TEST_ENGINE_SUITE_SLUG")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
 
 func TestHandleError_BadRequestError(t *testing.T) {
-	getStderr := captureStderr(t)
-
 	badReqErr := &api.BadRequestError{Message: "Invalid parameters"}
 	err := handleError(badReqErr)
 
-	assert.Equal(t, badReqErr, err)
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "❌ Invalid Request:")
-	assert.Contains(t, stderr, "Invalid parameters")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Invalid Request:")
+	assert.Contains(t, err.Error(), "Invalid parameters")
 }
 
 func TestHandleError_UnknownError(t *testing.T) {
@@ -108,7 +96,6 @@ func TestWarnErrorPlan(t *testing.T) {
 
 	stderr := getStderr()
 	assert.Contains(t, stderr, "⚠️ Error Plan:")
-	assert.Contains(t, stderr, "Server returned an error plan")
-	assert.Contains(t, stderr, "Upload test results first")
+	assert.Contains(t, stderr, "Test Engine API failed to generate a plan")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -62,7 +62,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	testPlan, err := createTestPlan(ctx, cfg, files, apiClient, testRunner)
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
-			return fmt.Errorf("create test plan failed: %w", err)
+			return fmt.Errorf("create test plan failed: %w", handledErr)
 		}
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -165,7 +165,7 @@ func createTestPlan(ctx context.Context, cfg *config.Config, files []string, api
 func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.GitRunner) {
 	// Check if we're in a git repo
 	if _, err := runner.Output(ctx, "rev-parse", "--git-dir"); err != nil {
-		fmt.Fprintln(os.Stderr, "Warning: not a git repository, skipping metadata auto-collection")
+		fmt.Fprintln(os.Stderr, "⚠️ Not a git repository, skipping metadata auto-collection.")
 		return
 	}
 
@@ -174,7 +174,7 @@ func autoCollectGitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	remote := cfg.Remote
 	baseBranch, err := git.ResolveBaseBranch(ctx, runner, explicit, remote)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Warning: could not resolve base branch for diff metadata. "+
+		fmt.Fprintln(os.Stderr, "⚠️ Could not resolve base branch for diff metadata. "+
 			"Set --metadata base_branch=<branch> if your repo uses a non-standard default branch.")
 	} else {
 		debug.Printf("auto-detected base branch: %s", baseBranch)

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -62,7 +62,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	testPlan, err := createTestPlan(ctx, cfg, files, apiClient, testRunner)
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
-			return fmt.Errorf("create test plan failed: %w", handledErr)
+			return handledErr
 		}
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -149,6 +149,13 @@ func createTestPlan(ctx context.Context, cfg *config.Config, files []string, api
 		return fallbackPlan, err
 	}
 
+	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
+	// In this case, we should create a fallback plan.
+	if len(testPlan.Tasks) == 0 {
+		warnErrorPlan()
+		return fallbackPlan, nil
+	}
+
 	return testPlan, nil
 }
 

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -303,7 +303,9 @@ called with testtemplate.yml
 func getZeroParallelismServer() *httptest.Server {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not found"}`))
 			return
 		}
 
@@ -317,11 +319,15 @@ func getZeroParallelismServer() *httptest.Server {
 			testPlan := plan.TestPlan{
 				Identifier:  "facecafe",
 				Parallelism: 0,
-				Tasks:       map[string]*plan.Task{},
+				Tasks: map[string]*plan.Task{
+					"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "testdata/rspec/spec/fruits/apple_spec.rb"}}},
+				},
 			}
 			enc.Encode(testPlan)
 		default:
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not found"}`))
 		}
 	}))
 	return svr
@@ -330,7 +336,9 @@ func getZeroParallelismServer() *httptest.Server {
 func getHttptestServer() *httptest.Server {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not found"}`))
 			return
 		}
 
@@ -344,6 +352,9 @@ func getHttptestServer() *httptest.Server {
 			testPlan := plan.TestPlan{
 				Identifier:  "facecafe",
 				Parallelism: 42,
+				Tasks: map[string]*plan.Task{
+					"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "testdata/rspec/spec/fruits/apple_spec.rb"}}},
+				},
 			}
 			enc.Encode(testPlan)
 		default:

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -492,7 +492,7 @@ func TestPlan_CollectGitMetadataWithoutSelection(t *testing.T) {
 	// The auto-collection should have been triggered. In a test environment
 	// without a git repo, it will warn and skip, but the important thing is
 	// that the code path was entered (the warning proves the gate was passed).
-	if !strings.Contains(stderrOutput, "not a git repository") &&
+	if !strings.Contains(stderrOutput, "Not a git repository") &&
 		!strings.Contains(stderrOutput, "auto-detected base branch") {
 		// If we're in a git repo (test runs inside a git checkout), we'll
 		// see metadata in the request body instead.
@@ -556,7 +556,7 @@ func TestPlan_NoCollectGitMetadataByDefault(t *testing.T) {
 	}
 
 	// Auto-collection should NOT have run -- no git warnings expected
-	if strings.Contains(stderrOutput, "not a git repository") ||
+	if strings.Contains(stderrOutput, "Not a git repository") ||
 		strings.Contains(stderrOutput, "auto-detected base branch") ||
 		strings.Contains(stderrOutput, "skipping metadata auto-collection") {
 		t.Errorf("auto-collection should not run when both SelectionStrategy and CollectGitMetadata are unset, stderr: %s", stderrOutput)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
-		return fmt.Errorf("couldn't fetch or create test plan: %w", err)
+		return err
 	}
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -324,9 +324,8 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 		// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
-			fmt.Println("⚠️ Error plan received, falling back to non-intelligent splitting. Your build may take longer than usual.")
-			testPlan := plan.CreateFallbackPlan(files, cfg.Parallelism)
-			return testPlan, nil
+			warnErrorPlan()
+			return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
 		}
 
 		debug.Printf("Test plan found. Identifier: %q", cfg.Identifier)
@@ -356,9 +355,8 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
-		fmt.Println("⚠️ Error plan received, falling back to non-intelligent splitting. Your build may take longer than usual.")
-		testPlan = plan.CreateFallbackPlan(files, cfg.Parallelism)
-		return testPlan, nil
+		warnErrorPlan()
+		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
 	}
 
 	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -396,7 +396,9 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// simulate cache miss for GET test_plan so it will trigger the test plan creation
 		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message": "Not Found"}`)
 		} else {
 			fmt.Fprint(w, response)
 		}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -521,6 +521,8 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	}))
 	defer svr.Close()
 
+	getStderr := captureStderr(t)
+
 	ctx := context.Background()
 	cfg := config.Config{
 		NodeIndex:     0,
@@ -543,6 +545,9 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Server returned an error plan")
 }
 
 func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
@@ -554,6 +559,8 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}))
 	defer svr.Close()
+
+	getStderr := captureStderr(t)
 
 	// set the fetch timeout to 1 second so we don't wait too long
 	ctx := context.Background()
@@ -581,17 +588,24 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Test Engine API timed out")
 }
 
 func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	files := []string{"apple", "banana"}
 	testRunner := runner.Rspec{}
 
-	// mock server to return 400 Bad Request
+	// mock server to return 400 Bad Request with JSON body
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"message": "Invalid parameters: runner is required"}`)
 	}))
 	defer svr.Close()
+
+	getStderr := captureStderr(t)
 
 	ctx := context.Background()
 
@@ -613,9 +627,15 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
 	}
+	assert.ErrorAs(t, err, new(*api.BadRequestError))
+
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Invalid request")
+	assert.Contains(t, stderr, "Invalid parameters: runner is required")
 }
 
 func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
@@ -627,6 +647,8 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 		http.Error(w, `{"message": "Billing Error: please update your plan"}`, http.StatusForbidden)
 	}))
 	defer svr.Close()
+
+	getStderr := captureStderr(t)
 
 	ctx := context.Background()
 
@@ -651,6 +673,97 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Billing Error: please update your plan")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
+func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
+	files := []string{"apple", "banana"}
+	testRunner := runner.Rspec{}
+
+	// mock server to return 401 Unauthorized
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"message": "Authentication required. Please supply a valid API Access Token: https://buildkite.com/docs/apis/rest-api#authentication"}`)
+	}))
+	defer svr.Close()
+
+	getStderr := captureStderr(t)
+
+	ctx := context.Background()
+
+	cfg := config.Config{
+		NodeIndex:     0,
+		Parallelism:   2,
+		Identifier:    "identifier",
+		Branch:        "",
+		ServerBaseUrl: svr.URL,
+	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
+
+	want := plan.TestPlan{}
+
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	if err == nil {
+		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
+	}
+	assert.ErrorAs(t, err, new(*api.AuthError))
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
+	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Authentication failed")
+}
+
+func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
+	files := []string{"apple", "banana"}
+	testRunner := runner.Rspec{}
+
+	// mock server to return 403 with a non-billing forbidden error
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message": "Your access token doesn't have the write_suites scope"}`)
+	}))
+	defer svr.Close()
+
+	getStderr := captureStderr(t)
+
+	ctx := context.Background()
+
+	cfg := config.Config{
+		NodeIndex:     0,
+		Parallelism:   2,
+		Identifier:    "identifier",
+		Branch:        "",
+		ServerBaseUrl: svr.URL,
+	}
+	apiClient := api.NewClient(api.ClientConfig{
+		ServerBaseUrl: cfg.ServerBaseUrl,
+	})
+
+	want := plan.TestPlan{}
+
+	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	if err == nil {
+		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
+	}
+	assert.ErrorAs(t, err, new(*api.ForbiddenError))
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
+	}
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "Access denied")
+	assert.Contains(t, stderr, "Your access token doesn't have the write_suites scope")
 }
 
 func TestSendMetadata(t *testing.T) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -547,7 +547,7 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	}
 
 	stderr := getStderr()
-	assert.Contains(t, stderr, "Server returned an error plan")
+	assert.Contains(t, stderr, "Test Engine API failed to generate a plan")
 }
 
 func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
@@ -605,8 +605,6 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	getStderr := captureStderr(t)
-
 	ctx := context.Background()
 
 	cfg := config.Config{
@@ -627,15 +625,13 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
 	}
-	assert.ErrorAs(t, err, new(*api.BadRequestError))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Invalid Request:")
+	assert.Contains(t, err.Error(), "Invalid parameters: runner is required")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "Invalid request")
-	assert.Contains(t, stderr, "Invalid parameters: runner is required")
 }
 
 func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
@@ -691,8 +687,6 @@ func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	getStderr := captureStderr(t)
-
 	ctx := context.Background()
 
 	cfg := config.Config{
@@ -712,14 +706,13 @@ func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
 	}
-	assert.ErrorAs(t, err, new(*api.AuthError))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Authentication Failed:")
+	assert.Contains(t, err.Error(), "Authentication required. Please supply a valid API Access Token")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "Authentication failed")
 }
 
 func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
@@ -734,8 +727,6 @@ func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	getStderr := captureStderr(t)
-
 	ctx := context.Background()
 
 	cfg := config.Config{
@@ -755,15 +746,13 @@ func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
 	if err == nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
 	}
-	assert.ErrorAs(t, err, new(*api.ForbiddenError))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "❌ Access Denied:")
+	assert.Contains(t, err.Error(), "Your access token doesn't have the write_suites scope")
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
-
-	stderr := getStderr()
-	assert.Contains(t, stderr, "Access denied")
-	assert.Contains(t, stderr, "Your access token doesn't have the write_suites scope")
 }
 
 func TestSendMetadata(t *testing.T) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -622,9 +622,6 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	want := plan.TestPlan{}
 
 	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
-	if err == nil {
-		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got %v", cfg, files, err)
-	}
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Invalid Request:")
 	assert.Contains(t, err.Error(), "Invalid parameters: runner is required")
@@ -703,9 +700,6 @@ func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
 	want := plan.TestPlan{}
 
 	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
-	if err == nil {
-		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
-	}
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Authentication Failed:")
 	assert.Contains(t, err.Error(), "Authentication required. Please supply a valid API Access Token")
@@ -743,9 +737,6 @@ func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
 	want := plan.TestPlan{}
 
 	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
-	if err == nil {
-		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) want error, got nil", cfg, files)
-	}
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Access Denied:")
 	assert.Contains(t, err.Error(), "Your access token doesn't have the write_suites scope")


### PR DESCRIPTION
### Description

A lot of fallback scenarios currently surface the same generic message: *"Could not fetch or create plan from server, falling back to non-intelligent splitting."* Users have no way to tell whether they're hitting a timeout, a billing issue, a missing suite, or an auth failure, and no indication of what to do next.

This PR replaces that catch-all with differentiated messages per failure mode. The API client now classifies non-2xx responses into typed errors (`AuthError`, `ForbiddenError`, `NotFoundError`, `BadRequestError`, `UnprocessableEntityError`, plus the existing `BillingError`). 
`handleError` maps each type to either:

- A **recoverable warning** with a fallback notice (timeout, billing, 422, 404. Build proceeds with non-intelligent splitting), or
- A **fatal error** that stops the build (401 auth, 403 access denied, 400 invalid request) so the user fixes the underlying problem.

Output is also colorized (yellow ⚠️ for warnings, red ❌ for fatal errors), with `NO_COLOR` honoured.

### Context

- Linear: [TE-5667](https://linear.app/buildkite/issue/TE-5667)
- Investigation doc: [Improving Test Splitting Communication](https://www.notion.so/buildkite/Improving-Test-Splitting-Communication-348b8dbc2c8980c78143c2e648d9edd3)

### Changes

- `internal/api/client.go`: new typed errors (`AuthError`, `ForbiddenError`, `NotFoundError`, `BadRequestError`, `UnprocessableEntityError`); `DoWithRetry` switches on `resp.StatusCode` to return the right type.
- `internal/api/fetch_test_plan.go`: uses `errors.As` instead of inspecting `resp.StatusCode`.
- `internal/command/errors.go`: `handleError` classifies each typed error and prints a labelled, coloured message; new `warn()` and `fatal()` helpers; `warnErrorPlan()` consolidates the empty-task-list fallback message.
- `internal/command/run.go`, `plan.go`: use the shared helpers; `Run`/`Plan` no longer wrap the returned error so the formatted `❌` message reaches the user verbatim.
- Tests added for each typed error path in both `internal/api` and `internal/command`.

#### Example output

**Error**
<img width="1156" height="226" alt="Screenshot 2026-04-28 at 3 33 25 PM" src="https://github.com/user-attachments/assets/673d6c5a-09cb-405f-bbb7-6fbbbe71ce42" />

**Warning**
<img width="1134" height="146" alt="Screenshot 2026-04-28 at 3 33 41 PM" src="https://github.com/user-attachments/assets/894654de-384e-4e9d-87dc-2f30de000ef1" />

### Testing

- Unit tests added for each typed error in `internal/api/client_test.go`, `internal/command/errors_test.go`, and `internal/command/run_test.go`.
- Manual: triggered each failure mode against a local mock server and confirmed messages render correctly with and without `NO_COLOR`
