### PR TITLE
[TE-5706] Print split summary to stderr from plan and run commands

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -72,6 +72,8 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	}
 
+	plan.PrintSplitSummary(os.Stderr, testPlan)
+
 	switch outputFormat {
 
 	case PlanOutputJSON:

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -68,6 +68,8 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
+	plan.PrintSplitSummary(os.Stderr, testPlan)
+
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -68,7 +68,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
-	plan.PrintSplitSummary(os.Stderr, testPlan)
+	plan.PrintSplitSummary(os.Stdout, testPlan)
 
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -1,0 +1,81 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// PrintSplitSummary writes a human-readable summary of the resolved test plan
+// to w (typically os.Stderr). It is a no-op when the plan does not carry
+// timing metadata (fallback plans, error plans, or cached plans created
+// before the server began emitting timing_metadata).
+func PrintSplitSummary(w io.Writer, p TestPlan) {
+	if p.Fallback || p.TimingMetadata == nil {
+		return
+	}
+
+	total := 0
+	known := 0
+	exampleMode := false
+	for _, task := range p.Tasks {
+		for _, tc := range task.Tests {
+			total++
+			if tc.TimingSampleSize > 0 {
+				known++
+			}
+			if tc.Format == TestCaseFormatExample {
+				exampleMode = true
+			}
+		}
+	}
+	if total == 0 {
+		return
+	}
+
+	noun := "files"
+	if exampleMode {
+		noun = "examples"
+	}
+
+	nodes := p.Parallelism
+	if nodes == 0 {
+		nodes = len(p.Tasks)
+	}
+
+	fmt.Fprintln(w, "\n+++ Buildkite Test Engine Client: 📊 Split summary")
+	fmt.Fprintf(w, "%d %s across %d nodes\n", total, noun, nodes)
+
+	width := len(strconv.Itoa(total))
+
+	if known == 0 {
+		fmt.Fprintf(w, "  %*d %s (100%%) had no history and used the default duration (%s)\n\n",
+			width, total, noun, formatDurationMS(p.TimingMetadata.DefaultDuration))
+		return
+	}
+
+	unknown := total - known
+	fmt.Fprintf(w, "  %*d %s (%d%%) estimated from past historical durations\n", width, known, noun, percentOf(known, total))
+	if unknown > 0 {
+		median := "unknown"
+		if p.TimingMetadata.MedianDuration != nil {
+			median = formatDurationMS(*p.TimingMetadata.MedianDuration)
+		}
+		fmt.Fprintf(w, "  %*d %s (%d%%) had no history — assumed median (%s)\n", width, unknown, noun, percentOf(unknown, total), median)
+	}
+	fmt.Fprintln(w)
+}
+
+func percentOf(n, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return n * 100 / total
+}
+
+func formatDurationMS(ms float64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", int(ms+0.5))
+	}
+	return fmt.Sprintf("%.1fs", ms/1000.0)
+}

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -7,11 +7,13 @@ import (
 )
 
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
-// to w (typically os.Stderr). It is a no-op when the plan does not carry
-// timing metadata (fallback plans, error plans, or cached plans created
-// before the server began emitting timing_metadata).
+// to w (typically os.Stderr). At parallelism > 1 it uses per-format
+// TimingMetadata to break down known vs unknown cases. At parallelism == 1
+// the server skips per-format timing data due to performance reasons, so it falls back to the
+// plan-level KnownTimingsRatio. Skipped for fallback plans, or when neither
+// signal is available.
 func PrintSplitSummary(w io.Writer, p TestPlan) {
-	if p.Fallback || p.TimingMetadata == nil {
+	if p.Fallback || (p.TimingMetadata == nil && p.KnownTimingsRatio == nil) {
 		return
 	}
 
@@ -32,7 +34,8 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	noun := summaryNoun(fileTotal, exampleTotal)
 
 	fmt.Fprintln(w, "\n+++ Buildkite Test Engine Client: 📊 Split summary")
-	fmt.Fprintf(w, "%d %s across %d nodes\n", total, noun, nodes)
+	fmt.Fprintf(w, "%d %s across %d %s\n",
+		total, pluralize(total, noun), nodes, pluralize(nodes, "node"))
 
 	// At parallelism == 1 the server skips the per-format timing fetch, so
 	// per-case TimingSampleSize is always 0. Fall back to the plan-level
@@ -43,18 +46,24 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 		return
 	}
 
+	if p.TimingMetadata == nil {
+		fmt.Fprintln(w)
+		return
+	}
+
 	if fileTotal > 0 {
-		printFormatBreakdown(w, fileTotal, fileKnown, "files", p.TimingMetadata.File, mixed)
+		printFormatBreakdown(w, fileTotal, fileKnown, "file", p.TimingMetadata.File, mixed)
 	}
 	if exampleTotal > 0 {
-		printFormatBreakdown(w, exampleTotal, exampleKnown, "examples", p.TimingMetadata.Example, mixed)
+		printFormatBreakdown(w, exampleTotal, exampleKnown, "example", p.TimingMetadata.Example, mixed)
 	}
 	fmt.Fprintln(w)
 }
 
 // printRatioBreakdown renders a single-node summary using the plan-level
