### PR TITLE
Change pytest runner default output to JUnit; keep test-collector JSON as an option

### DIFF
--- a/internal/runner/junit_xml.go
+++ b/internal/runner/junit_xml.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+)
+
+// JUnitXMLTestCase represents a single <testcase> element in JUnit XML.
+type JUnitXMLTestCase struct {
+	Classname string           `xml:"classname,attr"`
+	Name      string           `xml:"name,attr"`
+	Result    TestStatus
+	Failure   *JUnitXMLFailure `xml:"failure"`
+	Skipped   *JUnitXMLSkipped `xml:"skipped"`
+}
+
+type junitXMLTestSuite struct {
+	XMLName   xml.Name           `xml:"testsuite"`
+	Name      string             `xml:"name,attr"`
+	TestCases []JUnitXMLTestCase `xml:"testcase"`
+}
+
+type junitXMLTestSuites struct {
+	XMLName    xml.Name            `xml:"testsuites"`
+	TestSuites []junitXMLTestSuite `xml:"testsuite"`
+}
+
+func loadAndParseJUnitXML(path string) ([]JUnitXMLTestCase, error) {
+	xmlFile, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open JUnit XML file %s: %w", path, err)
+	}
+	defer xmlFile.Close()
+
+	byteValue, err := io.ReadAll(xmlFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JUnit XML file %s: %w", path, err)
+	}
+
+	var testSuites junitXMLTestSuites
+	if err = xml.Unmarshal(byteValue, &testSuites); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JUnit XML file %s: %w", path, err)
+	}
+
+	var results []JUnitXMLTestCase
+	for _, suite := range testSuites.TestSuites {
+		for _, tc := range suite.TestCases {
+			testCase := tc
+			if testCase.Failure != nil {
+				testCase.Result = TestStatusFailed
+			} else if testCase.Skipped != nil {
+				testCase.Result = TestStatusSkipped
+			} else {
+				testCase.Result = TestStatusPassed
+			}
+			results = append(results, testCase)
+		}
+	}
+
+	return results, nil
+}

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -16,6 +16,7 @@ import (
 
 type Pytest struct {
 	RunnerConfig
+	useJUnit bool
 }
 
 func (p Pytest) Name() string {
@@ -23,23 +24,39 @@ func (p Pytest) Name() string {
 }
 
 func NewPytest(c RunnerConfig) Pytest {
-	if !checkPythonPackageInstalled("buildkite_test_collector") { // python import only use underscore
-		fmt.Fprintln(os.Stderr, "Error: Required Python package 'buildkite-test-collector' is not installed.")
-		fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
-		os.Exit(1)
-	}
+	pluginInstalled := checkPythonPackageInstalled("buildkite_test_collector") // python import only uses underscore
 
-	// Ensure buildkite-test-collector version is >1.2.0 for --tag-filters support
-	if c.TagFilters != "" {
-		if err := checkBuildkiteTestCollectorVersion("1.2.0"); err != nil {
-			fmt.Fprintln(os.Stderr, "Error:", err)
-			fmt.Fprintln(os.Stderr, "Please upgrade with: pip install --upgrade buildkite-test-collector")
+	useJUnit := !pluginInstalled
+
+	if pluginInstalled {
+		// Ensure buildkite-test-collector version is >1.2.0 for --tag-filters support
+		if c.TagFilters != "" {
+			if err := checkBuildkiteTestCollectorVersion("1.2.0"); err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err)
+				fmt.Fprintln(os.Stderr, "Please upgrade with: pip install --upgrade buildkite-test-collector")
+				os.Exit(1)
+			}
+		}
+		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector found, using JSON output for pytest results.")
+		if c.TestCommand == "" {
+			c.TestCommand = "pytest {{testExamples}} --json={{resultPath}}"
+		}
+		if c.ResultPath == "" {
+			c.ResultPath = getRandomTempFilename("pytest-results.json")
+		}
+	} else {
+		if c.TagFilters != "" {
+			fmt.Fprintln(os.Stderr, "Error: --tag-filters requires the 'buildkite-test-collector' package.")
+			fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
 			os.Exit(1)
 		}
-	}
-
-	if c.TestCommand == "" {
-		c.TestCommand = "pytest {{testExamples}} --json={{resultPath}}"
+		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector not found, using JUnit XML output for pytest results.")
+		if c.TestCommand == "" {
+			c.TestCommand = "pytest {{testExamples}} --junit-xml={{resultPath}}"
+		}
+		if c.ResultPath == "" {
+			c.ResultPath = getRandomTempFilename("pytest-results.xml")
+		}
 	}
 
 	if c.TestFilePattern == "" {
@@ -50,12 +67,9 @@ func NewPytest(c RunnerConfig) Pytest {
 		c.RetryTestCommand = c.TestCommand
 	}
 
-	if c.ResultPath == "" {
-		c.ResultPath = getRandomTempFilename()
-	}
-
 	return Pytest{
 		RunnerConfig: c,
+		useJUnit:     useJUnit,
 	}
 }
 
@@ -85,12 +99,16 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		return cmdErr
 	}
 
-	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
+	if p.useJUnit {
+		return p.runParseJUnit(result, cmdErr)
+	}
+	return p.runParseJSON(result, cmdErr)
+}
 
+func (p Pytest) runParseJSON(result *RunResult, cmdErr error) error {
+	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read json output, failed tests will not be retried: %v\n", parseErr)
-		// We don't want to fail the build if we fail to parse the report,
-		// therefore we return the command error (which can be nil), instead of the parse error.
 		return cmdErr
 	}
 
@@ -106,8 +124,64 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		}, test.Result)
 	}
 
