### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.5.0 - 2026-05-08
 - **Breaking (preview feature):** `bktec tools backfill-commit-metadata` now calls the suite-scoped commit-metadata backfill presigned-upload endpoint (`POST /v2/analytics/organizations/:org/suites/:suite/commit-metadata-backfill/presigned-upload`) instead of the org-scoped one. `--suite-slug` (or `BUILDKITE_TEST_ENGINE_SUITE_SLUG`) is now required for `--upload` as well as for collection. The legacy org-scoped endpoint is being removed in a follow-up server release. This is a preview feature gated behind `BKTEC_PREVIEW_SELECTION`.
 - Remove Pact contract testing for the Test Engine API. Consumer tests now use plain `httptest` fixtures (no behaviour change for users); the `internal/api/pacts/` directory, `pact-go` dependency, and `bin/{publish-pact,release-pact-version,pact-record-support-ended}` scripts have been deleted.
 


### PR DESCRIPTION
## Description

Cuts `bktec` v2.5.0. Renames the `## Unreleased` section in `CHANGELOG.md` to `## 2.5.0 - 2026-05-08`. No code changes.

The release pipeline (`.buildkite/pipeline.release.yml`) is interactive (`svu`-driven prompt) and runs after this PR merges; an operator picks the **minor** bump option there.

## Context

Resolves [TE-5788](https://linear.app/buildkite/issue/TE-5788) (sub-issue of [TE-5780](https://linear.app/buildkite/issue/TE-5780)).

## Stacked on top of [#497](https://github.com/buildkite/test-engine-client/pull/497)

This PR's base branch is `te-5780-bktec-suite-scoped-backfill-upload`, not `main`, because the TE-5780 work it ships is still in draft on #497. When that PR merges, GitHub will auto-rebase this one onto `main` and the diff collapses to the single-line CHANGELOG rename.

## Verification

After merge and after the release pipeline runs, confirm:

1. https://github.com/buildkite/test-engine-client/releases shows `v2.5.0` with the CHANGELOG entry surfaced.
2. End-to-end smoke against production using a real suite (see [TE-5780](https://linear.app/buildkite/issue/TE-5780) PR for the same checks):
   - Default path: `bktec tools backfill-commit-metadata` -- request hits `/v2/analytics/organizations/<org>/suites/<suite>/commit-metadata-backfill/presigned-upload`.
   - Two-step: `--output` then `--upload <tarball> --suite-slug <suite>` -- same endpoint.
   - Negative: `--upload <tarball>` without `--suite-slug` -- fails validation up front, no network call.

## Deployment

**Draft -- not ready to merge.** Two prerequisites:

1. [#497](https://github.com/buildkite/test-engine-client/pull/497) (TE-5780) merged to `main`.
2. The upstream REST API endpoint from [TE-5569](https://linear.app/buildkite/issue/TE-5569) released to production.

Merging or releasing before either prerequisite is met would point bktec at a 404.

After release, two downstream tickets become unblocked:

- [TE-5784](https://linear.app/buildkite/issue/TE-5784) -- delete the legacy org-scoped endpoint server-side. The deprecation window was deliberately one bktec release.
- [TE-5781](https://linear.app/buildkite/issue/TE-5781) -- training pipeline drops the `tar tzf | head` slug filter, becomes runnable once a v2.5.0 run has uploaded to the new prefix.

## Rollback

Yes -- pin users to `v2.4.0`, or revert and cut `v2.5.1`. The legacy org-scoped endpoint stays live for one bktec release cycle behind deprecation headers, so reverted bktec builds keep working until [TE-5784](https://linear.app/buildkite/issue/TE-5784) lands.
