### PR TITLE
Bind BUILDKITE_PARALLEL_JOB_COUNT in `bktec plan` (TE-5745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Remove Pact contract testing for the Test Engine API. Consumer tests now use plain `httptest` fixtures (no behaviour change for users); the `internal/api/pacts/` directory, `pact-go` dependency, and `bin/{publish-pact,release-pact-version,pact-record-support-ended}` scripts have been deleted.
+- Fix `bktec plan` so it honors `BUILDKITE_PARALLEL_JOB_COUNT` (and the `--parallelism` flag). Previously the value was dropped before being sent to the `filter_tests` API, which caused split-by-example to never identify slow files when planning.
 
 ## 2.4.0 - 2026-04-17
 - Automatically collect git commit metadata on `bktec plan` when `--selection-strategy` is set. Commit info, diff stats, and context fields are sent with the plan request so test selection has the signal it needs without the caller shelling out to git. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.

--- a/cli.go
+++ b/cli.go
@@ -519,6 +519,7 @@ func planCommandFlags() []cli.Flag {
 	flags = append(flags, buildEnvironmentFlags...)
 	flags = append(flags, testEngineFlags...)
 	flags = append(flags, runnerEnvironmentFlags...)
+	flags = append(flags, parallelismFlag)
 	flags = append(flags, previewSelectionFlags()...)
 	return flags
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -58,6 +58,12 @@ func TestCollectGitMetadataFlagIsGatedByPreviewEnv(t *testing.T) {
 	}
 }
 
+func TestPlanCommandIncludesParallelismFlag(t *testing.T) {
+	if !hasFlag(planCommandFlags(), "parallelism") {
+		t.Fatalf("planCommandFlags() missing --parallelism flag; BUILDKITE_PARALLEL_JOB_COUNT will not be bound to cfg.Parallelism for `bktec plan`, breaking split-by-example slow-file detection")
+	}
+}
+
 func TestApplyPlanRequestContext_ClearsCollectGitMetadataWhenPreviewDisabled(t *testing.T) {
 	t.Setenv(previewSelectionEnvVar, "")
 


### PR DESCRIPTION
### Description

`bktec plan` was silently dropping `BUILDKITE_PARALLEL_JOB_COUNT` because `parallelismFlag` was only registered in `runCommandFlags()`, not in `planCommandFlags()`. As a result, `cfg.Parallelism` stayed at its zero value, and the entire `Config` struct sent as the `env` payload to `filter_tests` had `"BUILDKITE_PARALLEL_JOB_COUNT": 0`. That trips the server's `return [] if @parallelism <= 0` guard in `TestFilesFilter#slow_files`, so split-by-example could never identify slow files when planning.

The fix is to add `parallelismFlag` to `planCommandFlags()` so the env var / `--parallelism` flag binds to `cfg.Parallelism` for `bktec plan`, the same way it does for `bktec run`.

### Context

- Linear: [TE-5745](https://linear.app/buildkite/issue/TE-5745/circle-buildkite-test-engine-split-by-example-not-producing-example)

### Changes

- `cli.go`: append `parallelismFlag` to `planCommandFlags()`.
- `cli_test.go`: add `TestPlanCommandIncludesParallelismFlag` regression test.
- `CHANGELOG.md`: note the fix under Unreleased.

### Testing

- `go build ./...`
- `go test ./...` — `TestPlanCommandIncludesParallelismFlag` passes; existing tests still pass.
