### PR TITLE
Centralize buildCommand method for runners

### DIFF
--- a/internal/command/files.go
+++ b/internal/command/files.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/buildkite/test-engine-client/internal/runner"
 )
 
-func getTestFiles(fileList string, testRunner TestRunner) ([]string, error) {
+func getTestFiles(fileList string, testRunner runner.TestRunner) ([]string, error) {
 	if fileList != "" {
 		return getTestFilesFromFile(fileList)
 	} else {

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildkite/test-engine-client/internal/config"
 	"github.com/buildkite/test-engine-client/internal/debug"
 	"github.com/buildkite/test-engine-client/internal/plan"
+	"github.com/buildkite/test-engine-client/internal/runner"
 )
 
 // createRequestParam generates the parameters needed for a test plan request.
@@ -22,7 +23,7 @@ import (
 //
 // If tag filtering is enabled, all files are split into examples to support filtering.
 // Currently only the Pytest runner supports tag filtering.
-func createRequestParam(ctx context.Context, cfg *config.Config, files []string, client api.Client, runner TestRunner) (api.TestPlanParams, error) {
+func createRequestParam(ctx context.Context, cfg *config.Config, files []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	testFiles := []plan.TestCase{}
 
 	for _, file := range files {
@@ -118,7 +119,7 @@ func buildSelectionParams(strategy string, params map[string]string) *api.Select
 	}
 }
 
-func getExamplesWithPrefix(filePaths []string, runner TestRunner) ([]plan.TestCase, error) {
+func getExamplesWithPrefix(filePaths []string, runner runner.TestRunner) ([]plan.TestCase, error) {
 	prefix := runner.LocationPrefix()
 	trimmedPaths := make([]string, len(filePaths))
 
@@ -152,7 +153,7 @@ func getExamplesWithPrefix(filePaths []string, runner TestRunner) ([]plan.TestCa
 }
 
 // Splits all the test files into examples to support tag filtering.
-func splitAllFiles(files []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
+func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
 	debug.Printf("Splitting all %d files", len(files))
 	filePaths := make([]string, 0, len(files))
 	for _, file := range files {
@@ -174,7 +175,7 @@ func splitAllFiles(files []plan.TestCase, runner TestRunner) (api.TestPlanParams
 // filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
 // It returns the test plan parameters with the examples from the filtered files and the remaining files that are not filtered.
 // An error is returned if there is a failure in any of the process.
-func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []plan.TestCase, runner TestRunner) (api.TestPlanParamsTest, error) {
+func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []plan.TestCase, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
 	// Filter files that need to be split.
 	debug.Printf("Filtering %d files", len(allTestFiles))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -112,7 +112,7 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	runners := []TestRunner{
+	runners := []runner.TestRunner{
 		runner.Jest{}, runner.Cypress{},
 	}
 
@@ -375,6 +375,10 @@ func (r metadataTestRunner) LocationPrefix() string {
 
 func (r metadataTestRunner) Run(result *runner.RunResult, testCases []plan.TestCase, retry bool) error {
 	return nil
+}
+
+func (r metadataTestRunner) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	return "metadata-test-runner", testCases, nil
 }
 
 func TestCreateRequestParams_FilterTestsError(t *testing.T) {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -19,20 +19,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-type TestRunner interface {
-	// Run takes testCases as input, executes the test against the test cases, and mutates the runner.RunResult with the test results.
-	Run(result *runner.RunResult, testCases []plan.TestCase, retry bool) error
-	// GetExamples discovers all tests within given files.
-	// This function is only used for split by example use case. Currently only supported by RSpec.
-	GetExamples(files []string) ([]plan.TestCase, error)
-	// GetFiles discover all test files that the runner should execute.
-	// This is sent to server-side when creating test plan.
-	// This is also used to obtain a fallback non-intelligent test splitting mechanism.
-	GetFiles() ([]string, error)
-	Name() string
-	LocationPrefix() string
-}
-
 const Logo = `
 ______ ______ _____
 ___  /____  /___  /____________
@@ -225,7 +211,7 @@ func sendMetadata(ctx context.Context, apiClient *api.Client, cfg *config.Config
 // For next reader, there is a small caveat with current implementation:
 // - testCases and timeline are both expected to be mutated.
 // - testCases in this case serve both as input and output -> we should probably change it.
-func runTestsWithRetry(testRunner TestRunner, testsCases *[]plan.TestCase, maxRetries int, mutedTests []plan.TestCase, timeline *[]api.Timeline, retryForMutedTest bool, failOnNoTests bool) (runner.RunResult, error) {
+func runTestsWithRetry(testRunner runner.TestRunner, testsCases *[]plan.TestCase, maxRetries int, mutedTests []plan.TestCase, timeline *[]api.Timeline, retryForMutedTest bool, failOnNoTests bool) (runner.RunResult, error) {
 	attemptCount := 0
 
 	// Create a new run result with muted tests to keep track of the results.
@@ -307,7 +293,7 @@ func logSignalAndExit(name string, signal syscall.Signal) {
 
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, files []string, testRunner TestRunner) (plan.TestPlan, error) {
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, files []string, testRunner runner.TestRunner) (plan.TestPlan, error) {
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -8,6 +8,15 @@ import (
 	"syscall"
 )
 
+func buildCommand(runner TestRunner, testCases []string, retry bool) (*exec.Cmd, error) {
+	commandName, commandArgs, err := runner.CommandNameAndArgs(testCases, retry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build command: %w", err)
+	}
+
+	return exec.Command(commandName, commandArgs...), nil
+}
+
 // runAndForwardSignal runs the command and forwards any signals received to the command.
 func runAndForwardSignal(cmd *exec.Cmd) error {
 	cmd.Stderr = os.Stderr

--- a/internal/runner/cucumber.go
+++ b/internal/runner/cucumber.go
@@ -67,22 +67,15 @@ func (c Cucumber) GetFiles() ([]string, error) {
 
 // Run executes the Cucumber command and records results.
 func (c Cucumber) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	command := c.TestCommand
-	if retry {
-		command = c.RetryTestCommand
-	}
-
 	testPaths := make([]string, len(testCases))
 	for i, tc := range testCases {
 		testPaths[i] = tc.Path
 	}
 
-	commandName, commandArgs, err := c.commandNameAndArgs(command, testPaths)
+	cmd, err := buildCommand(c, testPaths, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd := exec.Command(commandName, commandArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -170,7 +163,7 @@ func (c Cucumber) GetExamples(files []string) ([]plan.TestCase, error) {
 		}
 	}()
 
-	cmdName, _, err := c.commandNameAndArgs(c.TestCommand, files)
+	cmdName, _, err := c.CommandNameAndArgs(files, false)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +206,13 @@ func (c Cucumber) GetExamples(files []string) ([]plan.TestCase, error) {
 	return testCases, nil
 }
 
-// commandNameAndArgs replaces placeholders and returns command + args.
-func (c Cucumber) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+// CommandNameAndArgs replaces placeholders and returns command + args.
+func (c Cucumber) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := c.TestCommand
+	if retry {
+		cmd = c.RetryTestCommand
+	}
+
 	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return "", []string{}, err

--- a/internal/runner/cucumber_test.go
+++ b/internal/runner/cucumber_test.go
@@ -422,7 +422,7 @@ func TestCucumberCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 		ResultPath:  "cucumber.json",
 	})
 
-	gotName, gotArgs, err := c.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := c.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -447,7 +447,7 @@ func TestCucumberCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T)
 		ResultPath:  "cucumber.json",
 	})
 
-	gotName, gotArgs, err := c.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := c.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -471,7 +471,7 @@ func TestCucumberCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := c.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := c.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/internal/debug"
@@ -64,13 +63,11 @@ func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	for i, tc := range testCases {
 		testPaths[i] = tc.Path
 	}
-	cmdName, cmdArgs, err := r.commandNameAndArgs(r.TestCommand, testPaths)
 
+	cmd, err := buildCommand(r, testPaths, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd := exec.Command(cmdName, cmdArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -103,7 +100,11 @@ func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	return cmdErr
 }
 
-func (r Custom) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (r Custom) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := r.TestCommand
+	if retry {
+		cmd = r.RetryTestCommand
+	}
 	cmd = strings.Replace(cmd, "{{testExamples}}", strings.Join(testCases, " "), 1)
 
 	words, err := shellquote.Split(cmd)

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -110,7 +110,7 @@ func TestCustom_CommandNameAndArgs(t *testing.T) {
 			t.Fatalf("Failed to create Custom runner: %v", err)
 		}
 
-		gotName, gotArgs, err := custom.commandNameAndArgs(custom.TestCommand, testCases)
+		gotName, gotArgs, err := custom.CommandNameAndArgs(testCases, false)
 		if err != nil {
 			t.Errorf("Custom.cmdNameAndArgs(%q, testCases) error = %v", tc.command, err)
 		}

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -23,6 +23,10 @@ func NewCypress(c RunnerConfig) Cypress {
 		c.TestCommand = "npx cypress run --spec {{testExamples}}"
 	}
 
+	if c.RetryTestCommand == "" {
+		c.RetryTestCommand = c.TestCommand
+	}
+
 	if c.TestFilePattern == "" {
 		c.TestFilePattern = "**/*.cy.{js,jsx,ts,tsx}"
 	}

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"os/exec"
 	"slices"
 	"strings"
 
@@ -38,12 +37,11 @@ func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) e
 	for i, tc := range testCases {
 		testPaths[i] = tc.Path
 	}
-	cmdName, cmdArgs, err := c.commandNameAndArgs(c.TestCommand, testPaths)
-	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
-	}
 
-	cmd := exec.Command(cmdName, cmdArgs...)
+	cmd, err := buildCommand(c, testPaths, retry)
+	if err != nil {
+		return err
+	}
 
 	err = runAndForwardSignal(cmd)
 
@@ -70,7 +68,11 @@ func (c Cypress) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in Cypress")
 }
 
-func (c Cypress) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (c Cypress) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := c.TestCommand
+	if retry {
+		cmd = c.RetryTestCommand
+	}
 	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return "", []string{}, err

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -125,7 +125,7 @@ func TestCypressCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 		ResultPath:  "cypress.json",
 	})
 
-	gotName, gotArgs, err := cy.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := cy.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -149,7 +149,7 @@ func TestCypressCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) 
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := cypress.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := cypress.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -173,7 +173,7 @@ func TestCypressCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := cypress.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := cypress.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -7,30 +7,12 @@ import (
 	"github.com/buildkite/test-engine-client/internal/plan"
 )
 
-type RunnerConfig struct {
-	TestRunner string
-
-	locationPrefix string
-	// ResultPath is used internally so bktec can read result from Test Runner.
-	// User typically don't need to worry about setting this except in in RSpec and playwright.
-	// In playwright, for example, it can only be configured via a config file, therefore it's mandatory for user to set.
-	ResultPath             string
-	RetryTestCommand       string
-	TagFilters             string
-	TestCommand            string
-	TestFileExcludePattern string
-	TestFilePattern        string
-}
-
-func (c RunnerConfig) LocationPrefix() string {
-	return c.locationPrefix
-}
-
 type TestRunner interface {
 	Run(result *RunResult, testCases []plan.TestCase, retry bool) error
 	GetExamples(files []string) ([]plan.TestCase, error)
 	GetFiles() ([]string, error)
 	Name() string
+	CommandNameAndArgs(testCases []string, retry bool) (string, []string, error)
 	LocationPrefix() string
 }
 

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -42,12 +42,16 @@ func (g GoTest) GetExamples(files []string) ([]plan.TestCase, error) {
 
 // Run executes the configured command for the specified packages.
 func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	cmdName, cmdArgs, err := g.commandNameAndArgs(g.TestCommand, testCases)
+	packages, err := g.getPackages(testCases)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return fmt.Errorf("failed to generate test package list: %w", err)
 	}
 
-	cmd := exec.Command(cmdName, cmdArgs...)
+	cmd, err := buildCommand(g, packages, retry)
+	if err != nil {
+		return err
+	}
+
 	cmdErr := runAndForwardSignal(cmd)
 
 	// go test output does not differentiate build fail or test fail. They both return 1
@@ -110,10 +114,10 @@ func (g GoTest) GetFiles() ([]string, error) {
 	return validPackages, nil
 }
 
-func (p GoTest) commandNameAndArgs(cmd string, testCases []plan.TestCase) (string, []string, error) {
-	packages, err := p.getPackages(testCases)
-	if err != nil {
-		return "", []string{}, nil
+func (g GoTest) CommandNameAndArgs(packages []string, retry bool) (string, []string, error) {
+	cmd := g.TestCommand
+	if retry {
+		cmd = g.RetryTestCommand
 	}
 
 	concatenatedPackages := strings.Join(packages, " ")
@@ -124,7 +128,7 @@ func (p GoTest) commandNameAndArgs(cmd string, testCases []plan.TestCase) (strin
 		cmd = cmd + " " + concatenatedPackages
 	}
 
-	cmd = strings.Replace(cmd, "{{resultPath}}", p.ResultPath, 1)
+	cmd = strings.Replace(cmd, "{{resultPath}}", g.ResultPath, 1)
 
 	args, err := shellquote.Split(cmd)
 

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -70,7 +70,7 @@ func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) erro
 	testPaths = slices.Compact(testPaths)
 
 	if !retry {
-		commandName, commandArgs, err := j.commandNameAndArgs(j.TestCommand, testPaths)
+		commandName, commandArgs, err := j.CommandNameAndArgs(testPaths, false)
 		if err != nil {
 			return fmt.Errorf("failed to build command: %w", err)
 		}
@@ -183,7 +183,12 @@ func (j Jest) ParseReport(path string) (JestReport, error) {
 	return report, nil
 }
 
-func (j Jest) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (j Jest) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := j.TestCommand
+	if retry {
+		cmd = j.RetryTestCommand
+	}
+
 	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return "", []string{}, err

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -345,7 +345,7 @@ func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 		ResultPath:  "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -370,7 +370,7 @@ func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 		ResultPath:  "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -394,7 +394,7 @@ func TestJestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}
@@ -425,7 +425,7 @@ func TestJestCommandNameAndArgs_WithSpecialCharactersInPath(t *testing.T) {
 		ResultPath:  "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -65,19 +64,13 @@ func (n NUnit) GetExamples(files []string) ([]plan.TestCase, error) {
 // Test cases are mapped from .cs file paths to class names, and joined into a
 // FullyQualifiedName~ filter expression.
 func (n NUnit) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	command := n.TestCommand
-	if retry {
-		command = n.RetryTestCommand
-	}
-
 	classNames := extractClassNames(testCases)
 
-	cmdName, cmdArgs, err := n.commandNameAndArgs(command, classNames)
+	cmd, err := buildCommand(n, classNames, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
 
-	cmd := exec.Command(cmdName, cmdArgs...)
 	cmdErr := runAndForwardSignal(cmd)
 
 	testResults, parseErr := loadAndParseJUnitXmlResult(n.ResultPath)
@@ -128,7 +121,12 @@ func buildTestFilter(classNames []string) string {
 	return strings.Join(parts, "|")
 }
 
-func (n NUnit) commandNameAndArgs(cmd string, classNames []string) (string, []string, error) {
+func (n NUnit) CommandNameAndArgs(classNames []string, retry bool) (string, []string, error) {
+	cmd := n.TestCommand
+	if retry {
+		cmd = n.RetryTestCommand
+	}
+
 	filter := buildTestFilter(classNames)
 
 	cmd = strings.Replace(cmd, "{{testFilter}}", filter, 1)

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -117,7 +117,7 @@ func TestNUnit_CommandNameAndArgs(t *testing.T) {
 
 	classNames := []string{"CalculatorTests", "StringUtilsTests"}
 
-	gotName, gotArgs, err := nunit.commandNameAndArgs(nunit.TestCommand, classNames)
+	gotName, gotArgs, err := nunit.CommandNameAndArgs(classNames, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs() error = %v", err)
 	}

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -42,12 +42,10 @@ func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool
 		testPaths[i] = tc.Path
 	}
 
-	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, testPaths)
+	cmd, err := buildCommand(p, testPaths, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd := exec.Command(cmdName, cmdArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -106,7 +104,12 @@ func (p Playwright) getTestResultsFromSuite(suite PlaywrightReportSuite, suiteNa
 	return testResults
 }
 
-func (p Playwright) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (p Playwright) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := p.TestCommand
+	if retry {
+		cmd = p.RetryTestCommand
+	}
+
 	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return "", []string{}, err
@@ -167,7 +170,7 @@ func (p Playwright) GetExamples(files []string) ([]plan.TestCase, error) {
 	tmpFile.Close()
 	defer os.Remove(tmpPath)
 
-	cmdName, cmdArgs, err := p.commandNameAndArgs(p.TestCommand, files)
+	cmdName, cmdArgs, err := p.CommandNameAndArgs(files, false)
 	if err != nil {
 		return []plan.TestCase{}, err
 	}

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -27,6 +27,10 @@ func NewPlaywright(p RunnerConfig) Playwright {
 		p.TestCommand = "npx playwright test"
 	}
 
+	if p.RetryTestCommand == "" {
+		p.RetryTestCommand = p.TestCommand
+	}
+
 	if p.TestFilePattern == "" {
 		p.TestFilePattern = "**/{*.spec,*.test}.{ts,js}"
 	}

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -203,7 +203,7 @@ func TestPlaywrightCommandNameAndArgs_WithPlaceholder(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := rspec.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -227,7 +227,7 @@ func TestPlaywrightCommandNameAndArgs_WithoutPlaceholder(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := rspec.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -65,18 +65,10 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		testPaths[i] = tc.Path
 	}
 
-	command := p.TestCommand
-
-	if retry {
-		command = p.RetryTestCommand
-	}
-
-	cmdName, cmdArgs, err := p.commandNameAndArgs(command, testPaths)
+	cmd, err := buildCommand(p, testPaths, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd := exec.Command(cmdName, cmdArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -211,7 +203,12 @@ func mapNodeIdToTestCase(nodeId string) plan.TestCase {
 	}
 }
 
-func (p Pytest) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (p Pytest) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := p.TestCommand
+	if retry {
+		cmd = p.RetryTestCommand
+	}
+
 	testExamples := shellquote.Join(testCases...)
 
 	if strings.Contains(cmd, "{{testExamples}}") {

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -56,18 +56,10 @@ func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry boo
 		testPaths[i] = tc.Path
 	}
 
-	command := p.TestCommand
-
-	if retry {
-		command = p.RetryTestCommand
-	}
-
-	cmdName, cmdArgs, err := p.commandNameAndArgs(command, testPaths)
+	cmd, err := buildCommand(p, testPaths, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd := exec.Command(cmdName, cmdArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -110,7 +102,12 @@ func (p PytestPants) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in pytest pants")
 }
 
-func (p PytestPants) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (p PytestPants) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := p.TestCommand
+	if retry {
+		cmd = p.RetryTestCommand
+	}
+
 	if strings.Contains(cmd, "{{testExamples}}") {
 		return "", []string{}, fmt.Errorf("currently, bktec does not support dynamically injecting {{testExamples}}. Please ensure the test command in BUILDKITE_TEST_ENGINE_TEST_CMD does *not* include {{testExamples}}")
 	}

--- a/internal/runner/pytest_pants_test.go
+++ b/internal/runner/pytest_pants_test.go
@@ -162,7 +162,7 @@ func TestPytestPantsCommandNameAndArgs_WithoutMergeJson(t *testing.T) {
 		ResultPath:  "result.json",
 	})
 
-	_, _, err := pytest.commandNameAndArgs(testCommand, testCases)
+	_, _, err := pytest.CommandNameAndArgs(testCases, false)
 	if err == nil {
 		t.Error("commandNameAndArgs() error = nil, want error")
 	}
@@ -176,7 +176,7 @@ func TestPytestPantsCommandNameAndArgs_WithoutResultPath(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	_, _, err := pytest.commandNameAndArgs(testCommand, testCases)
+	_, _, err := pytest.CommandNameAndArgs(testCases, false)
 	if err == nil {
 		t.Error("commandNameAndArgs() error = nil, want error")
 	}
@@ -190,7 +190,7 @@ func TestPytestPantsCommandNameAndArgs_PytestArgsBeforeDash(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	_, _, err := pytest.commandNameAndArgs(testCommand, testCases)
+	_, _, err := pytest.CommandNameAndArgs(testCases, false)
 	if err == nil {
 		t.Error("commandNameAndArgs() error = nil, want error")
 	}
@@ -204,7 +204,7 @@ func TestPytestPantsCommandNameAndArgs_NoDashSeparator(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 	if err == nil {
 		t.Error("commandNameAndArgs() error = nil, want error")
 	}
@@ -229,7 +229,7 @@ func TestPytestPantsCommandNameAndArgs_ValidCommand(t *testing.T) {
 		ResultPath:  "result.json",
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -253,7 +253,7 @@ func TestPytestPantsCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -163,7 +163,7 @@ func TestPytestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 		ResultPath:  "result.json",
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -187,7 +187,7 @@ func TestPytestCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -211,7 +211,7 @@ func TestPytestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}
@@ -242,7 +242,7 @@ func TestPytestCommandNameAndArgs_WithSpacesInTestCase(t *testing.T) {
 		},
 	}
 
-	gotName, gotArgs, err := pytest.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := pytest.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -72,25 +72,17 @@ func (r Rspec) GetFiles() ([]string, error) {
 //
 // Test failure is not considered an error, and is instead returned as a RunResult.
 func (r Rspec) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	command := r.TestCommand
-
-	if retry {
-		command = r.RetryTestCommand
-	}
-
 	testPaths := make([]string, len(testCases))
 	for i, tc := range testCases {
 		testPaths[i] = tc.Path
 	}
 
-	commandName, commandArgs, cmdErr := r.commandNameAndArgs(command, testPaths)
-	if cmdErr != nil {
-		return fmt.Errorf("failed to build command: %w", cmdErr)
+	cmd, err := buildCommand(r, testPaths, retry)
+	if err != nil {
+		return err
 	}
 
-	cmd := exec.Command(commandName, commandArgs...)
-
-	cmdErr = runAndForwardSignal(cmd)
+	cmdErr := runAndForwardSignal(cmd)
 
 	// RSpec exits with a non-zero status code when there are test failures,
 	// so we should always attempt to parse the report even if the command returns an error.
@@ -164,9 +156,14 @@ func (r Rspec) ParseReport(path string) (RspecReport, error) {
 	return report, nil
 }
 
-// commandNameAndArgs replaces the "{{testExamples}}" placeholder in the test command with the test cases.
+// CommandNameAndArgs replaces the "{{testExamples}}" placeholder in the test command with the test cases.
 // It returns the command name and arguments to run the tests.
-func (r Rspec) commandNameAndArgs(cmd string, testCases []string) (string, []string, error) {
+func (r Rspec) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+	cmd := r.TestCommand
+	if retry {
+		cmd = r.RetryTestCommand
+	}
+
 	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return "", []string{}, err
@@ -202,7 +199,7 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		os.Remove(f.Name())
 	}()
 
-	cmdName, cmdArgs, err := r.commandNameAndArgs(r.TestCommand, files)
+	cmdName, cmdArgs, err := r.CommandNameAndArgs(files, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -307,7 +307,7 @@ func TestRspecCommandNameAndArgs_WithPlaceholder(t *testing.T) {
 		ResultPath:  "tmp/rspec.json",
 	})
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := rspec.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -331,7 +331,7 @@ func TestRspecCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := rspec.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs(%q, %q) error = %v", testCases, testCommand, err)
 	}
@@ -355,7 +355,7 @@ func TestRspecCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 		TestCommand: testCommand,
 	})
 
-	gotName, gotArgs, err := rspec.commandNameAndArgs(testCommand, testCases)
+	gotName, gotArgs, err := rspec.CommandNameAndArgs(testCases, false)
 
 	wantName := ""
 	wantArgs := []string{}

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -1,0 +1,20 @@
+package runner
+
+type RunnerConfig struct {
+	TestRunner string
+
+	locationPrefix string
+	// ResultPath is used internally so bktec can read result from Test Runner.
+	// User typically don't need to worry about setting this except in in RSpec and playwright.
+	// In playwright, for example, it can only be configured via a config file, therefore it's mandatory for user to set.
+	ResultPath             string
+	RetryTestCommand       string
+	TagFilters             string
+	TestCommand            string
+	TestFileExcludePattern string
+	TestFilePattern        string
+}
+
+func (rc RunnerConfig) LocationPrefix() string {
+	return rc.locationPrefix
+}


### PR DESCRIPTION
Principal motivation for this change is to extract all of the duplicated logic for creating an `exec.Cmd` when executing the test runners. We'll be adding some additional behaviour to this in a follow up and this will avoid duplicating the new behaviour across 10 different runners.

- Removes duplicate `TestRunner` interface from `command` package
- Adds `CommandNameAndArgs` to `runner.TestRunner` interface
- Adds `LocationPrefix` to `runner.TestRunner` interface
- Extracts duplicated logic from all runners into `buildCommand`