### PR TITLE
[TE-5780] Update bktec to use suite-scoped commit-metadata-backfill endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- **Breaking (preview feature):** `bktec tools backfill-commit-metadata` now calls the suite-scoped commit-metadata backfill presigned-upload endpoint (`POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload`) instead of the org-scoped one. `--suite-slug` (or `BUILDKITE_TEST_ENGINE_SUITE_SLUG`) is now required for `--upload` as well as for collection. The legacy org-scoped endpoint is being removed in a follow-up server release. This is a preview feature gated behind `BKTEC_PREVIEW_SELECTION`; the only known consumer of the legacy endpoint is bktec itself, so no customer-facing usage is affected.
+- **Breaking (preview feature):** `bktec tools backfill-commit-metadata` now calls the suite-scoped commit-metadata backfill presigned-upload endpoint (`POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload`) instead of the org-scoped one. `--suite-slug` (or `BUILDKITE_TEST_ENGINE_SUITE_SLUG`) is now required for `--upload` as well as for collection. The legacy org-scoped endpoint is being removed in a follow-up server release. This is a preview feature gated behind `BKTEC_PREVIEW_SELECTION`.
 - Remove Pact contract testing for the Test Engine API. Consumer tests now use plain `httptest` fixtures (no behaviour change for users); the `internal/api/pacts/` directory, `pact-go` dependency, and `bin/{publish-pact,release-pact-version,pact-record-support-ended}` scripts have been deleted.
 
 ## 2.4.0 - 2026-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- **Breaking (preview feature):** `bktec tools backfill-commit-metadata` now calls the suite-scoped commit-metadata backfill presigned-upload endpoint (`POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload`) instead of the org-scoped one. `--suite-slug` (or `BUILDKITE_TEST_ENGINE_SUITE_SLUG`) is now required for `--upload` as well as for collection. The legacy org-scoped endpoint is being removed in a follow-up server release. This is a preview feature gated behind `BKTEC_PREVIEW_SELECTION`; the only known consumer of the legacy endpoint is bktec itself, so no customer-facing usage is affected.
 - Remove Pact contract testing for the Test Engine API. Consumer tests now use plain `httptest` fixtures (no behaviour change for users); the `internal/api/pacts/` directory, `pact-go` dependency, and `bin/{publish-pact,release-pact-version,pact-record-support-ended}` scripts have been deleted.
 
 ## 2.4.0 - 2026-04-17

--- a/README.md
+++ b/README.md
@@ -146,11 +146,15 @@ tar tzf commit-metadata.tar.gz
 # commit-metadata.jsonl
 # metadata.json
 
-# Upload when ready
-bktec tools backfill-commit-metadata --upload commit-metadata.tar.gz
+# Upload when ready (--suite-slug required, see breaking change note below)
+bktec tools backfill-commit-metadata \
+  --upload commit-metadata.tar.gz \
+  --suite-slug "my-suite"
 ```
 
 The API access token requires `read_suites` and `write_suites` scopes.
+
+> **Breaking change (preview feature):** the commit-metadata backfill upload endpoint is now suite-scoped. `--suite-slug` is required for `--upload` (previously it was only required for collection). The legacy org-scoped endpoint is being removed in a follow-up server release. The only known consumer of the legacy endpoint is bktec itself; no customer-facing usage is affected.
 
 For detailed usage, flags, and configuration options, see the [Commit Metadata Backfill](./docs/commit-metadata-backfill.md) guide.
 

--- a/README.md
+++ b/README.md
@@ -146,15 +146,13 @@ tar tzf commit-metadata.tar.gz
 # commit-metadata.jsonl
 # metadata.json
 
-# Upload when ready (--suite-slug required, see breaking change note below)
+# Upload when ready
 bktec tools backfill-commit-metadata \
   --upload commit-metadata.tar.gz \
   --suite-slug "my-suite"
 ```
 
 The API access token requires `read_suites` and `write_suites` scopes.