-// known_timings_ratio. The known/unknown split is rounded so the two lines
-// always sum to total.
+// known_timings_ratio. Per-format metadata is unavailable at parallelism == 1,
+// so it delegates to printFormatBreakdown with meta == nil; the breakdown text
+// is rendered without parenthesised duration values.
 func printRatioBreakdown(w io.Writer, total int, ratio float64, noun string) {
 	known := int(float64(total)*ratio + 0.5)
 	if known > total {
@@ -63,17 +72,7 @@ func printRatioBreakdown(w io.Writer, total int, ratio float64, noun string) {
 	if known < 0 {
 		known = 0
 	}
-	unknown := total - known
-	width := len(strconv.Itoa(total))
-
-	if known > 0 {
-		fmt.Fprintf(w, "  %*d %s (%d%%) estimated from past historical durations\n",
-			width, known, noun, percentOf(known, total))
-	}
-	if unknown > 0 {
-		fmt.Fprintf(w, "  %*d %s (%d%%) had no history\n",
-			width, unknown, noun, percentOf(unknown, total))
-	}
+	printFormatBreakdown(w, total, known, noun, nil, false)
 }
 
 // countByFormat returns (total, known) for cases of the given format. The
@@ -97,52 +96,63 @@ func countByFormat(p TestPlan, format TestCaseFormat) (total, known int) {
 	return total, known
 }
 
-// summaryNoun picks the heading noun when the plan only contains one format,
-// or "tests" when both are present.
+// summaryNoun returns the singular heading noun. The plan-level summary uses
+// "file"/"example" when the plan only contains one format, or "test" when
+// both are present. Callers pluralize as needed.
 func summaryNoun(fileTotal, exampleTotal int) string {
 	switch {
 	case exampleTotal == 0:
-		return "files"
+		return "file"
 	case fileTotal == 0:
-		return "examples"
+		return "example"
 	default:
-		return "tests"
+		return "test"
 	}
 }
 
+// pluralize returns singular when n == 1, otherwise singular + "s".
+func pluralize(n int, singular string) string {
+	if n == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+// printFormatBreakdown writes the per-format lines. noun is the singular form
+// ("file" or "example"); each line is pluralized to match its own count.
 func printFormatBreakdown(w io.Writer, total, known int, noun string, meta *FormatTimingMetadata, mixed bool) {
 	indent := "  "
-	itemNoun := " " + noun
+	itemNounFor := func(n int) string { return " " + pluralize(n, noun) }
 	if mixed {
-		fmt.Fprintf(w, "  %d %s\n", total, noun)
+		fmt.Fprintf(w, "  %d %s\n", total, pluralize(total, noun))
 		indent = "    "
 		// In nested form the "files"/"examples" header carries the noun, so
 		// each line just shows counts.
-		itemNoun = ""
+		itemNounFor = func(int) string { return "" }
 	}
 
 	width := len(strconv.Itoa(total))
 
 	if known == 0 {
-		suffix := ""
+		suffix := " and used the default duration"
 		if meta != nil {
-			suffix = fmt.Sprintf(" and used the default duration (%s)", formatDurationMS(meta.DefaultDuration))
+			suffix += fmt.Sprintf(" (%s)", formatDurationMS(meta.DefaultDuration))
 		}
 		fmt.Fprintf(w, "%s%*d%s (100%%) had no history%s\n",
-			indent, width, total, itemNoun, suffix)
+			indent, width, total, itemNounFor(total), suffix)
 		return
 	}
 
 	unknown := total - known
 	fmt.Fprintf(w, "%s%*d%s (%d%%) estimated from past historical durations\n",
-		indent, width, known, itemNoun, percentOf(known, total))
+		indent, width, known, itemNounFor(known), percentOf(known, total))
 	if unknown > 0 {
 		suffix := ""
 		if meta != nil && meta.MedianDuration != nil {
 			suffix = fmt.Sprintf(" — assumed median (%s)", formatDurationMS(*meta.MedianDuration))
 		}
 		fmt.Fprintf(w, "%s%*d%s (%d%%) had no history%s\n",
-			indent, width, unknown, itemNoun, percentOf(unknown, total), suffix)
+			indent, width, unknown, itemNounFor(unknown), percentOf(unknown, total), suffix)
 	}
 }
 

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -26,10 +26,6 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	}
 
 	nodes := p.Parallelism
-	if nodes == 0 {
-		nodes = len(p.Tasks)
-	}
-
 	mixed := fileTotal > 0 && exampleTotal > 0
 	noun := summaryNoun(fileTotal, exampleTotal)
 
@@ -68,9 +64,6 @@ func printRatioBreakdown(w io.Writer, total int, ratio float64, noun string) {
 	known := int(float64(total)*ratio + 0.5)
 	if known > total {
 		known = total
-	}
-	if known < 0 {
-		known = 0
 	}
 	printFormatBreakdown(w, total, known, noun, nil, false)
 }

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -15,27 +15,12 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 		return
 	}
 
