### PR TITLE
Rework `runner.buildCommand()` method signature

### DIFF
--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -377,8 +377,13 @@ func (r metadataTestRunner) Run(result *runner.RunResult, testCases []plan.TestC
 	return nil
 }
 
-func (r metadataTestRunner) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
-	return "metadata-test-runner", testCases, nil
+func (r metadataTestRunner) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
+	paths := make([]string, len(testCases))
+	for i, tc := range testCases {
+		paths[i] = tc.Path
+	}
+
+	return "metadata-test-runner", paths, nil
 }
 
 func TestCreateRequestParams_FilterTestsError(t *testing.T) {

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -6,9 +6,11 @@ import (
 	"os/exec"
 	"os/signal"
 	"syscall"
+
+	"github.com/buildkite/test-engine-client/internal/plan"
 )
 
-func buildCommand(runner TestRunner, testCases []string, retry bool) (*exec.Cmd, error) {
+func buildCommand(runner TestRunner, testCases []plan.TestCase, retry bool) (*exec.Cmd, error) {
 	commandName, commandArgs, err := runner.CommandNameAndArgs(testCases, retry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build command: %w", err)

--- a/internal/runner/cucumber.go
+++ b/internal/runner/cucumber.go
@@ -67,12 +67,7 @@ func (c Cucumber) GetFiles() ([]string, error) {
 
 // Run executes the Cucumber command and records results.
 func (c Cucumber) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(c, testPaths, retry)
+	cmd, err := buildCommand(c, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -163,7 +158,8 @@ func (c Cucumber) GetExamples(files []string) ([]plan.TestCase, error) {
 		}
 	}()
 
-	cmdName, _, err := c.CommandNameAndArgs(files, false)
+	testCases := testCasesFromPaths(files)
+	cmdName, _, err := c.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +181,8 @@ func (c Cucumber) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, fmt.Errorf("failed to parse cucumber dry run JSON report from %s: %w", f.Name(), parseErr)
 	}
 
-	var testCases []plan.TestCase
+	testCases = nil
+
 	for _, feature := range dryRunReport {
 		for _, scenario := range feature.Elements {
 			if scenario.Type == "scenario" { // Only include scenarios, not scenario outlines directly (examples are handled differently)
@@ -207,7 +204,9 @@ func (c Cucumber) GetExamples(files []string) ([]plan.TestCase, error) {
 }
 
 // CommandNameAndArgs replaces placeholders and returns command + args.
-func (c Cucumber) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (c Cucumber) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
+	testPaths := pathsFromTestCases(testCases)
+
 	cmd := c.TestCommand
 	if retry {
 		cmd = c.RetryTestCommand
@@ -220,9 +219,9 @@ func (c Cucumber) CommandNameAndArgs(testCases []string, retry bool) (string, []
 
 	idx := slices.Index(words, "{{testExamples}}")
 	if idx < 0 {
-		words = append(words, testCases...)
+		words = append(words, testPaths...)
 	} else {
-		words = slices.Replace(words, idx, idx+1, testCases...)
+		words = slices.Replace(words, idx, idx+1, testPaths...)
 	}
 
 	idx = slices.Index(words, "{{resultPath}}")

--- a/internal/runner/cucumber_test.go
+++ b/internal/runner/cucumber_test.go
@@ -414,7 +414,7 @@ func TestCucumberRun_ScenarioStatuses(t *testing.T) {
 }
 
 func TestCucumberCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"features/spells/expelliarmus.feature", "features/failure.feature"}
+	testCases := []plan.TestCase{{Path: "features/spells/expelliarmus.feature"}, {Path: "features/failure.feature"}}
 	testCommand := "cucumber --format json --out {{resultPath}} {{testExamples}}"
 
 	c := NewCucumber(RunnerConfig{
@@ -439,7 +439,7 @@ func TestCucumberCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestCucumberCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
-	testCases := []string{"features/spells/expelliarmus.feature", "features/failure.feature"}
+	testCases := []plan.TestCase{{Path: "features/spells/expelliarmus.feature"}, {Path: "features/failure.feature"}}
 	testCommand := "cucumber --format json --out {{resultPath}}"
 
 	c := NewCucumber(RunnerConfig{
@@ -464,7 +464,7 @@ func TestCucumberCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T)
 }
 
 func TestCucumberCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"features/spells/expelliarmus.feature", "features/failure.feature"}
+	testCases := []plan.TestCase{{Path: "features/spells/expelliarmus.feature"}, {Path: "features/failure.feature"}}
 	testCommand := "cucumber --format json --out '{{resultPath}} {{testExamples}}"
 
 	c := NewCucumber(RunnerConfig{

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -58,13 +58,7 @@ func (r Custom) GetExamples(files []string) ([]plan.TestCase, error) {
 }
 
 func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(r, testPaths, retry)
+	cmd, err := buildCommand(r, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -100,12 +94,15 @@ func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	return cmdErr
 }
 
-func (r Custom) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (r Custom) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := r.TestCommand
 	if retry {
 		cmd = r.RetryTestCommand
 	}
-	cmd = strings.Replace(cmd, "{{testExamples}}", strings.Join(testCases, " "), 1)
+
+	testPaths := pathsFromTestCases(testCases)
+
+	cmd = strings.Replace(cmd, "{{testExamples}}", strings.Join(testPaths, " "), 1)
 
 	words, err := shellquote.Split(cmd)
 	if err != nil {

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -80,7 +80,7 @@ func TestCustom_GetFiles(t *testing.T) {
 }
 
 func TestCustom_CommandNameAndArgs(t *testing.T) {
-	testCases := []string{"tests/test_a.sh", "tests/test_b.sh"}
+	testCases := []plan.TestCase{{Path: "tests/test_a.sh"}, {Path: "tests/test_b.sh"}}
 
 	commands := []struct {
 		command  string

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -37,12 +37,7 @@ func NewCypress(c RunnerConfig) Cypress {
 }
 
 func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(c, testPaths, retry)
+	cmd, err := buildCommand(c, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -72,7 +67,7 @@ func (c Cypress) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in Cypress")
 }
 
-func (c Cypress) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (c Cypress) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := c.TestCommand
 	if retry {
 		cmd = c.RetryTestCommand
@@ -82,7 +77,10 @@ func (c Cypress) CommandNameAndArgs(testCases []string, retry bool) (string, []s
 		return "", []string{}, err
 	}
 	idx := slices.Index(words, "{{testExamples}}")
-	specs := strings.Join(testCases, ",")
+
+	testPaths := pathsFromTestCases(testCases)
+
+	specs := strings.Join(testPaths, ",")
 	if idx < 0 {
 		words = append(words, "--spec", specs)
 	} else {

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -117,7 +117,7 @@ func TestCypressGetFiles(t *testing.T) {
 }
 
 func TestCypressCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"cypress/e2e/passing_spec.cy.js", "cypress/e2e/flaky_spec.cy.js"}
+	testCases := []plan.TestCase{{Path: "cypress/e2e/passing_spec.cy.js"}, {Path: "cypress/e2e/flaky_spec.cy.js"}}
 	testCommand := "cypress run --spec {{testExamples}}"
 
 	cy := NewCypress(RunnerConfig{
@@ -142,7 +142,7 @@ func TestCypressCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestCypressCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
-	testCases := []string{"cypress/e2e/passing_spec.cy.js", "cypress/e2e/flaky_spec.cy.js"}
+	testCases := []plan.TestCase{{Path: "cypress/e2e/passing_spec.cy.js"}, {Path: "cypress/e2e/flaky_spec.cy.js"}}
 	testCommand := "cypress run"
 
 	cypress := NewCypress(RunnerConfig{
@@ -166,7 +166,7 @@ func TestCypressCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) 
 }
 
 func TestCypressCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"cypress/e2e/passing_spec.cy.js", "cypress/e2e/flaky_spec.cy.js"}
+	testCases := []plan.TestCase{{Path: "cypress/e2e/passing_spec.cy.js"}, {Path: "cypress/e2e/flaky_spec.cy.js"}}
 	testCommand := "cypress run --options '{{testExamples}}"
 
 	cypress := NewCypress(RunnerConfig{

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -12,7 +12,7 @@ type TestRunner interface {
 	GetExamples(files []string) ([]plan.TestCase, error)
 	GetFiles() ([]string, error)
 	Name() string
-	CommandNameAndArgs(testCases []string, retry bool) (string, []string, error)
+	CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error)
 	LocationPrefix() string
 }
 

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -42,12 +42,7 @@ func (g GoTest) GetExamples(files []string) ([]plan.TestCase, error) {
 
 // Run executes the configured command for the specified packages.
 func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	packages, err := g.getPackages(testCases)
-	if err != nil {
-		return fmt.Errorf("failed to generate test package list: %w", err)
-	}
-
-	cmd, err := buildCommand(g, packages, retry)
+	cmd, err := buildCommand(g, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -114,7 +109,12 @@ func (g GoTest) GetFiles() ([]string, error) {
 	return validPackages, nil
 }
 
-func (g GoTest) CommandNameAndArgs(packages []string, retry bool) (string, []string, error) {
+func (g GoTest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
+	packages, err := g.getPackages(testCases)
+	if err != nil {
+		return "", []string{}, fmt.Errorf("failed to generate test package list: %w", err)
+	}
+
 	cmd := g.TestCommand
 	if retry {
 		cmd = g.RetryTestCommand

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -61,16 +61,12 @@ func (j Jest) GetFiles() ([]string, error) {
 func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	var cmd *exec.Cmd
 
-	testPaths := make([]string, len(testCases))
-	for i, testCase := range testCases {
-		testPaths[i] = testCase.Path
-	}
-
+	testPaths := pathsFromTestCases(testCases)
 	slices.Sort(testPaths)
 	testPaths = slices.Compact(testPaths)
 
 	if !retry {
-		commandName, commandArgs, err := j.CommandNameAndArgs(testPaths, false)
+		commandName, commandArgs, err := j.CommandNameAndArgs(testCases, false)
 		if err != nil {
 			return fmt.Errorf("failed to build command: %w", err)
 		}
@@ -183,7 +179,7 @@ func (j Jest) ParseReport(path string) (JestReport, error) {
 	return report, nil
 }
 
-func (j Jest) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (j Jest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := j.TestCommand
 	if retry {
 		cmd = j.RetryTestCommand
@@ -194,11 +190,13 @@ func (j Jest) CommandNameAndArgs(testCases []string, retry bool) (string, []stri
 		return "", []string{}, err
 	}
 
+	testPaths := pathsFromTestCases(testCases)
+
 	idx := slices.Index(words, "{{testExamples}}")
 	if idx < 0 {
-		words = append(words, testCases...)
+		words = append(words, testPaths...)
 	} else {
-		words = slices.Replace(words, idx, idx+1, testCases...)
+		words = slices.Replace(words, idx, idx+1, testPaths...)
 	}
 
 	outputIdx := slices.Index(words, "{{resultPath}}")

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -337,7 +337,7 @@ func TestJestRun_SignaledError(t *testing.T) {
 }
 
 func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{{Path: "spec/user.spec.js"}, {Path: "spec/billing.spec.js"}}
 	testCommand := "jest {{testExamples}} --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -362,7 +362,7 @@ func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{{Path: "spec/user.spec.js"}, {Path: "spec/billing.spec.js"}}
 	testCommand := "jest --json --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -387,7 +387,7 @@ func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestJestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{{Path: "spec/user.spec.js"}, {Path: "spec/billing.spec.js"}}
 	testCommand := "jest --options '{{testExamples}}"
 
 	jest := NewJest(RunnerConfig{
@@ -414,9 +414,9 @@ func TestJestCommandNameAndArgs_WithSpecialCharactersInPath(t *testing.T) {
 	// Test paths with special regex characters like parentheses (Next.js route groups)
 	// and square brackets (Next.js dynamic routes). These are passed as-is because
 	// the default TestCommand uses --runTestsByPath which treats args as literal paths.
-	testCases := []string{
-		"src/app/(main)/page.test.tsx",
-		"src/app/(main)/[catalogId]/product.test.tsx",
+	testCases := []plan.TestCase{
+		{Path: "src/app/(main)/page.test.tsx"},
+		{Path: "src/app/(main)/[catalogId]/product.test.tsx"},
 	}
 	testCommand := "jest --runTestsByPath {{testExamples}} --outputFile {{resultPath}}"
 

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -64,9 +64,7 @@ func (n NUnit) GetExamples(files []string) ([]plan.TestCase, error) {
 // Test cases are mapped from .cs file paths to class names, and joined into a
 // FullyQualifiedName~ filter expression.
 func (n NUnit) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	classNames := extractClassNames(testCases)
-
-	cmd, err := buildCommand(n, classNames, retry)
+	cmd, err := buildCommand(n, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -121,7 +119,9 @@ func buildTestFilter(classNames []string) string {
 	return strings.Join(parts, "|")
 }
 
-func (n NUnit) CommandNameAndArgs(classNames []string, retry bool) (string, []string, error) {
+func (n NUnit) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
+	classNames := extractClassNames(testCases)
+
 	cmd := n.TestCommand
 	if retry {
 		cmd = n.RetryTestCommand

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -115,7 +115,7 @@ func TestNUnit_CommandNameAndArgs(t *testing.T) {
 		ResultPath: "test-results.xml",
 	})
 
-	classNames := []string{"CalculatorTests", "StringUtilsTests"}
+	classNames := []plan.TestCase{{Path: "CalculatorTests"}, {Path: "StringUtilsTests"}}
 
 	gotName, gotArgs, err := nunit.CommandNameAndArgs(classNames, false)
 	if err != nil {

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -41,12 +41,7 @@ func NewPlaywright(p RunnerConfig) Playwright {
 }
 
 func (p Playwright) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(p, testPaths, retry)
+	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -108,7 +103,7 @@ func (p Playwright) getTestResultsFromSuite(suite PlaywrightReportSuite, suiteNa
 	return testResults
 }
 
-func (p Playwright) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (p Playwright) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := p.TestCommand
 	if retry {
 		cmd = p.RetryTestCommand
@@ -118,11 +113,14 @@ func (p Playwright) CommandNameAndArgs(testCases []string, retry bool) (string, 
 	if err != nil {
 		return "", []string{}, err
 	}
+
+	testPaths := pathsFromTestCases(testCases)
+
 	idx := slices.Index(words, "{{testExamples}}")
 	if idx < 0 {
-		words = append(words, testCases...)
+		words = append(words, testPaths...)
 	} else {
-		words = slices.Replace(words, idx, idx+1, testCases...)
+		words = slices.Replace(words, idx, idx+1, testPaths...)
 	}
 
 	return words[0], words[1:], nil
@@ -174,7 +172,8 @@ func (p Playwright) GetExamples(files []string) ([]plan.TestCase, error) {
 	tmpFile.Close()
 	defer os.Remove(tmpPath)
 
-	cmdName, cmdArgs, err := p.CommandNameAndArgs(files, false)
+	testCases := testCasesFromPaths(files)
+	cmdName, cmdArgs, err := p.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		return []plan.TestCase{}, err
 	}
@@ -199,7 +198,7 @@ func (p Playwright) GetExamples(files []string) ([]plan.TestCase, error) {
 		return []plan.TestCase{}, fmt.Errorf("failed to parse playwright test list output: %w", err)
 	}
 
-	var testCases []plan.TestCase
+	testCases = nil
 	for _, suite := range report.Suites {
 		testCases = append(testCases, p.getTestCasesFromSuite(suite, suite.Title)...)
 	}

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -196,7 +196,7 @@ func TestPlaywrightRun_SignaledError(t *testing.T) {
 }
 
 func TestPlaywrightCommandNameAndArgs_WithPlaceholder(t *testing.T) {
-	testCases := []string{"tests/example.spec.js", "tests/failed.spec.js"}
+	testCases := []plan.TestCase{{Path: "tests/example.spec.js"}, {Path: "tests/failed.spec.js"}}
 	testCommand := "npx playwright test {{testExamples}}"
 
 	rspec := NewPlaywright(RunnerConfig{
@@ -220,7 +220,7 @@ func TestPlaywrightCommandNameAndArgs_WithPlaceholder(t *testing.T) {
 }
 
 func TestPlaywrightCommandNameAndArgs_WithoutPlaceholder(t *testing.T) {
-	testCases := []string{"tests/example.spec.js", "tests/failed.spec.js"}
+	testCases := []plan.TestCase{{Path: "tests/example.spec.js"}, {Path: "tests/failed.spec.js"}}
 	testCommand := "npx playwright test"
 
 	rspec := NewPlaywright(RunnerConfig{

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -60,12 +60,7 @@ func NewPytest(c RunnerConfig) Pytest {
 }
 
 func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(p, testPaths, retry)
+	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -203,13 +198,15 @@ func mapNodeIdToTestCase(nodeId string) plan.TestCase {
 	}
 }
 
-func (p Pytest) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (p Pytest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := p.TestCommand
 	if retry {
 		cmd = p.RetryTestCommand
 	}
 
-	testExamples := shellquote.Join(testCases...)
+	testPaths := pathsFromTestCases(testCases)
+
+	testExamples := shellquote.Join(testPaths...)
 
 	if strings.Contains(cmd, "{{testExamples}}") {
 		cmd = strings.Replace(cmd, "{{testExamples}}", testExamples, 1)

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -51,12 +51,7 @@ func NewPytestPants(c RunnerConfig) PytestPants {
 }
 
 func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(p, testPaths, retry)
+	cmd, err := buildCommand(p, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -102,7 +97,7 @@ func (p PytestPants) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in pytest pants")
 }
 
-func (p PytestPants) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (p PytestPants) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := p.TestCommand
 	if retry {
 		cmd = p.RetryTestCommand

--- a/internal/runner/pytest_pants_test.go
+++ b/internal/runner/pytest_pants_test.go
@@ -154,7 +154,7 @@ func TestPytestPantsGetExamples(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_WithoutMergeJson(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test //:: -- --json={{resultPath}}"
 
 	pytest := NewPytestPants(RunnerConfig{
@@ -169,7 +169,7 @@ func TestPytestPantsCommandNameAndArgs_WithoutMergeJson(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_WithoutResultPath(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test //:: -- --merge-json"
 
 	pytest := NewPytestPants(RunnerConfig{
@@ -183,7 +183,7 @@ func TestPytestPantsCommandNameAndArgs_WithoutResultPath(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_PytestArgsBeforeDash(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test --json={{resultPath}} --merge-json //::"
 
 	pytest := NewPytestPants(RunnerConfig{
@@ -197,7 +197,7 @@ func TestPytestPantsCommandNameAndArgs_PytestArgsBeforeDash(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_NoDashSeparator(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test //:: --json={{resultPath}} --merge-json"
 
 	pytest := NewPytestPants(RunnerConfig{
@@ -221,7 +221,7 @@ func TestPytestPantsCommandNameAndArgs_NoDashSeparator(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_ValidCommand(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test //:: -- --json={{resultPath}} --merge-json"
 
 	pytest := NewPytestPants(RunnerConfig{
@@ -246,7 +246,7 @@ func TestPytestPantsCommandNameAndArgs_ValidCommand(t *testing.T) {
 }
 
 func TestPytestPantsCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"failing_test.py", "passing_test.py"}
+	testCases := []plan.TestCase{{Path: "failing_test.py"}, {Path: "passing_test.py"}}
 	testCommand := "pants test //:: -- --json={{resultPath}}' --merge-json"
 
 	pytest := NewPytestPants(RunnerConfig{

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -155,7 +155,7 @@ func TestPytestGetFiles(t *testing.T) {
 }
 
 func TestPytestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCases := []plan.TestCase{{Path: "failed_test.py"}, {Path: "test_sample.py"}}
 	testCommand := "pytest {{testExamples}} --full-trace --json={{resultPath}}"
 
 	pytest := NewPytest(RunnerConfig{
@@ -180,7 +180,7 @@ func TestPytestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 }
 
 func TestPytestCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
-	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCases := []plan.TestCase{{Path: "failed_test.py"}, {Path: "test_sample.py"}}
 	testCommand := "pytest --full-trace"
 
 	pytest := NewPytest(RunnerConfig{
@@ -204,7 +204,7 @@ func TestPytestCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
 }
 
 func TestPytestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"failed_test.py", "test_sample.py"}
+	testCases := []plan.TestCase{{Path: "failed_test.py"}, {Path: "test_sample.py"}}
 	testCommand := "pytest '{{testExamples}}"
 
 	pytest := NewPytest(RunnerConfig{
@@ -228,9 +228,9 @@ func TestPytestCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 }
 
 func TestPytestCommandNameAndArgs_WithSpacesInTestCase(t *testing.T) {
-	testCases := []string{
-		"foo/bar.py::TestFoo::test_foo[min-WeightedScalar-valid_reduce_ops0-only sum or avg are supported-2]",
-		"test_sample.py::test_simple",
+	testCases := []plan.TestCase{
+		{Path: "foo/bar.py::TestFoo::test_foo[min-WeightedScalar-valid_reduce_ops0-only sum or avg are supported-2]"},
+		{Path: "test_sample.py::test_simple"},
 	}
 	testCommand := "pytest {{testExamples}} --json={{resultPath}}"
 

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -72,12 +72,7 @@ func (r Rspec) GetFiles() ([]string, error) {
 //
 // Test failure is not considered an error, and is instead returned as a RunResult.
 func (r Rspec) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	testPaths := make([]string, len(testCases))
-	for i, tc := range testCases {
-		testPaths[i] = tc.Path
-	}
-
-	cmd, err := buildCommand(r, testPaths, retry)
+	cmd, err := buildCommand(r, testCases, retry)
 	if err != nil {
 		return err
 	}
@@ -158,7 +153,7 @@ func (r Rspec) ParseReport(path string) (RspecReport, error) {
 
 // CommandNameAndArgs replaces the "{{testExamples}}" placeholder in the test command with the test cases.
 // It returns the command name and arguments to run the tests.
-func (r Rspec) CommandNameAndArgs(testCases []string, retry bool) (string, []string, error) {
+func (r Rspec) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {
 	cmd := r.TestCommand
 	if retry {
 		cmd = r.RetryTestCommand
@@ -169,11 +164,13 @@ func (r Rspec) CommandNameAndArgs(testCases []string, retry bool) (string, []str
 		return "", []string{}, err
 	}
 
+	testPaths := pathsFromTestCases(testCases)
+
 	idx := slices.Index(words, "{{testExamples}}")
 	if idx < 0 {
-		words = append(words, testCases...)
+		words = append(words, testPaths...)
 	} else {
-		words = slices.Replace(words, idx, idx+1, testCases...)
+		words = slices.Replace(words, idx, idx+1, testPaths...)
 	}
 
 	idx = slices.Index(words, "{{resultPath}}")
@@ -199,7 +196,8 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		os.Remove(f.Name())
 	}()
 
-	cmdName, cmdArgs, err := r.CommandNameAndArgs(files, false)
+	testCases := testCasesFromPaths(files)
+	cmdName, cmdArgs, err := r.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +217,7 @@ func (r Rspec) GetExamples(files []string) ([]plan.TestCase, error) {
 		return []plan.TestCase{}, err
 	}
 
-	var testCases []plan.TestCase
+	testCases = nil
 	for _, example := range report.Examples {
 		testCases = append(testCases, mapExampleToTestCase(example))
 	}

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -299,7 +299,7 @@ func TestRspecRun_SignaledError(t *testing.T) {
 }
 
 func TestRspecCommandNameAndArgs_WithPlaceholder(t *testing.T) {
-	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testCases := []plan.TestCase{{Path: "spec/models/user_spec.rb"}, {Path: "spec/models/billing_spec.rb"}}
 	testCommand := "bin/rspec --options {{testExamples}} --out {{resultPath}}"
 
 	rspec := NewRspec(RunnerConfig{
@@ -324,7 +324,7 @@ func TestRspecCommandNameAndArgs_WithPlaceholder(t *testing.T) {
 }
 
 func TestRspecCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
-	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testCases := []plan.TestCase{{Path: "spec/models/user_spec.rb"}, {Path: "spec/models/billing_spec.rb"}}
 	testCommand := "bin/rspec --options --format"
 
 	rspec := NewRspec(RunnerConfig{
@@ -348,7 +348,7 @@ func TestRspecCommandNameAndArgs_WithoutTestExamplesPlaceholder(t *testing.T) {
 }
 
 func TestRspecCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
-	testCases := []string{"spec/models/user_spec.rb", "spec/models/billing_spec.rb"}
+	testCases := []plan.TestCase{{Path: "spec/models/user_spec.rb"}, {Path: "spec/models/billing_spec.rb"}}
 	testCommand := "bin/rspec --options ' {{testExamples}}"
 
 	rspec := NewRspec(RunnerConfig{

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -1,0 +1,19 @@
+package runner
+
+import "github.com/buildkite/test-engine-client/internal/plan"
+
+func testCasesFromPaths(paths []string) []plan.TestCase {
+	testCases := make([]plan.TestCase, len(paths))
+	for i, path := range paths {
+		testCases[i] = plan.TestCase{Path: path}
+	}
+	return testCases
+}
+
+func pathsFromTestCases(testCases []plan.TestCase) []string {
+	paths := make([]string, len(testCases))
+	for i, tc := range testCases {
+		paths[i] = tc.Path
+	}
+	return paths
+}


### PR DESCRIPTION
This change reworks `runner.buildCommand` and `runner.CommandNameAndArgs` from taking a `[]string` argument to a `[]plan.TestCase` argument.

All the runners currently convert an array of `plan.TestCase` structs into an array of `string` and pass the string array into the methods above. This works for all the runners **except** for Jest, which needs access to an array of `plan.TestCase` instances to use the generic `runner.buildCommand` method.

The change in this PR will allow a rework of the Jest `Run` method to use `runner.buildCommand` in the same way as all the other runners.