### PR TITLE
Port Jest to buildcommand

### DIFF
--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -59,14 +58,10 @@ func (j Jest) GetFiles() ([]string, error) {
 }
 
 func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
-	var cmd *exec.Cmd
-
-	commandName, commandArgs, err := j.CommandNameAndArgs(testCases, retry)
+	cmd, err := buildCommand(j, testCases, retry)
 	if err != nil {
-		return fmt.Errorf("failed to build command: %w", err)
+		return err
 	}
-
-	cmd = exec.Command(commandName, commandArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -61,29 +61,12 @@ func (j Jest) GetFiles() ([]string, error) {
 func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	var cmd *exec.Cmd
 
-	testPaths := pathsFromTestCases(testCases)
-	slices.Sort(testPaths)
-	testPaths = slices.Compact(testPaths)
-
-	if !retry {
-		commandName, commandArgs, err := j.CommandNameAndArgs(testCases, false)
-		if err != nil {
-			return fmt.Errorf("failed to build command: %w", err)
-		}
-
-		cmd = exec.Command(commandName, commandArgs...)
-	} else {
-		testNames := make([]string, len(testCases))
-		for i, testCase := range testCases {
-			testNames[i] = fmt.Sprintf("%s %s", testCase.Scope, testCase.Name)
-		}
-		commandName, commandArgs, err := j.retryCommandNameAndArgs(j.RetryTestCommand, testNames, testPaths)
-		if err != nil {
-			return fmt.Errorf("failed to build command: %w", err)
-		}
-
-		cmd = exec.Command(commandName, commandArgs...)
+	commandName, commandArgs, err := j.CommandNameAndArgs(testCases, retry)
+	if err != nil {
+		return fmt.Errorf("failed to build command: %w", err)
 	}
+
+	cmd = exec.Command(commandName, commandArgs...)
 
 	cmdErr := runAndForwardSignal(cmd)
 
@@ -191,12 +174,36 @@ func (j Jest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string,
 	}
 
 	testPaths := pathsFromTestCases(testCases)
+	slices.Sort(testPaths)
+	testPaths = slices.Compact(testPaths)
 
-	idx := slices.Index(words, "{{testExamples}}")
-	if idx < 0 {
-		words = append(words, testPaths...)
+	if retry {
+		idx := slices.Index(words, "{{testNamePattern}}")
+		if idx < 0 {
+			err := fmt.Errorf("couldn't find '{{testNamePattern}}' sentinel in retry command")
+			return "", []string{}, err
+		}
+
+		escapedTestCases := make([]string, len(testCases))
+		for i, testCase := range testCases {
+			escapedTestCases[i] = regexp.QuoteMeta(fmt.Sprintf("%s %s", testCase.Scope, testCase.Name))
+		}
+
+		testNamePattern := fmt.Sprintf("(%s)", strings.Join(escapedTestCases, "|"))
+
+		words = slices.Replace(words, idx, idx+1, testNamePattern)
+
+		testExamplesIdx := slices.Index(words, "{{testExamples}}")
+		if testExamplesIdx >= 0 {
+			words = slices.Replace(words, testExamplesIdx, testExamplesIdx+1, testPaths...)
+		}
 	} else {
-		words = slices.Replace(words, idx, idx+1, testPaths...)
+		idx := slices.Index(words, "{{testExamples}}")
+		if idx < 0 {
+			words = append(words, testPaths...)
+		} else {
+			words = slices.Replace(words, idx, idx+1, testPaths...)
+		}
 	}
 
 	outputIdx := slices.Index(words, "{{resultPath}}")
@@ -207,42 +214,6 @@ func (j Jest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string,
 	words = slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
 
 	return words[0], words[1:], nil
-}
-
-func (j Jest) retryCommandNameAndArgs(cmd string, testCases []string, testPaths []string) (string, []string, error) {
-	words, err := shellquote.Split(cmd)
-	if err != nil {
-		return "", []string{}, err
-	}
-
-	idx := slices.Index(words, "{{testNamePattern}}")
-	if idx < 0 {
-		err := fmt.Errorf("couldn't find '{{testNamePattern}}' sentinel in retry command")
-		return "", []string{}, err
-	}
-
-	escapedTestCases := make([]string, len(testCases))
-	for i, testCase := range testCases {
-		escapedTestCases[i] = regexp.QuoteMeta(testCase)
-	}
-
-	testNamePattern := fmt.Sprintf("(%s)", strings.Join(escapedTestCases, "|"))
-
-	words = slices.Replace(words, idx, idx+1, testNamePattern)
-
-	testExamplesIdx := slices.Index(words, "{{testExamples}}")
-	if testExamplesIdx >= 0 {
-		words = slices.Replace(words, testExamplesIdx, testExamplesIdx+1, testPaths...)
-	}
-
-	outputIdx := slices.Index(words, "{{resultPath}}")
-	if outputIdx < 0 {
-		err := fmt.Errorf("couldn't find '{{resultPath}}' sentinel in retry command, exiting")
-		return "", []string{}, err
-	}
-	words = slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
-
-	return words[0], words[1:], err
 }
 
 func (j Jest) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -351,7 +351,7 @@ func TestJestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	}
 
 	wantName := "jest"
-	wantArgs := []string{"spec/user.spec.js", "spec/billing.spec.js", "--outputFile", "jest.json"}
+	wantArgs := []string{"spec/billing.spec.js", "spec/user.spec.js", "--outputFile", "jest.json"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
@@ -376,7 +376,7 @@ func TestJestCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
 	}
 
 	wantName := "jest"
-	wantArgs := []string{"--json", "--outputFile", "jest.json", "spec/user.spec.js", "spec/billing.spec.js"}
+	wantArgs := []string{"--json", "--outputFile", "jest.json", "spec/billing.spec.js", "spec/user.spec.js"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
 		t.Errorf("commandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, testCommand, diff)
@@ -433,8 +433,8 @@ func TestJestCommandNameAndArgs_WithSpecialCharactersInPath(t *testing.T) {
 	wantName := "jest"
 	wantArgs := []string{
 		"--runTestsByPath",
-		"src/app/(main)/page.test.tsx",
 		"src/app/(main)/[catalogId]/product.test.tsx",
+		"src/app/(main)/page.test.tsx",
 		"--outputFile",
 		"jest.json",
 	}
@@ -448,8 +448,18 @@ func TestJestCommandNameAndArgs_WithSpecialCharactersInPath(t *testing.T) {
 }
 
 func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
-	testCases := []string{"this will fail", "this other one will fail"}
-	testPaths := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{
+		{
+			Scope: "this",
+			Name:  "will fail",
+			Path:  "spec/user.spec.js",
+		},
+		{
+			Scope: "this",
+			Name:  "other one will fail",
+			Path:  "spec/billing.spec.js",
+		},
+	}
 	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -457,25 +467,35 @@ func TestJestRetryCommandNameAndArgs_HappyPath(t *testing.T) {
 		ResultPath:       "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases, testPaths)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, true)
 	if err != nil {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
+		t.Errorf("CommandNameAndArgs(%q, %v) error = %v", testCases, true, err)
 	}
 
 	wantName := "jest"
 	wantArgs := []string{"--testNamePattern", "(this will fail|this other one will fail)", "--json", "--testLocationInResults", "--outputFile", "jest.json"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 }
 
 func TestJestRetryCommandNameAndArgs_WithSpecialCharacters(t *testing.T) {
-	testCases := []string{"test with special characters .+*?()|[]{}^$", "another test"}
-	testPaths := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{
+		{
+			Scope: "test",
+			Name:  "with special characters .+*?()|[]{}^$",
+			Path:  "spec/user.spec.js",
+		},
+		{
+			Scope: "another",
+			Name:  "test",
+			Path:  "spec/billing.spec.js",
+		},
+	}
 	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' --json --testLocationInResults --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -483,25 +503,35 @@ func TestJestRetryCommandNameAndArgs_WithSpecialCharacters(t *testing.T) {
 		ResultPath:       "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases, testPaths)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, true)
 	if err != nil {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
+		t.Errorf("CommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
 	}
 
 	wantName := "jest"
 	wantArgs := []string{"--testNamePattern", `(test with special characters \.\+\*\?\(\)\|\[\]\{\}\^\$|another test)`, "--json", "--testLocationInResults", "--outputFile", "jest.json"}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 }
 
 func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.T) {
-	testCases := []string{"this will fail", "this other one will fail"}
-	testPaths := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{
+		{
+			Scope: "this",
+			Name:  "will fail",
+			Path:  "spec/user.spec.js",
+		},
+		{
+			Scope: "this",
+			Name:  "other one will fail",
+			Path:  "spec/billing.spec.js",
+		},
+	}
 	retryTestCommand := "jest --json --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -509,28 +539,38 @@ func TestJestRetryCommandNameAndArgs_WithoutInterpolationPlaceholder(t *testing.
 		ResultPath:       "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases, testPaths)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, true)
 	fmt.Println(err)
 
 	wantName := ""
 	wantArgs := []string{}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("retryCommandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("CommandNameAndArgs() diff (-got +want):\n%s", diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("retryCommandNameAndArgs() diff (-got +want):\n%s", diff)
+		t.Errorf("CommandNameAndArgs() diff (-got +want):\n%s", diff)
 	}
 
 	desiredString := "couldn't find '{{testNamePattern}}' sentinel in retry command"
 	if err.Error() != desiredString {
-		t.Errorf("retryCommandNameAndArgs() error = %v, want %v", err, desiredString)
+		t.Errorf("CommandNameAndArgs() error = %v, want %v", err, desiredString)
 	}
 }
 
 func TestJestRetryCommandNameAndArgs_WithTestExamplesPlaceholder(t *testing.T) {
-	testCases := []string{"this will fail", "this other one will fail"}
-	testPaths := []string{"spec/user.spec.js", "spec/billing.spec.js"}
+	testCases := []plan.TestCase{
+		{
+			Scope: "this",
+			Name:  "will fail",
+			Path:  "spec/user.spec.js",
+		},
+		{
+			Scope: "this",
+			Name:  "other one will fail",
+			Path:  "spec/billing.spec.js",
+		},
+	}
 	retryTestCommand := "jest --testNamePattern '{{testNamePattern}}' {{testExamples}} --json --testLocationInResults --outputFile {{resultPath}}"
 
 	jest := NewJest(RunnerConfig{
@@ -538,17 +578,17 @@ func TestJestRetryCommandNameAndArgs_WithTestExamplesPlaceholder(t *testing.T) {
 		ResultPath:       "jest.json",
 	})
 
-	gotName, gotArgs, err := jest.retryCommandNameAndArgs(retryTestCommand, testCases, testPaths)
+	gotName, gotArgs, err := jest.CommandNameAndArgs(testCases, true)
 	if err != nil {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
+		t.Errorf("CommandNameAndArgs(%q, %q) error = %v", testCases, retryTestCommand, err)
 	}
 
 	wantName := "jest"
 	wantArgs := []string{
 		"--testNamePattern",
 		"(this will fail|this other one will fail)",
-		"spec/user.spec.js",
 		"spec/billing.spec.js",
+		"spec/user.spec.js",
 		"--json",
 		"--testLocationInResults",
 		"--outputFile",
@@ -556,10 +596,10 @@ func TestJestRetryCommandNameAndArgs_WithTestExamplesPlaceholder(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(gotName, wantName); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
-		t.Errorf("retryCommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
+		t.Errorf("CommandNameAndArgs(%q, %q) diff (-got +want):\n%s", testCases, retryTestCommand, diff)
 	}
 }
 


### PR DESCRIPTION
Updates `runner.Jest` to use `buildCommand` in line with the other runners.

Removes the method `retryCommandNameAndArgs` method which was unique to the `Jest` runner, moving it's behaviour into `CommandNameAndArgs`.