-	total := 0
-	known := 0
-	exampleMode := false
-	for _, task := range p.Tasks {
-		for _, tc := range task.Tests {
-			total++
-			if tc.TimingSampleSize > 0 {
-				known++
-			}
-			if tc.Format == TestCaseFormatExample {
-				exampleMode = true
-			}
-		}
-	}
+	fileTotal, fileKnown := countByFormat(p, TestCaseFormatFile)
+	exampleTotal, exampleKnown := countByFormat(p, TestCaseFormatExample)
+
+	total := fileTotal + exampleTotal
 	if total == 0 {
 		return
-	}
-
-	noun := "files"
-	if exampleMode {
-		noun = "examples"
 	}
 
 	nodes := p.Parallelism
@@ -43,27 +28,122 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 		nodes = len(p.Tasks)
 	}
 
+	mixed := fileTotal > 0 && exampleTotal > 0
+	noun := summaryNoun(fileTotal, exampleTotal)
+
 	fmt.Fprintln(w, "\n+++ Buildkite Test Engine Client: 📊 Split summary")
 	fmt.Fprintf(w, "%d %s across %d nodes\n", total, noun, nodes)
+
+	// At parallelism == 1 the server skips the per-format timing fetch, so
+	// per-case TimingSampleSize is always 0. Fall back to the plan-level
+	// known_timings_ratio for a meaningful breakdown.
+	if nodes <= 1 && p.KnownTimingsRatio != nil {
+		printRatioBreakdown(w, total, *p.KnownTimingsRatio, noun)
+		fmt.Fprintln(w)
+		return
+	}
+
+	if fileTotal > 0 {
+		printFormatBreakdown(w, fileTotal, fileKnown, "files", p.TimingMetadata.File, mixed)
+	}
+	if exampleTotal > 0 {
+		printFormatBreakdown(w, exampleTotal, exampleKnown, "examples", p.TimingMetadata.Example, mixed)
+	}
+	fmt.Fprintln(w)
+}
+
+// printRatioBreakdown renders a single-node summary using the plan-level
+// known_timings_ratio. The known/unknown split is rounded so the two lines
+// always sum to total.
+func printRatioBreakdown(w io.Writer, total int, ratio float64, noun string) {
+	known := int(float64(total)*ratio + 0.5)
+	if known > total {
+		known = total
+	}
+	if known < 0 {
+		known = 0
+	}
+	unknown := total - known
+	width := len(strconv.Itoa(total))
+
+	if known > 0 {
+		fmt.Fprintf(w, "  %*d %s (%d%%) estimated from past historical durations\n",
+			width, known, noun, percentOf(known, total))
+	}
+	if unknown > 0 {
+		fmt.Fprintf(w, "  %*d %s (%d%%) had no history\n",
+			width, unknown, noun, percentOf(unknown, total))
+	}
+}
+
+// countByFormat returns (total, known) for cases of the given format. The
+// empty (default) Format value is treated as TestCaseFormatFile.
+func countByFormat(p TestPlan, format TestCaseFormat) (total, known int) {
+	for _, task := range p.Tasks {
+		for _, tc := range task.Tests {
+			f := tc.Format
+			if f == "" {
+				f = TestCaseFormatFile
+			}
+			if f != format {
+				continue
+			}
+			total++
+			if tc.TimingSampleSize > 0 {
+				known++
+			}
+		}
+	}
+	return total, known
+}
+
+// summaryNoun picks the heading noun when the plan only contains one format,
+// or "tests" when both are present.
+func summaryNoun(fileTotal, exampleTotal int) string {
+	switch {
+	case exampleTotal == 0:
+		return "files"
+	case fileTotal == 0:
+		return "examples"
+	default:
+		return "tests"
+	}
+}
+
+func printFormatBreakdown(w io.Writer, total, known int, noun string, meta *FormatTimingMetadata, mixed bool) {
+	indent := "  "
+	itemNoun := " " + noun
+	if mixed {
+		fmt.Fprintf(w, "  %d %s\n", total, noun)
+		indent = "    "
+		// In nested form the "files"/"examples" header carries the noun, so
+		// each line just shows counts.
+		itemNoun = ""
+	}
 
 	width := len(strconv.Itoa(total))
 
 	if known == 0 {
-		fmt.Fprintf(w, "  %*d %s (100%%) had no history and used the default duration (%s)\n\n",
-			width, total, noun, formatDurationMS(p.TimingMetadata.DefaultDuration))
+		suffix := ""
+		if meta != nil {
+			suffix = fmt.Sprintf(" and used the default duration (%s)", formatDurationMS(meta.DefaultDuration))
+		}
+		fmt.Fprintf(w, "%s%*d%s (100%%) had no history%s\n",
+			indent, width, total, itemNoun, suffix)
 		return
 	}
 
 	unknown := total - known
-	fmt.Fprintf(w, "  %*d %s (%d%%) estimated from past historical durations\n", width, known, noun, percentOf(known, total))
+	fmt.Fprintf(w, "%s%*d%s (%d%%) estimated from past historical durations\n",
+		indent, width, known, itemNoun, percentOf(known, total))
 	if unknown > 0 {
-		median := "unknown"
-		if p.TimingMetadata.MedianDuration != nil {
-			median = formatDurationMS(*p.TimingMetadata.MedianDuration)
+		suffix := ""
+		if meta != nil && meta.MedianDuration != nil {
+			suffix = fmt.Sprintf(" — assumed median (%s)", formatDurationMS(*meta.MedianDuration))
 		}
-		fmt.Fprintf(w, "  %*d %s (%d%%) had no history — assumed median (%s)\n", width, unknown, noun, percentOf(unknown, total), median)
+		fmt.Fprintf(w, "%s%*d%s (%d%%) had no history%s\n",
+			indent, width, unknown, itemNoun, percentOf(unknown, total), suffix)
 	}
-	fmt.Fprintln(w)
 }
 
 func percentOf(n, total int) int {

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -1,0 +1,152 @@
+package plan
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func fp(v float64) *float64 { return &v }
+
+func TestPrintSplitSummary_MixedHistory(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a", TimingSampleSize: 5},
+				{Path: "b", TimingSampleSize: 3},
+				{Path: "c", TimingSampleSize: 0},
+			}},
+			"1": {NodeNumber: 1, Tests: []TestCase{
+				{Path: "d", TimingSampleSize: 1},
+				{Path: "e", TimingSampleSize: 0},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{MedianDuration: fp(4200), DefaultDuration: 1000},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"+++ Buildkite Test Engine Client: 📊 Split summary\n5 files across 2 nodes",
+		"3 files (60%) estimated from past historical durations",
+		"2 files (40%) had no history",
+		"4.2s",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintSplitSummary_NoHistory(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a"}, {Path: "b"}, {Path: "c"},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"+++ Buildkite Test Engine Client: 📊 Split summary\n3 files across 1 nodes",
+		"3 files (100%) had no history and used the default duration (1.0s)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "estimated from past") {
+		t.Errorf("unexpected estimated line in no-history output:\n%s", got)
+	}
+}
+
+func TestPrintSplitSummary_NullMedianWithUnknowns(t *testing.T) {
+	// In practice the server only sets median_duration=null when there is no
+	// history at all, but the client should still degrade gracefully.
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a", TimingSampleSize: 1},
+				{Path: "b", TimingSampleSize: 0},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	if !strings.Contains(got, "assumed median (unknown)") {
+		t.Errorf("expected fallback unknown median, got:\n%s", got)
+	}
+}
+
+func TestPrintSplitSummary_SkipsWhenNoMetadata(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}}},
+		},
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}
+
+func TestPrintSplitSummary_ExampleMode(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a[1]", Format: TestCaseFormatExample, TimingSampleSize: 4},
+				{Path: "a[2]", Format: TestCaseFormatExample, TimingSampleSize: 0},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{MedianDuration: fp(2000), DefaultDuration: 1000},
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 examples across 1 nodes",
+		"1 examples (50%) estimated from past historical durations",
+		"1 examples (50%) had no history",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, " files ") {
+		t.Errorf("expected no \"files\" in example-mode output, got:\n%s", got)
+	}
+}
+
+func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Fallback:    true,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}}},
+		},
+		TimingMetadata: &TimingMetadata{DefaultDuration: 1000},
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for fallback plan, got: %s", buf.String())
+	}
+}

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -34,8 +34,7 @@ func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 	for _, want := range []string{
 		"+++ Buildkite Test Engine Client: 📊 Split summary\n5 files across 2 nodes",
 		"3 files (60%) estimated from past historical durations",
-		"2 files (40%) had no history",
-		"4.2s",
+		"2 files (40%) had no history — assumed median (4.2s)",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -131,9 +130,9 @@ func TestPrintSplitSummary_ParallelismOneUsesKnownRatio(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"4 files across 1 nodes",
+		"4 files across 1 node",
 		"3 files (75%) estimated from past historical durations",
-		"1 files (25%) had no history",
+		"1 file (25%) had no history",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -184,8 +183,8 @@ func TestPrintSplitSummary_ExampleMode(t *testing.T) {
 
 	for _, want := range []string{
 		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 examples across 2 nodes",
-		"1 examples (50%) estimated from past historical durations",
-		"1 examples (50%) had no history",
+		"1 example (50%) estimated from past historical durations",
+		"1 example (50%) had no history",
 		"2.0s",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -22,7 +22,9 @@ func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 				{Path: "e", TimingSampleSize: 0},
 			}},
 		},
-		TimingMetadata: &TimingMetadata{MedianDuration: fp(4200), DefaultDuration: 1000},
+		TimingMetadata: &TimingMetadata{
+			File: &FormatTimingMetadata{MedianDuration: fp(4200), DefaultDuration: 1000},
+		},
 	}
 
 	var buf bytes.Buffer