-
-> **Breaking change (preview feature):** the commit-metadata backfill upload endpoint is now suite-scoped. `--suite-slug` is required for `--upload` (previously it was only required for collection). The legacy org-scoped endpoint is being removed in a follow-up server release. The only known consumer of the legacy endpoint is bktec itself; no customer-facing usage is affected.
 
 For detailed usage, flags, and configuration options, see the [Commit Metadata Backfill](./docs/commit-metadata-backfill.md) guide.
 

--- a/docs/commit-metadata-backfill.md
+++ b/docs/commit-metadata-backfill.md
@@ -69,10 +69,14 @@ bktec tools backfill-commit-metadata --days 30 --concurrency 5
 **Upload a previously generated tarball:**
 
 ```sh
-bktec tools backfill-commit-metadata --upload commit-metadata.tar.gz
+bktec tools backfill-commit-metadata \
+  --upload commit-metadata.tar.gz \
+  --suite-slug "my-suite"
 ```
 
 This is useful when you want to generate and upload in separate steps or when retrying a failed upload. If the command fails during upload, it retains the generated tarball locally and prints its path. You can then retry with `--upload` without re-running the entire metadata collection.
+
+`--suite-slug` is required even with `--upload` because the presigned upload endpoint is suite-scoped: the server partitions tarballs by suite for the training pipeline. Use the same suite slug that produced the tarball.
 
 ## Configuration
 
@@ -90,7 +94,7 @@ This is useful when you want to generate and upload in separate steps or when re
 | `BUILDKITE_TEST_ENGINE_BACKFILL_CONCURRENCY` | `--concurrency` | `10` | Number of concurrent git operations for diff collection |
 | `BUILDKITE_TEST_ENGINE_DEBUG_ENABLED` | `--debug` | `false` | Enable debug output |
 
-When using `--upload`, only `--access-token` and `--organization-slug` are required. The `--suite-slug`, `--days`, and other backfill-specific flags are not needed because the upload endpoint is organization-scoped.
+When using `--upload`, `--access-token`, `--organization-slug`, and `--suite-slug` are required. Collection-specific flags (`--days`, `--concurrency`, `--remote`, `--skip-diffs`) are not needed because the command only uploads an existing tarball.
 
 ### API access token scopes
 

