### PR TITLE
Include cwd in run_env when uploading test results

### DIFF
--- a/internal/api/upload_test_results.go
+++ b/internal/api/upload_test_results.go
@@ -58,9 +58,10 @@ func buildTestResultsMultipartBody(filePath string, format string, locationPrefi
 		return nil, "", fmt.Errorf("writing format field: %w", err)
 	}
 
+	buildId := os.Getenv("BUILDKITE_BUILD_ID")
 	runEnv := map[string]string{
 		"CI":              "buildkite",
-		"key":             os.Getenv("BUILDKITE_BUILD_ID"),
+		"key":             buildId,
 		"branch":          os.Getenv("BUILDKITE_BRANCH"),
 		"commit_sha":      os.Getenv("BUILDKITE_COMMIT"),
 		"number":          os.Getenv("BUILDKITE_BUILD_NUMBER"),
@@ -68,6 +69,10 @@ func buildTestResultsMultipartBody(filePath string, format string, locationPrefi
 		"job_id":          os.Getenv("BUILDKITE_JOB_ID"),
 		"message":         os.Getenv("BUILDKITE_MESSAGE"),
 		"location_prefix": locationPrefix,
+	}
+	if buildId != "" {
+		cwd, _ := os.Getwd()
+		runEnv["cwd"] = cwd
 	}
 	for k, v := range runEnv {
 		if err := w.WriteField(fmt.Sprintf("run_env[%s]", k), v); err != nil {

--- a/internal/api/upload_test_results.go
+++ b/internal/api/upload_test_results.go
@@ -58,10 +58,10 @@ func buildTestResultsMultipartBody(filePath string, format string, locationPrefi
 		return nil, "", fmt.Errorf("writing format field: %w", err)
 	}
 
-	buildId := os.Getenv("BUILDKITE_BUILD_ID")
+	buildID := os.Getenv("BUILDKITE_BUILD_ID")
 	runEnv := map[string]string{
 		"CI":              "buildkite",
-		"key":             buildId,
+		"key":             buildID,
 		"branch":          os.Getenv("BUILDKITE_BRANCH"),
 		"commit_sha":      os.Getenv("BUILDKITE_COMMIT"),
 		"number":          os.Getenv("BUILDKITE_BUILD_NUMBER"),
@@ -70,7 +70,7 @@ func buildTestResultsMultipartBody(filePath string, format string, locationPrefi
 		"message":         os.Getenv("BUILDKITE_MESSAGE"),
 		"location_prefix": locationPrefix,
 	}
-	if buildId != "" {
+	if buildID != "" {
 		cwd, _ := os.Getwd()
 		runEnv["cwd"] = cwd
 	}

--- a/internal/api/upload_test_results_test.go
+++ b/internal/api/upload_test_results_test.go
@@ -122,10 +122,45 @@ func TestBuildTestResultsMultipartBody(t *testing.T) {
 		}
 	}
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
 	assert.Equal(t, "rspec-json", fields["format"])
 	assert.Equal(t, "buildkite", fields["run_env[CI]"])
 	assert.Equal(t, "build-123", fields["run_env[key]"])
 	assert.Equal(t, "main", fields["run_env[branch]"])
 	assert.Equal(t, "abc123", fields["run_env[commit_sha]"])
 	assert.Equal(t, "my/prefix", fields["run_env[location_prefix]"])
+	assert.Equal(t, cwd, fields["run_env[cwd]"])
+}
+
+func TestBuildTestResultsMultipartBody_NoCwdOutsideBuildkite(t *testing.T) {
+	t.Setenv("BUILDKITE_BUILD_ID", "")
+
+	resultFile, err := os.CreateTemp("", "results-*.json")
+	require.NoError(t, err)
+	defer os.Remove(resultFile.Name())
+	resultFile.Close()
+
+	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "")
+	require.NoError(t, err)
+
+	_, params, err := mime.ParseMediaType(contentType)
+	require.NoError(t, err)
+
+	fields := map[string]string{}
+	mr := multipart.NewReader(buf, params["boundary"])
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		val, _ := io.ReadAll(part)
+		if part.FormName() != "" {
+			fields[part.FormName()] = string(val)
+		}
+	}
+
+	assert.NotContains(t, fields, "run_env[cwd]")
 }


### PR DESCRIPTION
### Description

The native Jest JSON output (`--json`) sets `suite.name` to an absolute path (e.g. `/buildkite/builds/.../foo.test.js`). When bktec uploads the raw Jest JSON, the upload includes that full path instead of a path relative to the repo root.

To produce a relative path on the receiving side, we need to know bktec's working directory. This PR includes the current working directory in `run_env` as `cwd`.

We only set `cwd` when running inside Buildkite (when `BUILDKITE_BUILD_ID` is set), so we don't leak a local working directory in other contexts.

### Context

[TE-5972](https://linear.app/buildkite/issue/TE-5972/jest-json-strip-absolute-file-path-using-cwd-from-run-env)

Related: TE-5953

### Changes

- Add `cwd` to `run_env` in the test results upload, only when running inside Buildkite.

### Testing

Covered by unit tests: one asserting `cwd` is present when `BUILDKITE_BUILD_ID` is set, and one asserting it's omitted otherwise.