### PR TITLE
Te 5851 add linter rule for initialisms

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,19 @@ linters:
   enable:
     - gosec
     - govet
+  settings:
+    staticcheck:
+      # Terms for which identifiers must be all caps. Defaults with the addition of OIDC
+      initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "OIDC", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
+      # Checks to run. Minus prefix means exclude this check.
+      # This is the default list except we enable ST1003 to enforce the initialisms above.
+      checks:
+        - all
+        - -ST1000
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
   exclusions:
     presets:
       - comments

--- a/cli.go
+++ b/cli.go
@@ -94,7 +94,7 @@ var buildIDFlag = &cli.StringFlag{
 	Category:    "BUILD ENVIRONMENT",
 	Usage:       "Buildkite build id",
 	Sources:     cli.EnvVars("BUILDKITE_BUILD_ID"),
-	Destination: &cfg.BuildId,
+	Destination: &cfg.BuildID,
 	Hidden:      true,
 }
 
@@ -103,7 +103,7 @@ var jobIDFlag = &cli.StringFlag{
 	Category:    "BUILD ENVIRONMENT",
 	Usage:       "Buildkite job id",
 	Sources:     cli.EnvVars("BUILDKITE_JOB_ID"),
-	Destination: &cfg.JobId,
+	Destination: &cfg.JobID,
 	Hidden:      true,
 }
 
@@ -112,7 +112,7 @@ var stepIDFlag = &cli.StringFlag{
 	Category:    "BUILD ENVIRONMENT",
 	Usage:       "Buildkite step id",
 	Sources:     cli.EnvVars("BUILDKITE_STEP_ID"),
-	Destination: &cfg.StepId,
+	Destination: &cfg.StepID,
 	Hidden:      true,
 }
 