@@ -43,13 +45,14 @@ func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 
 func TestPrintSplitSummary_NoHistory(t *testing.T) {
 	p := TestPlan{
-		Parallelism: 1,
+		Parallelism: 2,
 		Tasks: map[string]*Task{
-			"0": {NodeNumber: 0, Tests: []TestCase{
-				{Path: "a"}, {Path: "b"}, {Path: "c"},
-			}},
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}, {Path: "b"}}},
+			"1": {NodeNumber: 1, Tests: []TestCase{{Path: "c"}}},
 		},
-		TimingMetadata: &TimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+		TimingMetadata: &TimingMetadata{
+			File: &FormatTimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+		},
 	}
 
 	var buf bytes.Buffer
@@ -57,7 +60,7 @@ func TestPrintSplitSummary_NoHistory(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n3 files across 1 nodes",
+		"+++ Buildkite Test Engine Client: 📊 Split summary\n3 files across 2 nodes",
 		"3 files (100%) had no history and used the default duration (1.0s)",
 	} {
 		if !strings.Contains(got, want) {
@@ -73,22 +76,25 @@ func TestPrintSplitSummary_NullMedianWithUnknowns(t *testing.T) {
 	// In practice the server only sets median_duration=null when there is no
 	// history at all, but the client should still degrade gracefully.
 	p := TestPlan{
-		Parallelism: 1,
+		Parallelism: 2,
 		Tasks: map[string]*Task{
-			"0": {NodeNumber: 0, Tests: []TestCase{
-				{Path: "a", TimingSampleSize: 1},
-				{Path: "b", TimingSampleSize: 0},
-			}},
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a", TimingSampleSize: 1}}},
+			"1": {NodeNumber: 1, Tests: []TestCase{{Path: "b", TimingSampleSize: 0}}},
 		},
-		TimingMetadata: &TimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+		TimingMetadata: &TimingMetadata{
+			File: &FormatTimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+		},
 	}
 
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
 	got := buf.String()
 
-	if !strings.Contains(got, "assumed median (unknown)") {
-		t.Errorf("expected fallback unknown median, got:\n%s", got)
+	if strings.Contains(got, "assumed median") {
+		t.Errorf("expected no median when MedianDuration is nil, got:\n%s", got)
+	}
+	if !strings.Contains(got, "had no history\n") {
+		t.Errorf("expected bare \"had no history\" line, got:\n%s", got)
 	}
 }
 
@@ -106,25 +112,81 @@ func TestPrintSplitSummary_SkipsWhenNoMetadata(t *testing.T) {
 	}
 }
 
-func TestPrintSplitSummary_ExampleMode(t *testing.T) {
+func TestPrintSplitSummary_ParallelismOneUsesKnownRatio(t *testing.T) {
+	// At parallelism=1 the server skips per-format timing metadata, so the
+	// summary derives counts from the plan-level known_timings_ratio.
+	ratio := 0.75
 	p := TestPlan{
 		Parallelism: 1,
 		Tasks: map[string]*Task{
 			"0": {NodeNumber: 0, Tests: []TestCase{
-				{Path: "a[1]", Format: TestCaseFormatExample, TimingSampleSize: 4},
-				{Path: "a[2]", Format: TestCaseFormatExample, TimingSampleSize: 0},
+				{Path: "a"}, {Path: "b"}, {Path: "c"}, {Path: "d"},
 			}},
 		},
-		TimingMetadata: &TimingMetadata{MedianDuration: fp(2000), DefaultDuration: 1000},
+		TimingMetadata:    &TimingMetadata{},
+		KnownTimingsRatio: &ratio,
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 examples across 1 nodes",
+		"4 files across 1 nodes",
+		"3 files (75%) estimated from past historical durations",
+		"1 files (25%) had no history",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintSplitSummary_ParallelismOneZeroRatio(t *testing.T) {
+	ratio := 0.0
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}, {Path: "b"}}},
+		},
+		TimingMetadata:    &TimingMetadata{},
+		KnownTimingsRatio: &ratio,
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	if !strings.Contains(got, "2 files (100%) had no history") {
+		t.Errorf("expected all-no-history line, got:\n%s", got)
+	}
+	if strings.Contains(got, "estimated from past") {
+		t.Errorf("unexpected estimated line at ratio=0:\n%s", got)
+	}
+}
+
+func TestPrintSplitSummary_ExampleMode(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a[1]", Format: TestCaseFormatExample, TimingSampleSize: 4},
+			}},
+			"1": {NodeNumber: 1, Tests: []TestCase{
+				{Path: "a[2]", Format: TestCaseFormatExample, TimingSampleSize: 0},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{
+			Example: &FormatTimingMetadata{MedianDuration: fp(2000), DefaultDuration: 1000},
+		},
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 examples across 2 nodes",
 		"1 examples (50%) estimated from past historical durations",
 		"1 examples (50%) had no history",
+		"2.0s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -135,6 +197,44 @@ func TestPrintSplitSummary_ExampleMode(t *testing.T) {
 	}
 }
 