-	// Return any command error after processing the report
 	return cmdErr
+}
+
+func (p Pytest) runParseJUnit(result *RunResult, cmdErr error) error {
+	tests, parseErr := loadAndParseJUnitXML(p.ResultPath)
+	if parseErr != nil {
+		fmt.Printf("Buildkite Test Engine Client: Failed to read JUnit XML output, failed tests will not be retried: %v\n", parseErr)
+		return cmdErr
+	}
+
+	for _, test := range tests {
+		scope, path := pytestNodeIDFromJUnit(test.Classname, test.Name)
+		result.RecordTestResult(plan.TestCase{
+			Identifier: path,
+			Format:     plan.TestCaseFormatExample,
+			Scope:      scope,
+			Name:       test.Name,
+			Path:       path,
+		}, test.Result)
+	}
+
+	return cmdErr
+}
+
+// pytestNodeIDFromJUnit reconstructs a pytest node ID (scope and path) from a JUnit XML
+// classname and test name. pytest encodes the module path in the classname using dots as
+// separators, with any class names appended after the module.
+//
+// Examples:
+//
+//	classname="test_sample",             name="test_happy"   → scope="test_sample.py",               path="test_sample.py::test_happy"
+//	classname="tests.test_sample",       name="test_happy"   → scope="tests/test_sample.py",          path="tests/test_sample.py::test_happy"
+//	classname="tests.test_auth.TestLogin", name="test_success" → scope="tests/test_auth.py::TestLogin", path="tests/test_auth.py::TestLogin::test_success"
+func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
+	parts := strings.Split(classname, ".")
+
+	// Everything up to the first uppercase component is the module (file) path.
+	// Class names in Python use CamelCase; module/directory names use snake_case.
+	moduleEnd := len(parts)
+	for i, p := range parts {
+		if len(p) > 0 && p[0] >= 'A' && p[0] <= 'Z' {
+			moduleEnd = i
+			break
+		}
+	}
+
+	modulePath := strings.Join(parts[:moduleEnd], "/") + ".py"
+	classParts := parts[moduleEnd:]
+
+	if len(classParts) == 0 {
+		scope = modulePath
+		path = modulePath + "::" + name
+	} else {
+		classPath := strings.Join(classParts, "::")
+		scope = modulePath + "::" + classPath
+		path = modulePath + "::" + classPath + "::" + name
+	}
+	return
 }
 
 func (p Pytest) GetFiles() ([]string, error) {
@@ -236,12 +310,12 @@ func (p Pytest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (strin
 	return args[0], args[1:], nil
 }
 
-func getRandomTempFilename() string {
+func getRandomTempFilename(filename string) string {
 	tempDir, err := os.MkdirTemp("", "bktec-pytest-*")
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(tempDir, "pytest-results.json")
+	return filepath.Join(tempDir, filename)
 }
 
 // getPythonPackageVersion retrieves the version of a Python package using importlib.metadata.

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -42,7 +42,7 @@ func NewPytestPants(c RunnerConfig) PytestPants {
 	}
 
 	if c.ResultPath == "" {
-		c.ResultPath = getRandomTempFilename()
+		c.ResultPath = getRandomTempFilename("pytest-results.json")
 	}
 
 	return PytestPants{

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -33,11 +33,13 @@ func TestPytestRun(t *testing.T) {
 func TestPytestRun_RetryCommand(t *testing.T) {
 	changeCwd(t, "./testdata/pytest")
 
-	pytest := NewPytest(RunnerConfig{
-		TestCommand:      "pytest failed_test.py",
-		RetryTestCommand: "pytest",
-		ResultPath:       "result-passed.json",
-	})
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand:      "pytest failed_test.py",
+			RetryTestCommand: "pytest",
+			ResultPath:       "result-passed.json",
+		},
+	}
 
 	testCases := []plan.TestCase{
 		{Path: "test_sample.py"},
@@ -53,10 +55,12 @@ func TestPytestRun_RetryCommand(t *testing.T) {
 func TestPytestRun_TestFailed(t *testing.T) {
 	changeCwd(t, "./testdata/pytest")
 
-	pytest := NewPytest(RunnerConfig{
-		TestCommand: "pytest",
-		ResultPath:  "result-failed.json",
-	})
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-failed.json",
+		},
+	}
 	testCases := []plan.TestCase{
 		{Path: "failed_test.py"},
 	}
@@ -80,6 +84,69 @@ func TestPytestRun_TestFailed(t *testing.T) {
 		{
 			Format:     "example",
 			Identifier: "a1be7e52-0dba-4018-83ce-a1598ca68807",
+			Name:       "test_failed",
+			Path:       "tests/failed_test.py::test_failed",
+			Scope:      "tests/failed_test.py",
+		},
+	}
+
+	if diff := cmp.Diff(failedTest, wantFailedTests); diff != "" {
+		t.Errorf("Pytest.Run(%q) RunResult.FailedTests() diff (-got +want):\n%s", testCases, diff)
+	}
+}
+
+func TestPytestRun_JUnit_TestPassed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-passed.xml",
+		},
+		useJUnit: true,
+	}
+	testCases := []plan.TestCase{{Path: "test_sample.py"}}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+	if err != nil {
+		t.Errorf("Pytest.Run(%q) error = %v", testCases, err)
+	}
+
+	if result.Status() != RunStatusPassed {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusPassed)
+	}
+}
+
+func TestPytestRun_JUnit_TestFailed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-failed.xml",
+		},
+		useJUnit: true,
+	}
+	testCases := []plan.TestCase{{Path: "failed_test.py"}}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+
+	exitError := new(exec.ExitError)
+	assert.ErrorAs(t, err, &exitError)
+
+	if result.Status() != RunStatusFailed {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusFailed)
+	}
+
+	failedTest := result.FailedTests()
+	if len(failedTest) != 1 {
+		t.Errorf("len(result.FailedTests()) = %d, want 1", len(failedTest))
+	}
+
+	wantFailedTests := []plan.TestCase{
+		{
+			Format:     "example",
+			Identifier: "tests/failed_test.py::test_failed",
 			Name:       "test_failed",
 			Path:       "tests/failed_test.py::test_failed",
 			Scope:      "tests/failed_test.py",
@@ -331,6 +398,58 @@ func TestPytestGetExamples_TagFilter(t *testing.T) {
 
 	if got[1].Name != "test_happy" {
 		t.Errorf("got[0].Name = %q, want %q", got[0].Name, "test_happy")
+	}
+}
+
+func TestPytestNodeIDFromJUnit(t *testing.T) {
+	tests := []struct {
+		classname  string
+		name       string
+		wantScope  string
+		wantPath   string
+	}{
+		{
+			classname: "test_sample",
+			name:      "test_happy",
+			wantScope: "test_sample.py",
+			wantPath:  "test_sample.py::test_happy",
+		},
+		{
+			classname: "tests.test_sample",
+			name:      "test_happy",
+			wantScope: "tests/test_sample.py",
+			wantPath:  "tests/test_sample.py::test_happy",
+		},
+		{
+			classname: "tests.failed_test",
+			name:      "test_failed",
+			wantScope: "tests/failed_test.py",
+			wantPath:  "tests/failed_test.py::test_failed",
+		},
+		{
+			classname: "test_auth.TestLogin",
+			name:      "test_success",
+			wantScope: "test_auth.py::TestLogin",
+			wantPath:  "test_auth.py::TestLogin::test_success",
+		},
+		{
+			classname: "tests.test_auth.TestLogin",
+			name:      "test_success",
+			wantScope: "tests/test_auth.py::TestLogin",
+			wantPath:  "tests/test_auth.py::TestLogin::test_success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.classname+"::"+tt.name, func(t *testing.T) {
+			gotScope, gotPath := pytestNodeIDFromJUnit(tt.classname, tt.name)
+			if gotScope != tt.wantScope {
+				t.Errorf("pytestNodeIDFromJUnit(%q, %q) scope = %q, want %q", tt.classname, tt.name, gotScope, tt.wantScope)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("pytestNodeIDFromJUnit(%q, %q) path = %q, want %q", tt.classname, tt.name, gotPath, tt.wantPath)
+			}
+		})
 	}
 }
 

--- a/internal/runner/testdata/pytest/result-failed.xml
+++ b/internal/runner/testdata/pytest/result-failed.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="1" errors="0" failures="1" skipped="0">
+    <testcase classname="tests.failed_test" name="test_failed" time="0.012">
+      <failure message="assert 3 == 5">AssertionError: assert 3 == 5</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/runner/testdata/pytest/result-passed.xml
+++ b/internal/runner/testdata/pytest/result-passed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="1" errors="0" failures="0" skipped="0">
+    <testcase classname="test_sample" name="test_happy" time="0.001"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary

- When `buildkite-test-collector` is installed, `NewPytest` keeps the existing `--json={{resultPath}}` / JSON-parse path, leaving existing customers unaffected
- When the plugin is absent, the runner falls back to `--junit-xml={{resultPath}}` and parses results with a new shared `loadAndParseJUnitXML` helper (`junit_xml.go`)
- Pytest node IDs are reconstructed from JUnit classname + name via `pytestNodeIDFromJUnit`, which splits on `.` and converts the lowercase module prefix to a file path
- A log line is printed in both cases so customers can see which path was taken
- If `TagFilters` is set but the plugin is absent, the runner exits with an error (tag filtering requires the plugin)

Closes [TE-5956](https://linear.app/buildkite/issue/TE-5956)

> **Note:** This PR includes a new `junit_xml.go` with the shared JUnit parser. This overlaps with the intent of [TE-5959](https://linear.app/buildkite/issue/TE-5959); these two PRs should be coordinated to avoid conflicts.

## Test plan

- [x] `TestPytestNodeIDFromJUnit` — unit tests for all classname → node ID cases
- [x] `TestPytestRun_JUnit_TestPassed` / `TestPytestRun_JUnit_TestFailed` — verifies JUnit XML parsing with pre-baked `.xml` fixtures
- [x] Existing `TestPytestRun_*` tests updated to construct `Pytest{}` directly where they supply explicit JSON result paths
- [x] Full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)