--- a/internal/api/presign_upload.go
+++ b/internal/api/presign_upload.go
@@ -17,12 +17,18 @@ type PresignedUploadResponse struct {
 
 // PresignUpload requests a presigned S3 upload URL for commit metadata.
 //
-// Endpoint: POST /v2/analytics/organizations/:org/commit-metadata-backfill/presigned-upload
-// This is org-scoped (not suite-scoped) because git data applies across suites.
-func (c Client) PresignUpload(ctx context.Context) (PresignedUploadResponse, error) {
+// Endpoint: POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload
+//
+// The endpoint is suite-scoped: the server partitions uploaded tarballs under
+// `backfill/org=<org_uuid>/suite=<suite_uuid>/...` so the training pipeline
+// can ingest by suite without inspecting tarball contents. This replaces the
+// legacy org-scoped endpoint at
+// `/v2/analytics/organizations/:org/commit-metadata-backfill/presigned-upload`,
+// which is being removed in a follow-up server release.
+func (c Client) PresignUpload(ctx context.Context, suiteSlug string) (PresignedUploadResponse, error) {
 	reqURL := fmt.Sprintf(
-		"%s/v2/analytics/organizations/%s/commit-metadata-backfill/presigned-upload",
-		c.ServerBaseUrl, url.PathEscape(c.OrganizationSlug))
+		"%s/v2/analytics/organizations/%s/suites/%s/commit-metadata-backfill/presigned-upload",
+		c.ServerBaseUrl, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug))
 
 	var resp PresignedUploadResponse
 	_, err := c.DoWithRetry(ctx, httpRequest{Method: http.MethodPost, URL: reqURL}, &resp)

--- a/internal/api/presign_upload.go
+++ b/internal/api/presign_upload.go
@@ -18,13 +18,6 @@ type PresignedUploadResponse struct {
 // PresignUpload requests a presigned S3 upload URL for commit metadata.
 //
 // Endpoint: POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload
-//
-// The endpoint is suite-scoped: the server partitions uploaded tarballs under
-// `backfill/org=<org_uuid>/suite=<suite_uuid>/...` so the training pipeline
-// can ingest by suite without inspecting tarball contents. This replaces the
-// legacy org-scoped endpoint at
-// `/v2/analytics/organizations/:org/commit-metadata-backfill/presigned-upload`,
-// which is being removed in a follow-up server release.
 func (c Client) PresignUpload(ctx context.Context, suiteSlug string) (PresignedUploadResponse, error) {
 	reqURL := fmt.Sprintf(
 		"%s/v2/analytics/organizations/%s/suites/%s/commit-metadata-backfill/presigned-upload",

--- a/internal/command/backfill_commit_metadata.go
+++ b/internal/command/backfill_commit_metadata.go
@@ -229,7 +229,7 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 		fmt.Fprintf(os.Stderr, "Wrote %s\n", cfg.Output)
 	} else {
 		fmt.Fprintln(os.Stderr, "Requesting presigned upload URL...")
-		presigned, err := apiClient.PresignUpload(ctx)
+		presigned, err := apiClient.PresignUpload(ctx, cfg.SuiteSlug)
 		if err != nil {
 			removeTarball = false
 			fmt.Fprintf(os.Stderr, "Tarball retained at %s\n", tarPath)
@@ -277,7 +277,7 @@ func uploadOnly(ctx context.Context, cfg *config.Config) error {
 
 	// 4. Request presigned upload URL
 	fmt.Fprintln(os.Stderr, "Requesting presigned upload URL...")
-	presigned, err := apiClient.PresignUpload(ctx)
+	presigned, err := apiClient.PresignUpload(ctx, cfg.SuiteSlug)
 	if err != nil {
 		return fmt.Errorf("presigning upload: %w", err)
 	}

--- a/internal/command/backfill_commit_metadata.go
+++ b/internal/command/backfill_commit_metadata.go
@@ -257,32 +257,41 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 // via presigned S3 POST. This is the upload-only path for --upload, intended for
 // cases where generation and upload happen in separate steps.
 func uploadOnly(ctx context.Context, cfg *config.Config) error {
-	// 1. Verify file exists
+	// 1. Defensive contract check. Callers (today: main.go) are expected to call
+	// cfg.ValidateForBackfillCommitMetadata() first; this guard makes the layer
+	// boundary safe if that ever stops being true. Empty suite slug would otherwise
+	// produce a malformed URL with a `//` segment that 404s after a network round
+	// trip and a token-scope check.
+	if cfg.SuiteSlug == "" {
+		return fmt.Errorf("suite slug must not be blank (set --suite-slug or BUILDKITE_TEST_ENGINE_SUITE_SLUG)")
+	}
+
+	// 2. Verify file exists
 	if _, err := os.Stat(cfg.UploadFile); err != nil {
 		return fmt.Errorf("file not found: %w", err)
 	}
 
-	// 2. Create API client
+	// 3. Create API client
 	apiClient := api.NewClient(api.ClientConfig{
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
 		ServerBaseUrl:    cfg.ServerBaseUrl,
 	})
 
-	// 3. Verify token scopes
+	// 4. Verify token scopes
 	if _, err := apiClient.VerifyTokenScopes(ctx, []string{"write_suites"}); err != nil {
 		return fmt.Errorf("token scope check failed: %w", err)
 	}
 	debug.Println("Token scopes verified")
 
-	// 4. Request presigned upload URL
+	// 5. Request presigned upload URL
 	fmt.Fprintln(os.Stderr, "Requesting presigned upload URL...")
 	presigned, err := apiClient.PresignUpload(ctx, cfg.SuiteSlug)
 	if err != nil {
 		return fmt.Errorf("presigning upload: %w", err)
 	}
 
-	// 5. Upload to S3
+	// 6. Upload to S3
 	fmt.Fprintln(os.Stderr, "Uploading to S3...")
 	if err := upload.UploadToS3(ctx, cfg.UploadFile, presigned.Form); err != nil {
 		return fmt.Errorf("uploading to S3: %w", err)

--- a/internal/command/backfill_commit_metadata_test.go
+++ b/internal/command/backfill_commit_metadata_test.go
@@ -556,6 +556,41 @@ func TestBackfillCommitMetadata_UploadOnly_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestBackfillCommitMetadata_UploadOnly_MissingSuiteSlugFailsBeforeNetwork(t *testing.T) {
+	// Pins the contract that uploadOnly's defensive guard catches an empty
+	// suite slug before any network round trip. Today this can only be hit if
+	// a caller skips cfg.ValidateForBackfillCommitMetadata(); the guard makes
+	// the layer boundary safe regardless.
+
+	var requestCount int
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer apiServer.Close()
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-tarball-*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.WriteString("fake tarball content")
+	tmpFile.Close()
+
+	cfg := getUploadConfig(apiServer.URL, tmpFile.Name())
+	cfg.SuiteSlug = "" // bypass validation gate, exercise the in-command guard
+
+	err = BackfillCommitMetadata(context.Background(), cfg, nil)
+	if err == nil {
+		t.Fatal("expected error for empty suite slug, got nil")
+	}
+	if !strings.Contains(err.Error(), "suite slug must not be blank") {
+		t.Errorf("expected suite-slug error, got: %v", err)
+	}
+	if requestCount != 0 {
+		t.Errorf("expected no network requests, got %d", requestCount)
+	}
+}
+
 func TestBackfillCommitMetadata_UploadOnly_ScopeCheckFails(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/command/backfill_commit_metadata_test.go
+++ b/internal/command/backfill_commit_metadata_test.go
@@ -320,7 +320,7 @@ func TestBackfillCommitMetadata_Upload(t *testing.T) {
 			w.Header().Set("Content-Type", "text/plain")
 			w.Write([]byte("abc123\n"))
 
-		case "/v2/analytics/organizations/my-org/commit-metadata-backfill/presigned-upload":
+		case "/v2/analytics/organizations/my-org/suites/my-suite/commit-metadata-backfill/presigned-upload":
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"uri": "s3://bucket/test.tar.gz",
 				"form": map[string]interface{}{
@@ -445,6 +445,7 @@ func getUploadConfig(serverURL string, filePath string) *config.Config {
 	cfg := config.New()
 	cfg.AccessToken = "test-token"
 	cfg.OrganizationSlug = "my-org"
+	cfg.SuiteSlug = "my-suite"
 	cfg.ServerBaseUrl = serverURL
 	cfg.UploadFile = filePath
 	return &cfg
@@ -491,7 +492,7 @@ func TestBackfillCommitMetadata_UploadOnly_HappyPath(t *testing.T) {
 				"uuid":   "token-uuid",
 				"scopes": []string{"write_suites"},
 			})
-		case "/v2/analytics/organizations/my-org/commit-metadata-backfill/presigned-upload":
+		case "/v2/analytics/organizations/my-org/suites/my-suite/commit-metadata-backfill/presigned-upload":
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"uri": "s3://bucket/test.tar.gz",
 				"form": map[string]interface{}{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -123,8 +123,9 @@ func (c *Config) ValidateForRun() error {
 }
 
 // ValidateForBackfillCommitMetadata validates config for the backfill-commit-metadata command.
-// When --upload is set, only API connection fields are required.
-// Otherwise, requires API connection fields plus suite slug, days, and concurrency.
+// API connection fields and suite slug are required in all modes (the presigned upload
+// endpoint is suite-scoped). Collection-only fields (days, concurrency) are checked when
+// --upload is not set.
 func (c *Config) ValidateForBackfillCommitMetadata() error {
 	if c.ServerBaseUrl == "" {
 		c.ServerBaseUrl = "https://api.buildkite.com"

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -142,16 +142,18 @@ func (c *Config) ValidateForBackfillCommitMetadata() error {
 		c.errs.appendFieldError("--organization-slug / BUILDKITE_ORGANIZATION_SLUG", "must not be blank")
 	}
 
-	// Upload-only mode: only need API connection fields (no suite slug, days, etc.)
+	// SuiteSlug is required in both modes: the presigned upload endpoint is
+	// suite-scoped, so even upload-only needs the suite to construct the URL.
+	if c.SuiteSlug == "" {
+		c.errs.appendFieldError("--suite-slug / BUILDKITE_TEST_ENGINE_SUITE_SLUG", "must not be blank")
+	}
+
+	// Upload-only mode: skip days/concurrency checks (those govern collection).
 	if c.UploadFile != "" {
 		if len(c.errs) > 0 {
 			return c.errs
 		}
 		return nil
-	}
-
-	if c.SuiteSlug == "" {
-		c.errs.appendFieldError("--suite-slug / BUILDKITE_TEST_ENGINE_SUITE_SLUG", "must not be blank")
 	}
 
 	if got, min := c.Days, 1; got < min {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -498,13 +498,36 @@ func TestConfigValidateForBackfill_MissingAccessToken(t *testing.T) {
 	}
 }
 
-func TestConfigValidateForBackfill_UploadOnlySkipsSuiteSlug(t *testing.T) {
+func TestConfigValidateForBackfill_UploadOnlyRequiresSuiteSlug(t *testing.T) {
+	// The presigned upload endpoint is suite-scoped, so --suite-slug is
+	// required in upload-only mode too. Days/concurrency are still skipped
+	// (those govern collection, which doesn't run with --upload).
 	c := createBackfillConfig()
 	c.SuiteSlug = ""
 	c.UploadFile = "/tmp/test.tar.gz"
 	err := c.ValidateForBackfillCommitMetadata()
+
+	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Fatalf("ValidateForBackfillCommitMetadata() error = %v, want InvalidConfigError", err)
+	}
+
+	key := "--suite-slug / BUILDKITE_TEST_ENGINE_SUITE_SLUG"
+	if len(invConfigError[key]) != 1 {
+		t.Errorf("ValidateForBackfillCommitMetadata() error for %s length = %d, want 1", key, len(invConfigError[key]))
+	}
+}
+
+func TestConfigValidateForBackfill_UploadOnlySkipsDaysAndConcurrency(t *testing.T) {
+	// In upload-only mode, the collection-side checks (--days, --concurrency)
+	// don't apply because the command only uploads an existing tarball.
+	c := createBackfillConfig()
+	c.UploadFile = "/tmp/test.tar.gz"
+	c.Days = 0        // would be invalid for collection mode
+	c.Concurrency = 0 // would be invalid for collection mode
+	err := c.ValidateForBackfillCommitMetadata()
 	if err != nil {
-		t.Errorf("ValidateForBackfillCommitMetadata() error = %v, want nil (upload mode skips suite slug)", err)
+		t.Errorf("ValidateForBackfillCommitMetadata() error = %v, want nil (upload mode skips days/concurrency)", err)
 	}
 }
 


### PR DESCRIPTION
## Description

`bktec tools backfill-commit-metadata` currently POSTs to the org-scoped presigned-upload endpoint at
`/v2/analytics/organizations/:org/commit-metadata-backfill/presigned-upload`. [TE-5569](https://linear.app/buildkite/issue/TE-5569) added a suite-scoped replacement at
`/v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload`.

This PR is the bktec-side half of the migration. It is the required intermediate step before [TE-5784](https://linear.app/buildkite/issue/TE-5784), which removes the legacy org-scoped endpoint server-side after a one-release deprecation window. The legacy endpoint is currently kept alive behind RFC 9745 / 8594 deprecation headers.

### Breaking change (preview feature)

`--suite-slug` (env: `BUILDKITE_TEST_ENGINE_SUITE_SLUG`) is now required for `--upload` as well as for collection. Previously `--upload` only needed `--access-token` and `--organization-slug` because the endpoint was org-scoped; the suite slug now appears in the URL so it must be provided up front.

The feature remains gated behind `BKTEC_PREVIEW_SELECTION` and is documented as preview.

`--days`, `--concurrency`, `--remote`, and `--skip-diffs` are still skipped under `--upload` (those govern collection, which doesn't run with an existing tarball).

### Why not read suite slug from the tarball's `metadata.json`?

The tarball wrapper directory and `metadata.json` already contain `suite_slug`, so the upload-only path could in principle keep its existing UX by extracting it. We discussed and rejected that: it adds a tarball-parse step before validation runs and makes the required-flag set depend on file contents. Requiring the flag is simpler and more explicit.

## Context

Resolves [TE-5780](https://linear.app/buildkite/issue/TE-5780).

Parent: [TE-5569](https://linear.app/buildkite/issue/TE-5569).

## Changes

Best reviewed commit-by-commit:

- `[TE-5780]` Switch `PresignUpload` to suite-scoped commit-metadata-backfill endpoint
- `[TE-5780]` Pass suite slug from config through to `PresignUpload`
- `[TE-5780]` Require `--suite-slug` for backfill `--upload` mode
- `[TE-5780]` Update backfill tests to mock the suite-scoped endpoint
- `[TE-5780]` Document suite-scoped backfill upload as a breaking change
- `[TE-5780]` Address review: trim explanatory prose from doc comment, CHANGELOG, README

## Verification

Backed by specs. To verify locally:

```bash
go build ./...
go test ./internal/api/... ./internal/command/... ./internal/config/... -count=1
```

End-to-end manual check once the server endpoint is live in production. Run from a checkout of a repo whose suite has commit history in Test Engine, with `BKTEC_PREVIEW_SELECTION=1` set.

1. **Default path (collect + upload in one shot)** — exercises git collection, packaging, and the new suite-scoped endpoint together:

   ```bash
   bktec tools backfill-commit-metadata \
     --access-token "$BKUA" \
     --organization-slug my-org \
     --suite-slug my-suite
   ```

2. **Generate locally, upload separately** — exercises `--output` and `--upload` against the new endpoint:

   ```bash
   bktec tools backfill-commit-metadata \
     --access-token "$BKUA" \
     --organization-slug my-org \
     --suite-slug my-suite \
     --output /tmp/backfill.tar.gz

   bktec tools backfill-commit-metadata \
     --access-token "$BKUA" \
     --organization-slug my-org \
     --suite-slug my-suite \
     --upload /tmp/backfill.tar.gz
   ```

3. **Negative check** — confirm `--upload` without `--suite-slug` now fails fast with a validation error rather than hitting the network:

   ```bash
   bktec tools backfill-commit-metadata \
     --access-token "$BKUA" \
     --organization-slug my-org \
     --upload /tmp/backfill.tar.gz
   ```

In all three positive cases, confirm the upload request hits `/v2/analytics/organizations/my-org/suites/my-suite/commit-metadata-backfill/presigned-upload` and the command exits 0.

## Deployment

**Draft — not ready to merge.** Waiting for the suite-scoped REST API endpoint from [TE-5569](https://linear.app/buildkite/issue/TE-5569) to be released to production. Merging and cutting a bktec release before then would point bktec at an endpoint that returns 404. Once that has landed, this PR can be marked ready, merged, and a new bktec release cut.

Low risk once the dependency is in place: the change is a URL swap plus one new required flag in upload-only mode, gated behind the existing `BKTEC_PREVIEW_SELECTION` preview feature.

## Rollback

Yes — revert the bktec release. The legacy org-scoped endpoint stays live for one bktec release cycle behind deprecation headers, so a reverted bktec build keeps working until [TE-5784](https://linear.app/buildkite/issue/TE-5784) lands.

AI assisted.