+func TestPrintSplitSummary_MixedFormats(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Path: "a_spec.rb", Format: TestCaseFormatFile, TimingSampleSize: 3},
+				{Path: "b_spec.rb[1:1]", Format: TestCaseFormatExample, TimingSampleSize: 0},
+			}},
+			"1": {NodeNumber: 1, Tests: []TestCase{
+				{Path: "c_spec.rb", Format: TestCaseFormatFile, TimingSampleSize: 0},
+				{Path: "b_spec.rb[1:2]", Format: TestCaseFormatExample, TimingSampleSize: 2},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{
+			File:    &FormatTimingMetadata{MedianDuration: fp(4200), DefaultDuration: 1000},
+			Example: &FormatTimingMetadata{MedianDuration: fp(150), DefaultDuration: 500},
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"4 tests across 2 nodes",
+		"  2 files\n",
+		"    1 (50%) estimated from past historical durations",
+		"    1 (50%) had no history — assumed median (4.2s)",
+		"  2 examples\n",
+		"    1 (50%) estimated from past historical durations",
+		"    1 (50%) had no history — assumed median (150ms)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
 func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
 	p := TestPlan{
 		Parallelism: 1,
@@ -142,7 +242,9 @@ func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
 		Tasks: map[string]*Task{
 			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}}},
 		},
-		TimingMetadata: &TimingMetadata{DefaultDuration: 1000},
+		TimingMetadata: &TimingMetadata{
+			File: &FormatTimingMetadata{DefaultDuration: 1000},
+		},
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -22,6 +22,22 @@ type TestCase struct {
 	// In go test, the path can only be package name like "example.com/foo/bar".
 	Path  string `json:"path"`
 	Scope string `json:"scope,omitempty"`
+	// TimingSampleSize is the number of historical executions/runs behind this
+	// case's EstimatedDuration. For file-scoped cases this is distinct runs,
+	// for example-scoped cases this is raw executions. Defaults to 0 when no
+	// history is available or the field is missing on older/cached plans.
+	TimingSampleSize int `json:"timing_sample_size"`
+}
+
+// TimingMetadata describes the historical timing data the server used to
+// build the test plan. All durations are in milliseconds and may be
+// fractional (the server-side median can be the mean of two middle values).
+type TimingMetadata struct {
+	// MedianDuration is the median of historical timings used to backfill
+	// cases without history. Nil when no history existed at all.
+	MedianDuration *float64 `json:"median_duration"`
+	// DefaultDuration is the assumed duration when no history exists at all.
+	DefaultDuration float64 `json:"default_duration"`
 }
 
 // Task represents the task for the given node.
@@ -42,4 +58,8 @@ type TestPlan struct {
 	Fallback     bool
 	MutedTests   []TestCase `json:"muted_tests,omitempty"`
 	SkippedTests []TestCase `json:"skipped_tests,omitempty"`
+	// TimingMetadata describes the historical timing data the server used to
+	// build this plan. Nil when missing (e.g. error plans, plans cached before
+	// the server began emitting it).
+	TimingMetadata *TimingMetadata `json:"timing_metadata,omitempty"`
 }

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -26,7 +26,7 @@ type TestCase struct {
 	// case's EstimatedDuration. For file-scoped cases this is distinct runs,
 	// for example-scoped cases this is raw executions. Defaults to 0 when no
 	// history is available or the field is missing on older/cached plans.
-	TimingSampleSize int `json:"timing_sample_size"`
+	TimingSampleSize int `json:"timing_sample_size,omitempty"`
 }
 
 // TimingMetadata describes the historical timing data the server used to

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -30,9 +30,19 @@ type TestCase struct {
 }
 
 // TimingMetadata describes the historical timing data the server used to
-// build the test plan. All durations are in milliseconds and may be
-// fractional (the server-side median can be the mean of two middle values).
+// build the test plan, broken down per case format. Either key may be
+// omitted when the plan contains no cases of that format (or when
+// parallelism is 1 and no timings were fetched).
 type TimingMetadata struct {
+	File    *FormatTimingMetadata `json:"file,omitempty"`
+	Example *FormatTimingMetadata `json:"example,omitempty"`
+}
+
+// FormatTimingMetadata is the timing data for a single case format
+// (file-scoped or example-scoped). All durations are in milliseconds and
+// may be fractional (the server-side median can be the mean of two middle
+// values).
+type FormatTimingMetadata struct {
 	// MedianDuration is the median of historical timings used to backfill
 	// cases without history. Nil when no history existed at all.
 	MedianDuration *float64 `json:"median_duration"`
@@ -62,4 +72,8 @@ type TestPlan struct {
 	// build this plan. Nil when missing (e.g. error plans, plans cached before
 	// the server began emitting it).
 	TimingMetadata *TimingMetadata `json:"timing_metadata,omitempty"`
+	// KnownTimingsRatio is the fraction (0.0–1.0) of cases that had historical
+	// timing data when the plan was built. Used to summarise plans where
+	// per-format timing metadata is not emitted (e.g. parallelism == 1).
+	KnownTimingsRatio *float64 `json:"known_timings_ratio,omitempty"`
 }

--- a/internal/plan/type_test.go
+++ b/internal/plan/type_test.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
+	raw := `{
+		"identifier": "abc",
+		"parallelism": 2,
+		"tasks": {
+			"0": {
+				"node_number": 0,
+				"tests": [
+					{"path": "a_spec.rb", "estimated_duration": 1500, "timing_sample_size": 7},
+					{"path": "b_spec.rb", "estimated_duration": 1000, "timing_sample_size": 0}
+				]
+			}
+		},
+		"timing_metadata": {"median_duration": 1200, "default_duration": 1000}
+	}`
+
+	var p TestPlan
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if p.TimingMetadata == nil {
+		t.Fatal("TimingMetadata is nil, want non-nil")
+	}
+	if p.TimingMetadata.MedianDuration == nil || *p.TimingMetadata.MedianDuration != 1200 {
+		t.Errorf("MedianDuration = %v, want 1200", p.TimingMetadata.MedianDuration)
+	}
+	if p.TimingMetadata.DefaultDuration != 1000 {
+		t.Errorf("DefaultDuration = %v, want 1000", p.TimingMetadata.DefaultDuration)
+	}
+	gotTests := p.Tasks["0"].Tests
+	wantTests := []TestCase{
+		{Path: "a_spec.rb", EstimatedDuration: 1500, TimingSampleSize: 7},
+		{Path: "b_spec.rb", EstimatedDuration: 1000, TimingSampleSize: 0},
+	}
+	if diff := cmp.Diff(gotTests, wantTests); diff != "" {
+		t.Errorf("tests diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestTestPlan_UnmarshalWithNullMedianDuration(t *testing.T) {
+	raw := `{"identifier":"x","parallelism":1,"tasks":{},"timing_metadata":{"median_duration":null,"default_duration":1000}}`
+
+	var p TestPlan
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.TimingMetadata == nil {
+		t.Fatal("TimingMetadata is nil")
+	}
+	if p.TimingMetadata.MedianDuration != nil {
+		t.Errorf("MedianDuration = %v, want nil", *p.TimingMetadata.MedianDuration)
+	}
+	if p.TimingMetadata.DefaultDuration != 1000 {
+		t.Errorf("DefaultDuration = %v, want 1000", p.TimingMetadata.DefaultDuration)
+	}
+}
+
+func TestTestPlan_UnmarshalWithoutTimingFields(t *testing.T) {
+	// Older / cached / error plans omit timing_metadata and timing_sample_size entirely.
+	raw := `{
+		"identifier": "old",
+		"parallelism": 1,
+		"tasks": {
+			"0": {"node_number": 0, "tests": [{"path": "a_spec.rb"}]}
+		}
+	}`
+
+	var p TestPlan
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.TimingMetadata != nil {
+		t.Errorf("TimingMetadata = %+v, want nil", p.TimingMetadata)
+	}
+	if got := p.Tasks["0"].Tests[0].TimingSampleSize; got != 0 {
+		t.Errorf("TimingSampleSize = %d, want 0", got)
+	}
+}
+
+func TestTestPlan_RoundTrip(t *testing.T) {
+	median := 1234.5
+	original := TestPlan{
+		Identifier:  "id",
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a", TimingSampleSize: 3}}},
+		},
+		TimingMetadata: &TimingMetadata{MedianDuration: &median, DefaultDuration: 1000},
+	}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got TestPlan
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if diff := cmp.Diff(original, got); diff != "" {
+		t.Errorf("round-trip diff (-want +got):\n%s", diff)
+	}
+}

--- a/internal/plan/type_test.go
+++ b/internal/plan/type_test.go
@@ -20,7 +20,10 @@ func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
 				]
 			}
 		},