@@ -175,7 +175,7 @@ var oidcFlag = &cli.BoolWithInverseFlag{
 	Category:    "TEST ENGINE",
 	Usage:       "When required tokens are missing, generate OIDC tokens using buildkite-agent",
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_OIDC"),
-	Destination: &cfg.Oidc,
+	Destination: &cfg.OIDC,
 }
 
 var oidcLifetimeFlag = &cli.DurationFlag{
@@ -184,7 +184,7 @@ var oidcLifetimeFlag = &cli.DurationFlag{
 	Category:    "TEST ENGINE",
 	Usage:       "Specify OIDC token lifetime",
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_OIDC_LIFETIME"),
-	Destination: &cfg.OidcLifetime,
+	Destination: &cfg.OIDCLifetime,
 }
 
 var suiteSlugFlag = &cli.StringFlag{
@@ -229,7 +229,7 @@ var baseURLFlag = &cli.StringFlag{
 	Usage:       "Buildkite API base URL",
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_BASE_URL"),
 	Value:       "https://api.buildkite.com",
-	Destination: &cfg.ServerBaseUrl,
+	Destination: &cfg.ServerBaseURL,
 	Hidden:      true,
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -22,7 +22,7 @@ import (
 // It contains the organization slug, server base URL, and an HTTP client.
 type Client struct {
 	OrganizationSlug string
-	ServerBaseUrl    string
+	ServerBaseURL    string
 	httpClient       *http.Client
 }
 
@@ -30,7 +30,7 @@ type Client struct {
 type ClientConfig struct {
 	AccessToken      string
 	OrganizationSlug string
-	ServerBaseUrl    string
+	ServerBaseURL    string
 }
 
 // authTransport is a middleware for the HTTP client.
@@ -59,7 +59,7 @@ func NewClient(cfg ClientConfig) *Client {
 
 	return &Client{
 		OrganizationSlug: cfg.OrganizationSlug,
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 		httpClient:       httpClient,
 	}
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -39,7 +39,7 @@ func TestNewClient(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    "http://example.com",
+		ServerBaseURL:    "http://example.com",
 	}
 	c := NewClient(cfg)
 
@@ -49,8 +49,8 @@ func TestNewClient(t *testing.T) {
 	}
 
 	// Check if the client has the correct server base URL.
-	if c.ServerBaseUrl != cfg.ServerBaseUrl {
-		t.Errorf("NewClient() = %v, want %v", c.ServerBaseUrl, cfg.ServerBaseUrl)
+	if c.ServerBaseURL != cfg.ServerBaseURL {
+		t.Errorf("NewClient() = %v, want %v", c.ServerBaseURL, cfg.ServerBaseURL)
 	}
 
 	// Check if the client has an HTTP client.
@@ -69,7 +69,7 @@ func TestHttpClient_AttachAccessTokenToRequest(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -96,7 +96,7 @@ func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -115,7 +115,7 @@ func TestDoWithRetry_Succesful_POST(t *testing.T) {
 	defer svr.Close()
 
 	cfg := ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	c := NewClient(cfg)
 
@@ -158,7 +158,7 @@ func TestDoWithRetry_Succesful_GET(t *testing.T) {
 	defer svr.Close()
 
 	cfg := ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	c := NewClient(cfg)
 
@@ -227,7 +227,7 @@ func TestDoWithRetry_429(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -273,7 +273,7 @@ func TestDoWithRetry_409(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -320,7 +320,7 @@ func TestDoWithRetry_500(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -356,7 +356,7 @@ func TestDoWithRetry_403(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -395,7 +395,7 @@ func TestDoWithRetry_401(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "bad-token",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -433,7 +433,7 @@ func TestDoWithRetry_404(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -471,7 +471,7 @@ func TestDoWithRetry_400(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -510,7 +510,7 @@ func TestDoWithRetry_BillingError(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -34,12 +34,12 @@ type TestPlanParams struct {
 // CreateTestPlan creates a test plan from the server.
 // ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
 func (c Client) CreateTestPlan(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, error) {
-	postUrl := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
+	postURL := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var testPlan plan.TestPlan
 	_, err := c.DoWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,
-		URL:    postUrl,
+		URL:    postURL,
 		Body:   params,
 	}, &testPlan)
 	if err != nil {

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -76,7 +76,7 @@ func TestCreateTestPlan(t *testing.T) {
 	apiClient := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	got, err := apiClient.CreateTestPlan(ctx, "rspec", params)
@@ -169,7 +169,7 @@ func TestCreateTestPlan_SplitByExample(t *testing.T) {
 	apiClient := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	got, err := apiClient.CreateTestPlan(ctx, "rspec", params)
@@ -218,7 +218,7 @@ func TestCreateTestPlan_BadRequest(t *testing.T) {
 	ctx := context.Background()
 	params := TestPlanParams{}
 	apiClient := NewClient(ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 
 	got, err := apiClient.CreateTestPlan(ctx, "my-suite", params)
@@ -278,7 +278,7 @@ func TestCreateTestPlan_MutedTests(t *testing.T) {
 	apiClient := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	got, err := apiClient.CreateTestPlan(ctx, "rspec", params)
@@ -321,7 +321,7 @@ func TestCreateTestPlan_InternalServerError(t *testing.T) {
 
 	params := TestPlanParams{}
 	apiClient := NewClient(ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 
 	got, err := apiClient.CreateTestPlan(context.Background(), "my-suite", params)

--- a/internal/api/fetch_commit_list.go
+++ b/internal/api/fetch_commit_list.go
@@ -28,7 +28,7 @@ import (
 func (c Client) FetchCommitList(ctx context.Context, suiteSlug string, days int) ([]string, error) {
 	url := fmt.Sprintf(
 		"%s/v2/analytics/organizations/%s/suites/%s/commits?days=%d",
-		c.ServerBaseUrl, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug), days)
+		c.ServerBaseURL, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug), days)
 
 	debug.Printf("Fetching commit list: GET %s", url)
 

--- a/internal/api/fetch_files_timing.go
+++ b/internal/api/fetch_files_timing.go
@@ -15,7 +15,7 @@ type fetchFilesTimingParams struct {
 // The server only returns timings for the files that has been run before.
 // ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
 func (c Client) FetchFilesTiming(ctx context.Context, suiteSlug string, files []string) (map[string]time.Duration, error) {
-	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_files", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_files", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var filesTiming map[string]int
 	_, err := c.DoWithRetry(ctx, httpRequest{

--- a/internal/api/fetch_files_timing_test.go
+++ b/internal/api/fetch_files_timing_test.go
@@ -50,7 +50,7 @@ func TestFetchFilesTiming(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 	got, err := c.FetchFilesTiming(context.Background(), "rspec", files)
 	if err != nil {
@@ -76,7 +76,7 @@ func TestFetchFilesTiming_BadRequest(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	files := []string{"apple_spec.rb", "banana_spec.rb"}
@@ -105,7 +105,7 @@ func TestFetchFilesTiming_InternalServerError(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	files := []string{"apple_spec.rb", "banana_spec.rb"}

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -12,7 +12,7 @@ import (
 // FetchTestPlan fetchs a test plan from the server.
 // ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
 func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier string, jobRetryCount int) (*plan.TestPlan, error) {
-	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s&job_retry_count=%d", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug, identifier, jobRetryCount)
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s&job_retry_count=%d", c.ServerBaseURL, c.OrganizationSlug, suiteSlug, identifier, jobRetryCount)
 
 	var testPlan plan.TestPlan
 

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -53,7 +53,7 @@ func TestFetchTestPlan(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	got, err := c.FetchTestPlan(context.Background(), "rspec", "abc123", 0)
@@ -93,7 +93,7 @@ func TestFetchTestPlan_NotFound(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	got, err := c.FetchTestPlan(context.Background(), "rspec", "abc123", 0)
@@ -117,7 +117,7 @@ func TestFetchTestPlan_BadRequest(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)
@@ -151,7 +151,7 @@ func TestFetchTestPlan_InternalServerError(t *testing.T) {
 	cfg := ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "my-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 
 	c := NewClient(cfg)

--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -32,7 +32,7 @@ type FilteredTestResponse struct {
 // return test files that contain skipped tests, while true will also return slow test
 // files.
 func (c Client) FilterTests(ctx context.Context, suiteSlug string, params FilterTestsParams) ([]FilteredTest, error) {
-	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan/filter_tests", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan/filter_tests", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var response FilteredTestResponse
 	_, err := c.DoWithRetry(ctx, httpRequest{

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -86,7 +86,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 	got, err := c.FilterTests(context.Background(), "rspec", params)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestFilterTests_InternalServerError(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		OrganizationSlug: "msy-org",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	_, err := c.FilterTests(context.Background(), "my-suite", FilterTestsParams{

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -22,7 +22,7 @@ type TestPlanMetadataParams struct {
 }
 
 func (c Client) PostTestPlanMetadata(ctx context.Context, suiteSlug string, identifier string, params TestPlanMetadataParams) error {
-	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, suiteSlug)
+	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	_, err := c.DoWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -96,12 +96,12 @@ func TestPostTestPlanMetadata(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	_, err := c.DoWithRetry(context.Background(), httpRequest{
 		Method: http.MethodPost,
-		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, "rspec"),
+		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, "rspec"),
 		Body:   params,
 	}, nil)
 	if err != nil {
@@ -136,12 +136,12 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 	c := NewClient(ClientConfig{
 		AccessToken:      "asdf1234",
 		OrganizationSlug: "buildkite",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	})
 
 	_, err := c.DoWithRetry(context.Background(), httpRequest{
 		Method: http.MethodPost,
-		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseUrl, c.OrganizationSlug, "rspec"),
+		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, "rspec"),
 		Body:   params,
 	}, nil)
 

--- a/internal/api/presign_upload.go
+++ b/internal/api/presign_upload.go
@@ -21,7 +21,7 @@ type PresignedUploadResponse struct {
 func (c Client) PresignUpload(ctx context.Context, suiteSlug string) (PresignedUploadResponse, error) {
 	reqURL := fmt.Sprintf(
 		"%s/v2/analytics/organizations/%s/suites/%s/commit-metadata-backfill/presigned-upload",
-		c.ServerBaseUrl, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug))
+		c.ServerBaseURL, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug))
 
 	var resp PresignedUploadResponse
 	_, err := c.DoWithRetry(ctx, httpRequest{Method: http.MethodPost, URL: reqURL}, &resp)

--- a/internal/command/backfill_commit_metadata.go
+++ b/internal/command/backfill_commit_metadata.go
@@ -35,7 +35,7 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	apiClient := api.NewClient(api.ClientConfig{
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 	})
 
 	// 2. Fetch commit list from server.
@@ -257,7 +257,7 @@ func uploadOnly(ctx context.Context, cfg *config.Config) error {
 	apiClient := api.NewClient(api.ClientConfig{
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 	})
 
 	// 4. Request presigned upload URL

--- a/internal/command/backfill_commit_metadata_test.go
+++ b/internal/command/backfill_commit_metadata_test.go
@@ -24,7 +24,7 @@ func getBackfillConfig(serverURL string) *config.Config {
 	cfg.AccessToken = "test-token"
 	cfg.OrganizationSlug = "my-org"
 	cfg.SuiteSlug = "my-suite"
-	cfg.ServerBaseUrl = serverURL
+	cfg.ServerBaseURL = serverURL
 	cfg.Concurrency = 10
 	cfg.Days = 90
 	cfg.Remote = "origin"
@@ -585,7 +585,7 @@ func getUploadConfig(serverURL string, filePath string) *config.Config {
 	cfg.AccessToken = "test-token"
 	cfg.OrganizationSlug = "my-org"
 	cfg.SuiteSlug = "my-suite"
-	cfg.ServerBaseUrl = serverURL
+	cfg.ServerBaseURL = serverURL
 	cfg.UploadFile = filePath
 	return &cfg
 }

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -52,7 +52,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	}
 
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
 	})

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -24,7 +24,7 @@ func TestPlanJSON(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -57,7 +57,7 @@ func TestPlanPipelineUpload(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -99,7 +99,7 @@ func TestPlanJSON_BillingError(t *testing.T) {
 	cfg := getConfig()
 	cfg.Identifier = "hello"
 	cfg.MaxParallelism = 123
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -137,7 +137,7 @@ func TestPlanJSON_InternalServerError(t *testing.T) {
 	cfg := getConfig()
 	cfg.Identifier = "hello"
 	cfg.MaxParallelism = 123
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -174,7 +174,7 @@ func TestPlanJSON_Parallelism0(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -217,7 +217,7 @@ func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -265,7 +265,7 @@ func TestPlanPipelineUpload_InternalServerError(t *testing.T) {
 	cfg := getConfig()
 	cfg.Identifier = "hello"
 	cfg.MaxParallelism = 123
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -368,8 +368,8 @@ func getConfig() *config.Config {
 	cfg := config.New()
 
 	cfg.Branch = "tet-123-add-branch-name"
-	cfg.BuildId = "123"
-	cfg.StepId = "789"
+	cfg.BuildID = "123"
+	cfg.StepID = "789"
 	cfg.OrganizationSlug = "buildkite"
 	cfg.NodeIndex = 0
 	cfg.Parallelism = 3
@@ -470,7 +470,7 @@ func TestPlan_CollectGitMetadataWithoutSelection(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 	cfg.CollectGitMetadata = true
 	cfg.SelectionStrategy = "" // no selection
 
@@ -536,7 +536,7 @@ func TestPlan_NoCollectGitMetadataByDefault(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 	cfg.CollectGitMetadata = false
 	cfg.SelectionStrategy = ""
 
@@ -578,7 +578,7 @@ func TestPlanJSON_DebugLogging(t *testing.T) {
 	defer svr.Close()
 
 	cfg := getConfig()
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -643,7 +643,7 @@ func TestPlanJSON_DebugLogging_Fallback(t *testing.T) {
 	cfg := getConfig()
 	cfg.Identifier = "hello"
 	cfg.MaxParallelism = 10
-	cfg.ServerBaseUrl = svr.URL
+	cfg.ServerBaseURL = svr.URL
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -36,7 +36,7 @@ func TestCreateRequestParams(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 	files := []string{
 		"testdata/rspec/spec/fruits/apple_spec.rb",
@@ -128,7 +128,7 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 			}
 
 			client := api.NewClient(api.ClientConfig{
-				ServerBaseUrl: svr.URL,
+				ServerBaseURL: svr.URL,
 			})
 			files := []string{
 				"testdata/fruits/apple.spec.js",
@@ -187,7 +187,7 @@ func TestCreateRequestParams_PytestPants(t *testing.T) {
 		}
 
 		client := api.NewClient(api.ClientConfig{
-			ServerBaseUrl: svr.URL,
+			ServerBaseURL: svr.URL,
 		})
 		files := []string{
 			"test/apple_test.py",
@@ -237,7 +237,7 @@ func TestCreateRequestParams_WithSelectionAndMetadata_NonRSpec(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: "http://example.com",
+		ServerBaseURL: "http://example.com",
 	})
 
 	files := []string{
@@ -295,7 +295,7 @@ func TestCreateRequestParams_WithSelectionAndMetadata_SplitAllFilesBranch(t *tes
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: "http://example.com",
+		ServerBaseURL: "http://example.com",
 	})
 
 	files := []string{
@@ -407,7 +407,7 @@ func TestCreateRequestParams_FilterTestsError(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 	files := []string{
 		"apple_spec.rb",
@@ -445,7 +445,7 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 	files := []string{
 		"testdata/rspec/spec/fruits/apple_spec.rb",
@@ -500,7 +500,7 @@ func TestCreateRequestParams_WithTagFilters(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: "example.com",
+		ServerBaseURL: "example.com",
 	})
 
 	files := []string{
@@ -569,7 +569,7 @@ func TestCreateRequestParams_WithTagFilters_NonPytest(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 
 	files := []string{
@@ -614,7 +614,7 @@ func TestCreateRequestParams_WithLocationPrefix(t *testing.T) {
 	defer svr.Close()
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 
 	cfg := config.Config{
@@ -758,7 +758,7 @@ func TestCreateRequestParams_WithLocationPrefix_SplitByExample(t *testing.T) {
 	}
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 	files := []string{
 		"testdata/rspec/spec/fruits/apple_spec.rb",

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	// get plan
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 		AccessToken:      cfg.AccessToken,
 		OrganizationSlug: cfg.OrganizationSlug,
 	})

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -410,10 +410,10 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		NodeIndex:     0,
 		Parallelism:   10,
 		Identifier:    "identifier",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	// we want the function to return the test plan fetched from the server
@@ -477,13 +477,13 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		NodeIndex:        0,
 		Parallelism:      10,
 		Identifier:       "identifier",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 		OrganizationSlug: "org",
 		SuiteSlug:        "suite",
 		Branch:           "tat-123/my-cool-feature",
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl:    cfg.ServerBaseUrl,
+		ServerBaseURL:    cfg.ServerBaseURL,
 		OrganizationSlug: cfg.OrganizationSlug,
 	})
 
@@ -529,10 +529,10 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 		Parallelism:   2,
 		Identifier:    "identifier",
 		Branch:        "tat-123/my-cool-feature",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	// we want the function to return a fallback plan
@@ -572,10 +572,10 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 		Parallelism:   3,
 		Identifier:    "identifier",
 		Branch:        "tat-123/my-cool-feature",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	// we want the function to return a fallback plan
@@ -612,10 +612,10 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 		Parallelism:   2,
 		Identifier:    "identifier",
 		Branch:        "",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	// we want the function to return an empty test plan and an error
@@ -650,10 +650,10 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 		Parallelism:   2,
 		Identifier:    "identifier",
 		Branch:        "",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	// we want the function to return a fallback plan
@@ -691,10 +691,10 @@ func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
 		Parallelism:   2,
 		Identifier:    "identifier",
 		Branch:        "",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	want := plan.TestPlan{}
@@ -728,10 +728,10 @@ func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
 		Parallelism:   2,
 		Identifier:    "identifier",
 		Branch:        "",
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	}
 	apiClient := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	want := plan.TestPlan{}
@@ -759,9 +759,9 @@ func TestSendMetadata(t *testing.T) {
 	}
 
 	cfg := config.Config{
-		BuildId:          "xyz",
-		JobId:            "abc",
-		StepId:           "pqr",
+		BuildID:          "xyz",
+		JobID:            "abc",
+		StepID:           "pqr",
 		OrganizationSlug: "buildkite",
 		Parallelism:      10,
 		NodeIndex:        5,
@@ -807,7 +807,7 @@ func TestSendMetadata(t *testing.T) {
 	defer svr.Close()
 
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: svr.URL,
+		ServerBaseURL: svr.URL,
 	})
 
 	statistics := runner.RunStatistics{
@@ -827,10 +827,10 @@ func TestSendMetadata_Unauthorized(t *testing.T) {
 		OrganizationSlug: "my-org",
 		SuiteSlug:        "my-suite",
 		Identifier:       "identifier",
-		ServerBaseUrl:    svr.URL,
+		ServerBaseURL:    svr.URL,
 	}
 	client := api.NewClient(api.ClientConfig{
-		ServerBaseUrl: cfg.ServerBaseUrl,
+		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
 	timeline := []api.Timeline{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,7 @@ type Config struct {
 	AccessToken string `json:"-"`
 	// Branch is the string value of the git branch name, used by Buildkite only.
 	Branch                string `json:"BUILDKITE_BRANCH"`
-	BuildId               string `json:"BUILDKITE_BUILD_ID"`
+	BuildID               string `json:"BUILDKITE_BUILD_ID"`
 	BuildkiteAgentCommand string `json:"-"`
 	// CollectGitMetadata enables git metadata auto-collection on plan without requiring --selection-strategy to be set.
 	CollectGitMetadata bool `json:"-"`
@@ -22,7 +22,7 @@ type Config struct {
 	FailOnNoTests bool `json:"BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS"`
 	// Identifier is the identifier of the build.
 	Identifier string `json:"BUILDKITE_TEST_ENGINE_IDENTIFIER"`
-	JobId      string `json:"BUILDKITE_JOB_ID"`
+	JobID      string `json:"BUILDKITE_JOB_ID"`
 	// JobRetryCount is the count of the number of times the job has been retried.
 	JobRetryCount int `json:"BUILDKITE_RETRY_COUNT"`
 	// LocationPrefix is prepended to test file paths when requesting a test plan.
@@ -38,9 +38,9 @@ type Config struct {
 	// Node index is index of the current node.
 	NodeIndex int `json:"BUILDKITE_PARALLEL_JOB"`
 	// Enable OIDC token generation
-	Oidc bool `json:"BUILDKITE_TEST_ENGINE_OIDC"`
+	OIDC bool `json:"BUILDKITE_TEST_ENGINE_OIDC"`
 	// Lifetime of OIDC tokens
-	OidcLifetime time.Duration `json:"BUILDKITE_TEST_ENGINE_OIDC_LIFETIME"`
+	OIDCLifetime time.Duration `json:"BUILDKITE_TEST_ENGINE_OIDC_LIFETIME"`
 	// OrganizationSlug is the slug of the organization.
 	OrganizationSlug string `json:"BUILDKITE_ORGANIZATION_SLUG"`
 	// Output is the local file path for the export tarball. If set, skip S3 upload.
@@ -60,8 +60,8 @@ type Config struct {
 	SelectionParams map[string]string `json:"-"`
 	// SelectionStrategy is the selection strategy sent to the test plan API.
 	SelectionStrategy string `json:"BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY"`
-	// ServerBaseUrl is the base URL of the test plan server.
-	ServerBaseUrl string `json:"-"`
+	// ServerBaseURL is the base URL of the test plan server.
+	ServerBaseURL string `json:"-"`
 	// SkipDiffs omits git_diff and git_diff_raw from the export to reduce upload size.
 	SkipDiffs bool `json:"-"`
 	// UploadFile is the path to a previously generated tarball for the --upload flag of backfill-commit-metadata.
@@ -70,7 +70,7 @@ type Config struct {
 	UploadToken string `json:"-"`
 	// SplitByExample is the flag to enable split the test by example.
 	SplitByExample bool   `json:"BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE"`
-	StepId         string `json:"BUILDKITE_STEP_ID"`
+	StepID         string `json:"BUILDKITE_STEP_ID"`
 	// SuiteSlug is the slug of the suite.
 	SuiteSlug string `json:"BUILDKITE_TEST_ENGINE_SUITE_SLUG"`
 	// TagFilters filters test examples by execution tags.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -17,28 +17,28 @@ func (c *Config) validate() error {
 	}
 
 	if c.Identifier == "" {
-		if c.BuildId != "" && c.StepId != "" {
-			c.Identifier = fmt.Sprintf("%s/%s", c.BuildId, c.StepId)
+		if c.BuildID != "" && c.StepID != "" {
+			c.Identifier = fmt.Sprintf("%s/%s", c.BuildID, c.StepID)
 		} else {
-			if c.BuildId == "" {
+			if c.BuildID == "" {
 				c.errs.appendFieldError("BUILDKITE_BUILD_ID", "must not be blank")
 			}
-			if c.StepId == "" {
+			if c.StepID == "" {
 				c.errs.appendFieldError("BUILDKITE_STEP_ID", "must not be blank")
 			}
 		}
 	}
 
-	if c.ServerBaseUrl == "" {
-		c.ServerBaseUrl = "https://api.buildkite.com"
+	if c.ServerBaseURL == "" {
+		c.ServerBaseURL = "https://api.buildkite.com"
 	} else {
-		if _, err := url.ParseRequestURI(c.ServerBaseUrl); err != nil {
+		if _, err := url.ParseRequestURI(c.ServerBaseURL); err != nil {
 			c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_BASE_URL", "must be a valid URL")
 		}
 	}
 
 	if c.AccessToken == "" {
-		token, err := c.generateOidcToken()
+		token, err := c.generateOIDCToken()
 
 		if err != nil {
 			c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN", "%v", err)
@@ -114,7 +114,7 @@ func (c *Config) ValidateForRun() error {
 		} else {
 			// If OIDC was *not* used to generate the bktec API access token then we need
 			// to generate a token for collector uploads.
-			token, err := c.generateOidcToken()
+			token, err := c.generateOIDCToken()
 
 			if err != nil {
 				c.errs.appendFieldError("BUILDKITE_ANALYTICS_TOKEN", "%v", err)
@@ -160,10 +160,10 @@ func (c *Config) ValidateForRun() error {
 // endpoint is suite-scoped). Collection-only fields (days, concurrency) are checked when
 // --upload is not set.
 func (c *Config) ValidateForBackfillCommitMetadata() error {
-	if c.ServerBaseUrl == "" {
-		c.ServerBaseUrl = "https://api.buildkite.com"
+	if c.ServerBaseURL == "" {
+		c.ServerBaseURL = "https://api.buildkite.com"
 	} else {
-		if _, err := url.ParseRequestURI(c.ServerBaseUrl); err != nil {
+		if _, err := url.ParseRequestURI(c.ServerBaseURL); err != nil {
 			c.errs.appendFieldError("--base-url / BUILDKITE_TEST_ENGINE_BASE_URL", "must be a valid URL")
 		}
 	}
@@ -235,18 +235,18 @@ func (c *Config) ValidateForPlan() error {
 	return nil
 }
 
-func (c *Config) generateOidcToken() (token string, err error) {
-	if !c.Oidc {
+func (c *Config) generateOIDCToken() (token string, err error) {
+	if !c.OIDC {
 		return "", nil
 	}
 
-	suiteUrl := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s", c.ServerBaseUrl, c.OrganizationSlug, c.SuiteSlug)
+	suiteURL := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s", c.ServerBaseURL, c.OrganizationSlug, c.SuiteSlug)
 	var tokenWriter strings.Builder
 	var errorWriter strings.Builder
-	lifetime := strconv.Itoa(int(c.OidcLifetime.Seconds()))
+	lifetime := strconv.Itoa(int(c.OIDCLifetime.Seconds()))
 	// Skipping a security linter check here. The issue is "G204: Subprocess launched with a potential tainted input or cmd arguments"
 	// Given that running tainted input commands is bktec's raison d'etre this is acceptable.
-	cmd := exec.Command(c.BuildkiteAgentCommand, "oidc", "request-token", "--audience", suiteUrl, "--lifetime", lifetime) //nolint:gosec
+	cmd := exec.Command(c.BuildkiteAgentCommand, "oidc", "request-token", "--audience", suiteURL, "--lifetime", lifetime) //nolint:gosec
 	cmd.Stderr = &errorWriter
 	cmd.Stdout = &tokenWriter
 	cmd.Env = os.Environ()

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -8,7 +8,7 @@ import (
 
 func createConfig() Config {
 	return Config{
-		ServerBaseUrl:    "http://example.com",
+		ServerBaseURL:    "http://example.com",
 		Parallelism:      10,
 		NodeIndex:        0,
 		Identifier:       "my_identifier",
@@ -41,7 +41,7 @@ func TestConfigValidate_Empty(t *testing.T) {
 func TestConfigValidate_SetsDefaults(t *testing.T) {
 	c := createConfig()
 
-	c.ServerBaseUrl = ""
+	c.ServerBaseURL = ""
 
 	err := c.validate()
 	if err != nil {
@@ -49,7 +49,7 @@ func TestConfigValidate_SetsDefaults(t *testing.T) {
 	}
 
 	want := "https://api.buildkite.com"
-	got := c.ServerBaseUrl
+	got := c.ServerBaseURL
 
 	if want != got {
 		t.Errorf("c.Validate() -> c.ServerBaseUrl want %q got %q", want, got)
@@ -94,7 +94,7 @@ func TestConfigValidate_Invalid(t *testing.T) {
 			c := createConfig()
 			switch s.name {
 			case "BUILDKITE_TEST_ENGINE_BASE_URL":
-				c.ServerBaseUrl = s.value.(string)
+				c.ServerBaseURL = s.value.(string)
 			case "BUILDKITE_PARALLEL_JOB":
 				c.NodeIndex = s.value.(int)
 			case "BUILDKITE_PARALLEL_JOB_COUNT":
@@ -144,8 +144,8 @@ func TestConfigValidate_Invalid(t *testing.T) {
 
 	t.Run("BuildId, StepId and Identifier are empty", func(t *testing.T) {
 		c := createConfig()
-		c.BuildId = ""
-		c.StepId = ""
+		c.BuildID = ""
+		c.StepID = ""
 		c.Identifier = ""
 		err := c.validate()
 
@@ -169,8 +169,8 @@ func TestConfigValidate_Invalid(t *testing.T) {
 
 func TestConfigValidate_IdentifierPresentBuildIdStepIdMissing(t *testing.T) {
 	c := createConfig()
-	c.BuildId = ""
-	c.StepId = ""
+	c.BuildID = ""
+	c.StepID = ""
 
 	if err := c.validate(); err != nil {
 		t.Errorf("config.validate() error = %v", err)
@@ -333,7 +333,7 @@ func TestMaxParallelismOutOfRange(t *testing.T) {
 	}
 }
 
-func ValidateForPlan_SkipsParallelismAndNodeIndexValidation(t *testing.T) {
+func TestValidateForPlan_SkipsParallelismAndNodeIndexValidation(t *testing.T) {
 	c := createConfig()
 
 	// These 2 fields are only required on ValidateForRun
@@ -378,7 +378,7 @@ func TestConfigValidate_SelectionParamsRequireStrategy(t *testing.T) {
 
 func createBackfillConfig() Config {
 	return Config{
-		ServerBaseUrl:    "http://example.com",
+		ServerBaseURL:    "http://example.com",
 		OrganizationSlug: "my_org",
 		SuiteSlug:        "my_suite",
 		AccessToken:      "my_token",
@@ -569,7 +569,7 @@ func TestConfigValidate_TagFiltersOnlyWorksWithPytest(t *testing.T) {
 
 func TestConfigValidate_OidcTokens(t *testing.T) {
 	c := createConfig()
-	c.Oidc = true
+	c.OIDC = true
 	c.BuildkiteAgentCommand = "./mock-buildkite-agent"
 	c.AccessToken = ""
 	c.UploadToken = ""
@@ -590,7 +590,7 @@ func TestConfigValidate_OidcTokens(t *testing.T) {
 
 func TestConfigValidate_OidcTokensAccessTokenAlreadySet(t *testing.T) {
 	c := createConfig()
-	c.Oidc = true
+	c.OIDC = true
 	c.BuildkiteAgentCommand = "./mock-buildkite-agent"
 	c.AccessToken = "already_set"
 	c.UploadToken = ""
@@ -612,7 +612,7 @@ func TestConfigValidate_OidcTokensAccessTokenAlreadySet(t *testing.T) {
 
 func TestConfigValidate_OidcTokensUploadTokenAlreadySet(t *testing.T) {
 	c := createConfig()
-	c.Oidc = true
+	c.OIDC = true
 	c.BuildkiteAgentCommand = "./mock-buildkite-agent"
 	c.AccessToken = ""
 	c.UploadToken = "already_set"

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -80,7 +80,7 @@ func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 
 	for _, test := range tests {
 		result.RecordTestResult(plan.TestCase{
-			Identifier: test.Id,
+			Identifier: test.ID,
 			Format:     plan.TestCaseFormatExample,
 			Scope:      test.Scope,
 			Name:       test.Name,

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -56,7 +56,7 @@ func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		return cmdErr
 	}
 
-	testResults, parseErr := loadAndParseGotestJUnitXmlResult(g.ResultPath)
+	testResults, parseErr := loadAndParseGotestJUnitXMLResult(g.ResultPath)
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read gotestsum output, tests will not be retried: %v\n", parseErr)
 		// We don't want to fail the build if we fail to parse the report,

--- a/internal/runner/gotest_junit.go
+++ b/internal/runner/gotest_junit.go
@@ -50,7 +50,7 @@ type JUnitXMLTestSuites struct {
 	TestSuites []JUnitXMLTestSuite `xml:"testsuite"`
 }
 
-func loadAndParseGotestJUnitXmlResult(path string) ([]GoTestJUnitResult, error) {
+func loadAndParseGotestJUnitXMLResult(path string) ([]GoTestJUnitResult, error) {
 	xmlFile, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open JUnit XML file %s: %w", path, err)

--- a/internal/runner/gotest_junit_test.go
+++ b/internal/runner/gotest_junit_test.go
@@ -33,7 +33,7 @@ func TestLoadAndParseGotestJUnitXmlResult(t *testing.T) {
 	err = tmpfile.Close()
 	require.NoError(t, err)
 
-	results, err := loadAndParseGotestJUnitXmlResult(tmpfile.Name())
+	results, err := loadAndParseGotestJUnitXMLResult(tmpfile.Name())
 	require.NoError(t, err)
 
 	require.Len(t, results, 4)

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -16,7 +16,7 @@ func TestGotestRun(t *testing.T) {
 	changeCwd(t, "./testdata/go")
 
 	gotest := NewGoTest(RunnerConfig{
-		ResultPath: getRandomXmlTempFilename(),
+		ResultPath: getRandomXMLTempFilename(),
 	})
 	testCases := []plan.TestCase{
 		{Path: "example.com/hello"},
@@ -41,7 +41,7 @@ func TestGotestRun_TestFailed(t *testing.T) {
 	changeCwd(t, "./testdata/go")
 
 	gotest := NewGoTest(RunnerConfig{
-		ResultPath: getRandomXmlTempFilename(),
+		ResultPath: getRandomXMLTempFilename(),
 	})
 	testCases := []plan.TestCase{
 		{Path: "example.com/hello/bad"},
@@ -62,7 +62,7 @@ func TestGotestRun_CommandFailed(t *testing.T) {
 
 	gotest := NewGoTest(RunnerConfig{
 		TestCommand: "gotestsum --junitfile {{resultPath}} bluhbluh",
-		ResultPath:  getRandomXmlTempFilename(),
+		ResultPath:  getRandomXMLTempFilename(),
 	})
 	testCases := []plan.TestCase{
 		{Path: "example.com/hello"},
@@ -98,7 +98,7 @@ func TestGotestGetFiles(t *testing.T) {
 	}
 }
 
-func getRandomXmlTempFilename() string {
+func getRandomXMLTempFilename() string {
 	tempDir, err := os.MkdirTemp("", "bktec-*")
 	if err != nil {
 		panic(err)

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -71,7 +71,7 @@ func (n NUnit) Run(result *RunResult, testCases []plan.TestCase, retry bool) err
 
 	cmdErr := runAndForwardSignal(cmd)
 
-	testResults, parseErr := loadAndParseJUnitXmlResult(n.ResultPath)
+	testResults, parseErr := loadAndParseJUnitXMLResult(n.ResultPath)
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read NUnit output, tests will not be retried: %v\n", parseErr)
 		return cmdErr

--- a/internal/runner/nunit_junit.go
+++ b/internal/runner/nunit_junit.go
@@ -30,7 +30,7 @@ type nunitJUnitTestSuites struct {
 	TestSuites []nunitJUnitTestSuite `xml:"testsuite"`
 }
 
-func loadAndParseJUnitXmlResult(path string) ([]NUnitJUnitResult, error) {
+func loadAndParseJUnitXMLResult(path string) ([]NUnitJUnitResult, error) {
 	xmlFile, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open JUnit XML file %s: %w", path, err)

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -142,7 +142,7 @@ func TestNUnit_CommandNameAndArgs(t *testing.T) {
 }
 
 func TestNUnit_ParseJUnitResults(t *testing.T) {
-	results, err := loadAndParseJUnitXmlResult("./testdata/nunit/junit-results.xml")
+	results, err := loadAndParseJUnitXMLResult("./testdata/nunit/junit-results.xml")
 	if err != nil {
 		t.Fatalf("loadAndParseJUnitXmlResult() error = %v", err)
 	}

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -249,7 +249,7 @@ type PlaywrightSpec struct {
 	File   string
 	Line   int
 	Column int
-	Id     string
+	ID     string
 	Title  string
 	Ok     bool
 	Tests  []PlaywrightTest

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -84,7 +84,7 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 
 	for _, test := range tests {
 		result.RecordTestResult(plan.TestCase{
-			Identifier: test.Id,
+			Identifier: test.ID,
 			Format:     plan.TestCaseFormatExample,
 			Scope:      test.Scope,
 			Name:       test.Name,
@@ -169,29 +169,29 @@ func parsePytestCollectOutput(output string) ([]plan.TestCase, error) {
 		}
 
 		// Parse node ID: "file.py::TestClass::test_method" or "file.py::test_func"
-		testCases = append(testCases, mapNodeIdToTestCase(line))
+		testCases = append(testCases, mapNodeIDToTestCase(line))
 	}
 
 	return testCases, nil
 }
 
-// mapNodeIdToTestCase converts a pytest node ID to a TestCase.
+// mapNodeIDToTestCase converts a pytest node ID to a TestCase.
 // Node ID format: file_path::class::method or file_path::function
 // Must match the format used by buildkite-test-collector for pytest.
 // Scope is everything except the final component, Name is the last component.
-func mapNodeIdToTestCase(nodeId string) plan.TestCase {
+func mapNodeIDToTestCase(nodeID string) plan.TestCase {
 	// Split on the last :: to get scope (everything before) and name (last component)
-	lastIdx := strings.LastIndex(nodeId, "::")
+	lastIdx := strings.LastIndex(nodeID, "::")
 	scope := ""
-	name := nodeId
+	name := nodeID
 	if lastIdx != -1 {
-		scope = nodeId[:lastIdx]
-		name = nodeId[lastIdx+2:]
+		scope = nodeID[:lastIdx]
+		name = nodeID[lastIdx+2:]
 	}
 
 	return plan.TestCase{
-		Identifier: nodeId,
-		Path:       nodeId,
+		Identifier: nodeID,
+		Path:       nodeID,
 		Scope:      scope,
 		Name:       name,
 		Format:     plan.TestCaseFormatExample,

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -75,7 +75,7 @@ func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry boo
 
 	for _, test := range tests {
 		result.RecordTestResult(plan.TestCase{
-			Identifier: test.Id,
+			Identifier: test.ID,
 			Format:     plan.TestCaseFormatExample,
 			Scope:      test.Scope,
 			Name:       test.Name,

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -115,7 +115,7 @@ func (r Rspec) Run(result *RunResult, testCases []plan.TestCase, retry bool) err
 
 // RspecExample represents a single test example in an Rspec report.
 type RspecExample struct {
-	Id              string  `json:"id"`
+	ID              string  `json:"id"`
 	Description     string  `json:"description"`
 	FullDescription string  `json:"full_description"`
 	Status          string  `json:"status"`
@@ -236,9 +236,9 @@ func mapExampleToTestCase(example RspecExample) plan.TestCase {
 	// [Buildkite Test Collector - RSpec implementation](https://github.com/buildkite/test-collector-ruby/blob/2d641486e42f666dd07ffed4cbf2cd0f9dc97619/lib/buildkite/test_collector/rspec_plugin/trace.rb#L27)
 	scope := strings.TrimSuffix(example.FullDescription, " "+example.Description)
 	return plan.TestCase{
-		Identifier: example.Id,
+		Identifier: example.ID,
 		Name:       example.Description,
-		Path:       example.Id,
+		Path:       example.ID,
 		Scope:      scope,
 	}
 }

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -428,9 +428,9 @@ func TestRspecGetExamples_WithOtherFormatters(t *testing.T) {
 	}
 	defer f.Close()
 	defer os.Remove(f.Name())
-	withOtherJson := "rspec --format json --out " + f.Name()
+	withOtherJSON := "rspec --format json --out " + f.Name()
 
-	commands := []string{"rspec --format documentation", "rspec --format html", withOtherJson}
+	commands := []string{"rspec --format documentation", "rspec --format html", withOtherJSON}
 	for _, command := range commands {
 		rspec := NewRspec(RunnerConfig{
 			TestCommand: command,

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -237,7 +237,7 @@ func (r *RunResult) Statistics() RunStatistics {
 //
 // Currently, only pytest and custom runner uses result from test collector.
 type TestEngineTest struct {
-	Id       string
+	ID       string
 	Name     string
 	Scope    string
 	Location string


### PR DESCRIPTION
Enables a [staticcheck linter rule](https://staticcheck.dev/docs/checks/#ST1003) for [initialisms](https://go.dev/wiki/CodeReviewComments#initialisms) and fixes existing deviations.

> Words in names that are initialisms or acronyms (e.g. “URL” or “NATO”) have a consistent case. For example, “URL” should appear as “URL” or “url” (as in “urlPony”, or “URLPony”), never as “Url”.

Adding in response to [previous PR feedback](https://github.com/buildkite/test-engine-client/pull/507#discussion_r3255610009).