### PR TITLE
Change pytest runner default output to JUnit; keep test-collector JSON as an option

### DIFF
--- a/docs/pytest.md
+++ b/docs/pytest.md
@@ -1,19 +1,32 @@
 # Using bktec with pytest
-To integrate bktec with pytest, you need to [install and configure Buildkite Test Collector for pytest](https://buildkite.com/docs/test-engine/python-collectors#pytest-collector) first. Then set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` environment variable to `pytest`.
+Set the `BUILDKITE_TEST_ENGINE_TEST_RUNNER` environment variable to `pytest` to use bktec with pytest.
 
 ```sh
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=pytest
 bktec run
 ```
 
-## Configure test command
-By default, bktec runs pytest with the following command:
+bktec works with pytest in two modes depending on whether [Buildkite Test Collector for pytest](https://buildkite.com/docs/test-engine/python-collectors#pytest-collector) is installed:
 
+- **With `buildkite-test-collector`** (recommended): bktec uses the collector's JSON output for richer test result data and supports `--tag-filters`.
+- **Without `buildkite-test-collector`**: bktec falls back to JUnit XML output. This is sufficient for basic parallelisation and retry, but `--tag-filters` is not available.
+
+bktec logs which mode it is using on startup.
+
+## Configure test command
+By default, bktec runs pytest with one of the following commands depending on which mode is active:
+
+**With `buildkite-test-collector`:**
 ```sh
 pytest {{testExamples}} --json={{resultPath}}
 ```
 
-In this command, `{{testExamples}}` is replaced by bktec with the list of test files or tests to run, and `{{resultPath}}` is replaced with a unique temporary path created by bktec. `--json` option is a custom option added by Buildkite Test Collector to save the result into a JSON file at given path. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable. 
+**Without `buildkite-test-collector` (JUnit fallback):**
+```sh
+pytest {{testExamples}} --junit-xml={{resultPath}}
+```
+
+In both commands, `{{testExamples}}` is replaced by bktec with the list of test files or tests to run, and `{{resultPath}}` is replaced with a unique temporary path created by bktec. You can customize this command using the `BUILDKITE_TEST_ENGINE_TEST_CMD` environment variable.
 
 To customize the test command, set the following environment variable:
 ```sh
@@ -21,7 +34,7 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="pytest --cache-clear --json={{resultPath}
 ```
 
 > [!IMPORTANT]
-> Make sure to include `--json={{resultPath}}` in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
+> Make sure to include the appropriate result flag (`--json={{resultPath}}` or `--junit-xml={{resultPath}}`) in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
 
 ## Filter test files
 By default, bktec runs test files that match the `**/{*_test,test_*}.py` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run test files inside the `tests` directory, use:
@@ -47,6 +60,10 @@ export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=tests/api
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
 
 ## Filter test by tags
+
+> [!NOTE]
+> Tag filtering requires `buildkite-test-collector` to be installed. bktec will exit with an error if `--tag-filters` is used without it.
+
 You can filter tests to run based on `execution_tag` markers using the `BUILDKITE_TEST_ENGINE_TAG_FILTERS` environment variable or `--tag-filters` CLI option. 
 
 ```py

--- a/docs/pytest.md
+++ b/docs/pytest.md
@@ -34,7 +34,7 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="pytest --cache-clear --json={{resultPath}
 ```
 
 > [!IMPORTANT]
-> Make sure to include the appropriate result flag (`--json={{resultPath}}` or `--junit-xml={{resultPath}}`) in your custom test command, as bktec requires this to read the test results for retries and verification purposes.
+> bktec determines the output format by detecting `--junit-xml` or `--json=` in your test command, so the flag you include controls which parser is used — regardless of whether `buildkite-test-collector` is installed. Make sure your command includes exactly one of these flags so bktec can read the results for retries and verification. If neither flag is present, bktec falls back to the collector-based default.
 
 ## Filter test files
 By default, bktec runs test files that match the `**/{*_test,test_*}.py` pattern. You can customize this pattern using the `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` environment variable. For instance, to configure bktec to only run test files inside the `tests` directory, use:

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -62,6 +62,11 @@ func NewPytest(c RunnerConfig) Pytest {
 	if strings.Contains(c.TestCommand, "--junit-xml") {
 		useJUnit = true
 	} else if strings.Contains(c.TestCommand, "--json=") {
+		if !pluginInstalled {
+			fmt.Fprintln(os.Stderr, "Error: --json requires the 'buildkite-test-collector' package to be installed.")
+			fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
+			os.Exit(1)
+		}
 		useJUnit = false
 	}
 
@@ -171,9 +176,11 @@ func (p Pytest) runParseJUnit(result *RunResult) error {
 //
 // Examples:
 //
-//	classname="test_sample",               name="test_happy"   → scope="test_sample.py",               path="test_sample.py::test_happy"
-//	classname="tests.test_sample",         name="test_happy"   → scope="tests/test_sample.py",          path="tests/test_sample.py::test_happy"
-//	classname="tests.test_auth.TestLogin", name="test_success" → scope="tests/test_auth.py::TestLogin", path="tests/test_auth.py::TestLogin::test_success"
+//	classname="test_sample",                          name="test_happy"   → scope="test_sample.py",                          path="test_sample.py::test_happy"
+//	classname="tests.test_sample",                    name="test_happy"   → scope="tests/test_sample.py",                    path="tests/test_sample.py::test_happy"
+//	classname="tests.test_auth.TestLogin",            name="test_success" → scope="tests/test_auth.py::TestLogin",           path="tests/test_auth.py::TestLogin::test_success"
+//	classname="tests.MyTest.test_subtract.TestClass", name="test_positive"→ scope="tests/MyTest/test_subtract.py::TestClass",path="tests/MyTest/test_subtract.py::TestClass::test_positive"
+//	classname="tests.MyTest.test_add",                name="test_add"     → scope="tests/MyTest/test_add.py",                path="tests/MyTest/test_add.py::test_add"
 func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
 	if classname == "" {
 		return name, name
@@ -181,13 +188,25 @@ func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
 
 	parts := strings.Split(classname, ".")
 
-	// Everything up to the first uppercase component is the module (file) path.
-	// Class names in Python use CamelCase; module/directory names use snake_case.
-	moduleEnd := len(parts)
+	// Identify the module (test file) as the last component that matches pytest's test file
+	// naming convention (test_* or *_test). This correctly handles uppercase package directories
+	// such as tests.MyTest.test_foo.TestClass, where MyTest is a directory, not a class.
+	// If no such component is found (non-standard naming), fall back to stopping at the first
+	// CamelCase component.
+	moduleEnd := -1
 	for i, p := range parts {
-		if len(p) > 0 && p[0] >= 'A' && p[0] <= 'Z' {
-			moduleEnd = i
-			break
+		if strings.HasPrefix(p, "test_") || strings.HasSuffix(p, "_test") {
+			moduleEnd = i + 1
+		}
+	}
+
+	if moduleEnd == -1 {
+		moduleEnd = len(parts)
+		for i, p := range parts {
+			if len(p) > 0 && p[0] >= 'A' && p[0] <= 'Z' {
+				moduleEnd = i
+				break
+			}
 		}
 	}
 

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -37,7 +37,6 @@ func NewPytest(c RunnerConfig) Pytest {
 				os.Exit(1)
 			}
 		}
-		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector found, using JSON output for pytest results.")
 		if c.TestCommand == "" {
 			c.TestCommand = "pytest {{testExamples}} --json={{resultPath}}"
 		}
@@ -50,13 +49,26 @@ func NewPytest(c RunnerConfig) Pytest {
 			fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
 			os.Exit(1)
 		}
-		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector not found, using JUnit XML output for pytest results.")
 		if c.TestCommand == "" {
 			c.TestCommand = "pytest {{testExamples}} --junit-xml={{resultPath}}"
 		}
 		if c.ResultPath == "" {
 			c.ResultPath = getRandomTempFilename("pytest-results.xml")
 		}
+	}
+
+	// Detect output format from the result flag in the command, so a custom command
+	// with --junit-xml works even when buildkite-test-collector is installed (and vice versa).
+	if strings.Contains(c.TestCommand, "--junit-xml") {
+		useJUnit = true
+	} else if strings.Contains(c.TestCommand, "--json=") {
+		useJUnit = false
+	}
+
+	if useJUnit {
+		fmt.Println("Buildkite Test Engine Client: Using JUnit XML output for pytest results.")
+	} else {
+		fmt.Println("Buildkite Test Engine Client: Using JSON output for pytest results.")
 	}
 
 	if c.TestFilePattern == "" {
@@ -99,17 +111,23 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		return cmdErr
 	}
 
+	var parseErr error
 	if p.useJUnit {
-		return p.runParseJUnit(result, cmdErr)
+		parseErr = p.runParseJUnit(result)
+	} else {
+		parseErr = p.runParseJSON(result)
 	}
-	return p.runParseJSON(result, cmdErr)
+	if parseErr != nil {
+		fmt.Printf("Buildkite Test Engine Client: Failed to read test output, failed tests will not be retried: %v\n", parseErr)
+	}
+
+	return cmdErr
 }
 
-func (p Pytest) runParseJSON(result *RunResult, cmdErr error) error {
+func (p Pytest) runParseJSON(result *RunResult) error {
 	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
 	if parseErr != nil {
-		fmt.Printf("Buildkite Test Engine Client: Failed to read json output, failed tests will not be retried: %v\n", parseErr)
-		return cmdErr
+		return parseErr
 	}
 
 	for _, test := range tests {
@@ -124,14 +142,13 @@ func (p Pytest) runParseJSON(result *RunResult, cmdErr error) error {
 		}, test.Result)
 	}
 
-	return cmdErr
+	return nil
 }
 
-func (p Pytest) runParseJUnit(result *RunResult, cmdErr error) error {
+func (p Pytest) runParseJUnit(result *RunResult) error {
 	tests, parseErr := loadAndParseJUnitXML(p.ResultPath)
 	if parseErr != nil {
-		fmt.Printf("Buildkite Test Engine Client: Failed to read JUnit XML output, failed tests will not be retried: %v\n", parseErr)
-		return cmdErr
+		return parseErr
 	}
 
 	for _, test := range tests {
@@ -145,7 +162,7 @@ func (p Pytest) runParseJUnit(result *RunResult, cmdErr error) error {
 		}, test.Result)
 	}
 
-	return cmdErr
+	return nil
 }
 
 // pytestNodeIDFromJUnit reconstructs a pytest node ID (scope and path) from a JUnit XML

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -158,6 +158,10 @@ func (p Pytest) runParseJUnit(result *RunResult, cmdErr error) error {
 //	classname="tests.test_sample",         name="test_happy"   → scope="tests/test_sample.py",          path="tests/test_sample.py::test_happy"
 //	classname="tests.test_auth.TestLogin", name="test_success" → scope="tests/test_auth.py::TestLogin", path="tests/test_auth.py::TestLogin::test_success"
 func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
+	if classname == "" {
+		return name, name
+	}
+
 	parts := strings.Split(classname, ".")
 
 	// Everything up to the first uppercase component is the module (file) path.

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -16,6 +16,7 @@ import (
 
 type Pytest struct {
 	RunnerConfig
+	useJUnit bool
 }
 
 func (p Pytest) Name() string {
@@ -23,23 +24,39 @@ func (p Pytest) Name() string {
 }
 
 func NewPytest(c RunnerConfig) Pytest {
-	if !checkPythonPackageInstalled("buildkite_test_collector") { // python import only use underscore
-		fmt.Fprintln(os.Stderr, "Error: Required Python package 'buildkite-test-collector' is not installed.")
-		fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
-		os.Exit(1)
-	}
+	pluginInstalled := checkPythonPackageInstalled("buildkite_test_collector") // python import only uses underscore
 
-	// Ensure buildkite-test-collector version is >1.2.0 for --tag-filters support
-	if c.TagFilters != "" {
-		if err := checkBuildkiteTestCollectorVersion("1.2.0"); err != nil {
-			fmt.Fprintln(os.Stderr, "Error:", err)
-			fmt.Fprintln(os.Stderr, "Please upgrade with: pip install --upgrade buildkite-test-collector")
+	useJUnit := !pluginInstalled
+
+	if pluginInstalled {
+		// Ensure buildkite-test-collector version is >1.2.0 for --tag-filters support
+		if c.TagFilters != "" {
+			if err := checkBuildkiteTestCollectorVersion("1.2.0"); err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err)
+				fmt.Fprintln(os.Stderr, "Please upgrade with: pip install --upgrade buildkite-test-collector")
+				os.Exit(1)
+			}
+		}
+		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector found, using JSON output for pytest results.")
+		if c.TestCommand == "" {
+			c.TestCommand = "pytest {{testExamples}} --json={{resultPath}}"
+		}
+		if c.ResultPath == "" {
+			c.ResultPath = getRandomTempFilename("pytest-results.json")
+		}
+	} else {
+		if c.TagFilters != "" {
+			fmt.Fprintln(os.Stderr, "Error: --tag-filters requires the 'buildkite-test-collector' package.")
+			fmt.Fprintln(os.Stderr, "Please install it with: pip install buildkite-test-collector.")
 			os.Exit(1)
 		}
-	}
-
-	if c.TestCommand == "" {
-		c.TestCommand = "pytest {{testExamples}} --json={{resultPath}}"
+		fmt.Println("Buildkite Test Engine Client: buildkite-test-collector not found, using JUnit XML output for pytest results.")
+		if c.TestCommand == "" {
+			c.TestCommand = "pytest {{testExamples}} --junit-xml={{resultPath}}"
+		}
+		if c.ResultPath == "" {
+			c.ResultPath = getRandomTempFilename("pytest-results.xml")
+		}
 	}
 
 	if c.TestFilePattern == "" {
@@ -50,12 +67,9 @@ func NewPytest(c RunnerConfig) Pytest {
 		c.RetryTestCommand = c.TestCommand
 	}
 
-	if c.ResultPath == "" {
-		c.ResultPath = getRandomTempFilename()
-	}
-
 	return Pytest{
 		RunnerConfig: c,
+		useJUnit:     useJUnit,
 	}
 }
 
@@ -85,12 +99,16 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		return cmdErr
 	}
 
-	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
+	if p.useJUnit {
+		return p.runParseJUnit(result, cmdErr)
+	}
+	return p.runParseJSON(result, cmdErr)
+}
 
+func (p Pytest) runParseJSON(result *RunResult, cmdErr error) error {
+	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read json output, failed tests will not be retried: %v\n", parseErr)
-		// We don't want to fail the build if we fail to parse the report,
-		// therefore we return the command error (which can be nil), instead of the parse error.
 		return cmdErr
 	}
 
@@ -106,8 +124,64 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		}, test.Result)
 	}
 
-	// Return any command error after processing the report
 	return cmdErr
+}
+
+func (p Pytest) runParseJUnit(result *RunResult, cmdErr error) error {
+	tests, parseErr := loadAndParseJUnitXML(p.ResultPath)
+	if parseErr != nil {
+		fmt.Printf("Buildkite Test Engine Client: Failed to read JUnit XML output, failed tests will not be retried: %v\n", parseErr)
+		return cmdErr
+	}
+
+	for _, test := range tests {
+		scope, path := pytestNodeIDFromJUnit(test.Classname, test.Name)
+		result.RecordTestResult(plan.TestCase{
+			Identifier: path,
+			Format:     plan.TestCaseFormatExample,
+			Scope:      scope,
+			Name:       test.Name,
+			Path:       path,
+		}, test.Result)
+	}
+
+	return cmdErr
+}
+
+// pytestNodeIDFromJUnit reconstructs a pytest node ID (scope and path) from a JUnit XML
+// classname and test name. pytest encodes the module path in the classname using dots as
+// separators, with any class names appended after the module.
+//
+// Examples:
+//
+//	classname="test_sample",               name="test_happy"   → scope="test_sample.py",               path="test_sample.py::test_happy"
+//	classname="tests.test_sample",         name="test_happy"   → scope="tests/test_sample.py",          path="tests/test_sample.py::test_happy"
+//	classname="tests.test_auth.TestLogin", name="test_success" → scope="tests/test_auth.py::TestLogin", path="tests/test_auth.py::TestLogin::test_success"
+func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
+	parts := strings.Split(classname, ".")
+
+	// Everything up to the first uppercase component is the module (file) path.
+	// Class names in Python use CamelCase; module/directory names use snake_case.
+	moduleEnd := len(parts)
+	for i, p := range parts {
+		if len(p) > 0 && p[0] >= 'A' && p[0] <= 'Z' {
+			moduleEnd = i
+			break
+		}
+	}
+
+	modulePath := strings.Join(parts[:moduleEnd], "/") + ".py"
+	classParts := parts[moduleEnd:]
+
+	if len(classParts) == 0 {
+		scope = modulePath
+		path = modulePath + "::" + name
+	} else {
+		classPath := strings.Join(classParts, "::")
+		scope = modulePath + "::" + classPath
+		path = modulePath + "::" + classPath + "::" + name
+	}
+	return
 }
 
 func (p Pytest) GetFiles() ([]string, error) {
@@ -236,12 +310,12 @@ func (p Pytest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (strin
 	return args[0], args[1:], nil
 }
 
-func getRandomTempFilename() string {
+func getRandomTempFilename(filename string) string {
 	tempDir, err := os.MkdirTemp("", "bktec-pytest-*")
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(tempDir, "pytest-results.json")
+	return filepath.Join(tempDir, filename)
 }
 
 // getPythonPackageVersion retrieves the version of a Python package using importlib.metadata.

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -42,7 +42,7 @@ func NewPytestPants(c RunnerConfig) PytestPants {
 	}
 
 	if c.ResultPath == "" {
-		c.ResultPath = getRandomTempFilename()
+		c.ResultPath = getRandomTempFilename("pytest-results.json")
 	}
 
 	return PytestPants{

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -115,6 +115,25 @@ func TestPytestRun_JUnit_TestPassed(t *testing.T) {
 	if result.Status() != RunStatusPassed {
 		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusPassed)
 	}
+
+	var passedTests []plan.TestCase
+	for _, tr := range result.tests {
+		if tr.Status == TestStatusPassed {
+			passedTests = append(passedTests, tr.TestCase)
+		}
+	}
+	wantPassedTests := []plan.TestCase{
+		{
+			Format:     "example",
+			Identifier: "test_sample.py::test_happy",
+			Name:       "test_happy",
+			Path:       "test_sample.py::test_happy",
+			Scope:      "test_sample.py",
+		},
+	}
+	if diff := cmp.Diff(passedTests, wantPassedTests); diff != "" {
+		t.Errorf("Pytest.Run(%q) passed tests diff (-got +want):\n%s", testCases, diff)
+	}
 }
 
 func TestPytestRun_JUnit_TestFailed(t *testing.T) {
@@ -437,6 +456,12 @@ func TestPytestNodeIDFromJUnit(t *testing.T) {
 			name:      "test_success",
 			wantScope: "tests/test_auth.py::TestLogin",
 			wantPath:  "tests/test_auth.py::TestLogin::test_success",
+		},
+		{
+			classname: "",
+			name:      "test_something",
+			wantScope: "test_something",
+			wantPath:  "test_something",
 		},
 	}
 

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -463,6 +463,20 @@ func TestPytestNodeIDFromJUnit(t *testing.T) {
 			wantScope: "test_something",
 			wantPath:  "test_something",
 		},
+		{
+			// Uppercase package directory: MyTest is a directory, TestSubtract is a class.
+			classname: "tests.MyTest.test_subtract.TestSubtract",
+			name:      "test_positive",
+			wantScope: "tests/MyTest/test_subtract.py::TestSubtract",
+			wantPath:  "tests/MyTest/test_subtract.py::TestSubtract::test_positive",
+		},
+		{
+			// Uppercase package directory with no class: MyTest is a directory.
+			classname: "tests.MyTest.test_add",
+			name:      "test_add",
+			wantScope: "tests/MyTest/test_add.py",
+			wantPath:  "tests/MyTest/test_add.py::test_add",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -33,11 +33,13 @@ func TestPytestRun(t *testing.T) {
 func TestPytestRun_RetryCommand(t *testing.T) {
 	changeCwd(t, "./testdata/pytest")
 
-	pytest := NewPytest(RunnerConfig{
-		TestCommand:      "pytest failed_test.py",
-		RetryTestCommand: "pytest",
-		ResultPath:       "result-passed.json",
-	})
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand:      "pytest failed_test.py",
+			RetryTestCommand: "pytest",
+			ResultPath:       "result-passed.json",
+		},
+	}
 
 	testCases := []plan.TestCase{
 		{Path: "test_sample.py"},
@@ -53,10 +55,12 @@ func TestPytestRun_RetryCommand(t *testing.T) {
 func TestPytestRun_TestFailed(t *testing.T) {
 	changeCwd(t, "./testdata/pytest")
 
-	pytest := NewPytest(RunnerConfig{
-		TestCommand: "pytest",
-		ResultPath:  "result-failed.json",
-	})
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-failed.json",
+		},
+	}
 	testCases := []plan.TestCase{
 		{Path: "failed_test.py"},
 	}
@@ -80,6 +84,69 @@ func TestPytestRun_TestFailed(t *testing.T) {
 		{
 			Format:     "example",
 			Identifier: "a1be7e52-0dba-4018-83ce-a1598ca68807",
+			Name:       "test_failed",
+			Path:       "tests/failed_test.py::test_failed",
+			Scope:      "tests/failed_test.py",
+		},
+	}
+
+	if diff := cmp.Diff(failedTest, wantFailedTests); diff != "" {
+		t.Errorf("Pytest.Run(%q) RunResult.FailedTests() diff (-got +want):\n%s", testCases, diff)
+	}
+}
+
+func TestPytestRun_JUnit_TestPassed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-passed.xml",
+		},
+		useJUnit: true,
+	}
+	testCases := []plan.TestCase{{Path: "test_sample.py"}}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+	if err != nil {
+		t.Errorf("Pytest.Run(%q) error = %v", testCases, err)
+	}
+
+	if result.Status() != RunStatusPassed {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusPassed)
+	}
+}
+
+func TestPytestRun_JUnit_TestFailed(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "pytest",
+			ResultPath:  "result-failed.xml",
+		},
+		useJUnit: true,
+	}
+	testCases := []plan.TestCase{{Path: "failed_test.py"}}
+	result := NewRunResult([]plan.TestCase{})
+	err := pytest.Run(result, testCases, false)
+
+	exitError := new(exec.ExitError)
+	assert.ErrorAs(t, err, &exitError)
+
+	if result.Status() != RunStatusFailed {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusFailed)
+	}
+
+	failedTest := result.FailedTests()
+	if len(failedTest) != 1 {
+		t.Errorf("len(result.FailedTests()) = %d, want 1", len(failedTest))
+	}
+
+	wantFailedTests := []plan.TestCase{
+		{
+			Format:     "example",
+			Identifier: "tests/failed_test.py::test_failed",
 			Name:       "test_failed",
 			Path:       "tests/failed_test.py::test_failed",
 			Scope:      "tests/failed_test.py",
@@ -331,6 +398,58 @@ func TestPytestGetExamples_TagFilter(t *testing.T) {
 
 	if got[1].Name != "test_happy" {
 		t.Errorf("got[0].Name = %q, want %q", got[0].Name, "test_happy")
+	}
+}
+
+func TestPytestNodeIDFromJUnit(t *testing.T) {
+	tests := []struct {
+		classname string
+		name      string
+		wantScope string
+		wantPath  string
+	}{
+		{
+			classname: "test_sample",
+			name:      "test_happy",
+			wantScope: "test_sample.py",
+			wantPath:  "test_sample.py::test_happy",
+		},
+		{
+			classname: "tests.test_sample",
+			name:      "test_happy",
+			wantScope: "tests/test_sample.py",
+			wantPath:  "tests/test_sample.py::test_happy",
+		},
+		{
+			classname: "tests.failed_test",
+			name:      "test_failed",
+			wantScope: "tests/failed_test.py",
+			wantPath:  "tests/failed_test.py::test_failed",
+		},
+		{
+			classname: "test_auth.TestLogin",
+			name:      "test_success",
+			wantScope: "test_auth.py::TestLogin",
+			wantPath:  "test_auth.py::TestLogin::test_success",
+		},
+		{
+			classname: "tests.test_auth.TestLogin",
+			name:      "test_success",
+			wantScope: "tests/test_auth.py::TestLogin",
+			wantPath:  "tests/test_auth.py::TestLogin::test_success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.classname+"::"+tt.name, func(t *testing.T) {
+			gotScope, gotPath := pytestNodeIDFromJUnit(tt.classname, tt.name)
+			if gotScope != tt.wantScope {
+				t.Errorf("pytestNodeIDFromJUnit(%q, %q) scope = %q, want %q", tt.classname, tt.name, gotScope, tt.wantScope)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("pytestNodeIDFromJUnit(%q, %q) path = %q, want %q", tt.classname, tt.name, gotPath, tt.wantPath)
+			}
+		})
 	}
 }
 

--- a/internal/runner/testdata/pytest/result-failed.xml
+++ b/internal/runner/testdata/pytest/result-failed.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="1" errors="0" failures="1" skipped="0">
+    <testcase classname="tests.failed_test" name="test_failed" time="0.012">
+      <failure message="assert 3 == 5">AssertionError: assert 3 == 5</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/internal/runner/testdata/pytest/result-passed.xml
+++ b/internal/runner/testdata/pytest/result-passed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="1" errors="0" failures="0" skipped="0">
+    <testcase classname="test_sample" name="test_happy" time="0.001"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Closes https://linear.app/buildkite/issue/TE-5956

## Summary

- When `buildkite-test-collector` is installed, keep existing behavior: use `--json={{resultPath}}` and parse Test Engine JSON output
- When not installed, fall back to `--junit-xml={{resultPath}}` and parse via the shared JUnit XML parser
- Logs a message indicating which path was taken so customers can see the behavior
- `--tag-filters` requires the plugin and exits with a clear error if used without it
- Adds `pytestNodeIDFromJUnit` to reconstruct pytest node IDs (scope + path) from JUnit `classname`/`name` attributes

## Test plan

- [ ] `TestPytestRun_JUnit_TestPassed` — JUnit path parses a passing result file
- [ ] `TestPytestRun_JUnit_TestFailed` — JUnit path parses a failing result file and maps node IDs correctly
- [ ] `TestPytestNodeIDFromJUnit` — unit tests for classname → node ID conversion (flat, nested dirs, class methods)
- [ ] Existing JSON-path tests (`TestPytestRun`, `TestPytestRun_TestFailed`, etc.) still pass
- [ ] Full suite: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)