### PR TITLE
Add CHANGELOG for 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
-- `bktec tools backfill-commit-metadata` now accepts OIDC tokens from `buildkite-agent oidc request-token` in addition to API access tokens. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.
+## 2.5.1 - 2026-05-15
+- `bktec tools backfill-commit-metadata` accepts OIDC tokens from `buildkite-agent oidc request-token`. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.
+- **Breaking (Go module consumers):** module path is now `github.com/buildkite/test-engine-client/v2`. Earlier v2.x tags lacked the [required `/v2` suffix](https://go.dev/ref/mod#major-version-suffixes) and were unfetchable via `go get`/`go tool`. Update imports to include `/v2` and pin to v2.5.1+.
 
 ## 2.5.0 - 2026-05-11
 - Add split-by-example support for [Playwright](./docs/playwright.md), allowing slow test files to be split across parallel jobs by individual test case rather than by file.


### PR DESCRIPTION
## Description

Rename `## Unreleased` to `## 2.5.1 - 2026-05-15` so the release pipeline picks it up. The entry now covers two changes shipping in `v2.5.1`:

- OIDC support for `bktec tools backfill-commit-metadata`, shipped by [TE-5834](https://linear.app/buildkite/issue/TE-5834) (merged at `8ccafd6` on `main`).
- The `go.mod` module-path fix from [TE-5843](https://linear.app/buildkite/issue/TE-5843) (#510, the base of this PR). This is the first v2.x tag with a correctly-suffixed module path, so downstream consumers should pin to `v2.5.1` or later and update their import paths to include the `/v2` suffix.

Phase 1 of the v2.5.1 release ([TE-5839](https://linear.app/buildkite/issue/TE-5839)): land #510, then this, then cut `v2.5.1-rc.1` from the release pipeline and smoke-test against `test-prediction-backfill` with a real OIDC JWT before tagging the final `v2.5.1`.

## Context

Resolves [TE-5839](https://linear.app/buildkite/issue/TE-5839).

This PR is **stacked on top of #510** ([TE-5843] Encode v2 major version in go.mod module path). Merge #510 first; this PR will then automatically retarget to `main` and show only the CHANGELOG diff.

## Verification

Diff against #510 is a single bullet appended to the `2.5.1` entry — visually reviewable. The release pipeline ([TE-5839](https://linear.app/buildkite/issue/TE-5839) phase 2) is what actually validates the new `2.5.1` heading.

AI assisted.

## Deployment

Low risk. CHANGELOG only.

## Rollback

Yes.