-		"timing_metadata": {"median_duration": 1200, "default_duration": 1000}
+		"timing_metadata": {
+			"file": {"median_duration": 1200, "default_duration": 1000},
+			"example": {"median_duration": 800, "default_duration": 1000}
+		}
 	}`
 
 	var p TestPlan
@@ -31,11 +34,20 @@ func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
 	if p.TimingMetadata == nil {
 		t.Fatal("TimingMetadata is nil, want non-nil")
 	}
-	if p.TimingMetadata.MedianDuration == nil || *p.TimingMetadata.MedianDuration != 1200 {
-		t.Errorf("MedianDuration = %v, want 1200", p.TimingMetadata.MedianDuration)
+	if p.TimingMetadata.File == nil {
+		t.Fatal("TimingMetadata.File is nil")
 	}
-	if p.TimingMetadata.DefaultDuration != 1000 {
-		t.Errorf("DefaultDuration = %v, want 1000", p.TimingMetadata.DefaultDuration)
+	if p.TimingMetadata.File.MedianDuration == nil || *p.TimingMetadata.File.MedianDuration != 1200 {
+		t.Errorf("File.MedianDuration = %v, want 1200", p.TimingMetadata.File.MedianDuration)
+	}
+	if p.TimingMetadata.File.DefaultDuration != 1000 {
+		t.Errorf("File.DefaultDuration = %v, want 1000", p.TimingMetadata.File.DefaultDuration)
+	}
+	if p.TimingMetadata.Example == nil {
+		t.Fatal("TimingMetadata.Example is nil")
+	}
+	if p.TimingMetadata.Example.MedianDuration == nil || *p.TimingMetadata.Example.MedianDuration != 800 {
+		t.Errorf("Example.MedianDuration = %v, want 800", p.TimingMetadata.Example.MedianDuration)
 	}
 	gotTests := p.Tasks["0"].Tests
 	wantTests := []TestCase{
@@ -47,21 +59,29 @@ func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
 	}
 }
 
-func TestTestPlan_UnmarshalWithNullMedianDuration(t *testing.T) {
-	raw := `{"identifier":"x","parallelism":1,"tasks":{},"timing_metadata":{"median_duration":null,"default_duration":1000}}`
+func TestTestPlan_UnmarshalWithFileOnly(t *testing.T) {
+	raw := `{
+		"identifier": "x",
+		"parallelism": 2,
+		"tasks": {},
+		"timing_metadata": {"file": {"median_duration": null, "default_duration": 1000}}
+	}`
 
 	var p TestPlan
 	if err := json.Unmarshal([]byte(raw), &p); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if p.TimingMetadata == nil {
-		t.Fatal("TimingMetadata is nil")
+	if p.TimingMetadata == nil || p.TimingMetadata.File == nil {
+		t.Fatal("TimingMetadata.File is nil")
 	}
-	if p.TimingMetadata.MedianDuration != nil {
-		t.Errorf("MedianDuration = %v, want nil", *p.TimingMetadata.MedianDuration)
+	if p.TimingMetadata.Example != nil {
+		t.Errorf("TimingMetadata.Example = %+v, want nil", p.TimingMetadata.Example)
 	}
-	if p.TimingMetadata.DefaultDuration != 1000 {
-		t.Errorf("DefaultDuration = %v, want 1000", p.TimingMetadata.DefaultDuration)
+	if p.TimingMetadata.File.MedianDuration != nil {
+		t.Errorf("File.MedianDuration = %v, want nil", *p.TimingMetadata.File.MedianDuration)
+	}
+	if p.TimingMetadata.File.DefaultDuration != 1000 {
+		t.Errorf("File.DefaultDuration = %v, want 1000", p.TimingMetadata.File.DefaultDuration)
 	}
 }
 
@@ -95,7 +115,9 @@ func TestTestPlan_RoundTrip(t *testing.T) {
 		Tasks: map[string]*Task{
 			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a", TimingSampleSize: 3}}},
 		},
-		TimingMetadata: &TimingMetadata{MedianDuration: &median, DefaultDuration: 1000},
+		TimingMetadata: &TimingMetadata{
+			File: &FormatTimingMetadata{MedianDuration: &median, DefaultDuration: 1000},
+		},
 	}
 	b, err := json.Marshal(original)
 	if err != nil {


### PR DESCRIPTION
### Description

After a test plan is resolved (fetched or newly created), print a human-readable split summary to stderr from both plan and run commands, so users can see at a glance how the plan was built and how much of it relied on historical timing data.

Output examples:

<img width="521" height="102" alt="Screenshot 2026-05-01 at 2 32 55 PM" src="https://github.com/user-attachments/assets/821d2527-1e5c-4bf9-96d1-cb72c28f71df" />

All-default case:

<img width="571" height="155" alt="Screenshot 2026-04-29 at 4 49 52 PM" src="https://github.com/user-attachments/assets/b65c2021-84e3-4181-8b23-d1aedf0ba174" />

At parallelism=1 the server skips per-format timing data for performance reasons, so the breakdown falls back to the plan-level `known_timings_ratio`.

### Context

- [TE-5706](https://linear.app/buildkite/issue/TE-5706/print-split-summary-to-stderr-from-plan-and-run-commands)
- Parent: [TE-5668](https://linear.app/buildkite/issue/TE-5668/surface-a-split-summary-after-plan-resolution) (Surface a split summary after plan resolution)
- Depends on the API changes that emit `timing_metadata` and per-case `timing_sample_size` - done in https://github.com/buildkite/buildkite/pull/29320

### Changes

- New `internal/plan/summary.go` with `PrintSplitSummary` covering single-format, mixed-format, and parallelism=1 fallback paths
- New schema fields on `internal/plan/type.go`: `TestPlan.TimingMetadata`, `TestPlan.KnownTimingsRatio`, `TestCase.TimingSampleSize` (omitempty)
- Wire `PrintSplitSummary` into `internal/command/plan.go` and `internal/command/run.go` after plan resolution
- Skipped for fallback plans and when neither `timing_metadata` nor `known_timings_ratio` is present (older/cached plans)


### Testing

- Unit tests in `internal/plan/summary_test.go` cover mixed history, all-no-history, null median, parallelism=1 ratio path, ratio=0, example-format, mixed file+example, and fallback skip
- Round-trip and unmarshal tests in `internal/plan/type_test.go` cover the new fields with and without timing metadata
