### PR TITLE
Add CHANGELOG for 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 2.6.1 - 2026-05-28
 - Extend the OIDC token fallback added in 2.6.0 to cover `bktec tools backfill-commit-metadata`. When `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` is blank, the backfill subcommand now mints a token via `buildkite-agent oidc request-token` instead of failing config validation.
 
 ## 2.6.0 - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Extend the OIDC token fallback added in 2.6.0 to cover `bktec tools backfill-commit-metadata`. When `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` is blank, the backfill subcommand now mints a token via `buildkite-agent oidc request-token` instead of failing config validation.
+
 ## 2.6.0 - 2026-05-20
 - Generate OIDC tokens using `buildkite-agent` when either `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` or `BUILDKITE_ANALYTIC_TOKEN` are not provided.
 - Fix `bktec plan` so it honors `BUILDKITE_PARALLEL_JOB_COUNT` (and the `--parallelism` flag). Previously the value was dropped before being sent to the `filter_tests` API, which caused split-by-example to never identify slow files when planning.

--- a/cli.go
+++ b/cli.go
@@ -490,6 +490,9 @@ func backfillCommitMetadataFlags() []cli.Flag {
 		daysFlag,
 		remoteFlag,
 		concurrencyFlag,
+		oidcFlag,
+		oidcLifetimeFlag,
+		buildkiteAgentCommandFlag,
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -168,10 +168,6 @@ func (c *Config) ValidateForBackfillCommitMetadata() error {
 		}
 	}
 
-	if c.AccessToken == "" {
-		c.errs.appendFieldError("--access-token / BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN", "must not be blank")
-	}
-
 	if c.OrganizationSlug == "" {
 		c.errs.appendFieldError("--organization-slug / BUILDKITE_ORGANIZATION_SLUG", "must not be blank")
 	}
@@ -180,6 +176,22 @@ func (c *Config) ValidateForBackfillCommitMetadata() error {
 	// suite-scoped, so even upload-only needs the suite to construct the URL.
 	if c.SuiteSlug == "" {
 		c.errs.appendFieldError("--suite-slug / BUILDKITE_TEST_ENGINE_SUITE_SLUG", "must not be blank")
+	}
+
+	// OIDC fallback, mirrors validate(). Mint needs org and suite slug,
+	// so the slug checks above must run first.
+	if c.AccessToken == "" {
+		token, err := c.generateOIDCToken()
+
+		if err != nil {
+			c.errs.appendFieldError("--access-token / BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN", "%v", err)
+		} else {
+			c.AccessToken = token
+		}
+	}
+
+	if c.AccessToken == "" {
+		c.errs.appendFieldError("--access-token / BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN", "must not be blank")
 	}
 
 	// Upload-only mode: skip days/concurrency checks (those govern collection).

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -528,6 +529,81 @@ func TestConfigValidateForBackfill_UploadOnlySkipsDaysAndConcurrency(t *testing.
 	err := c.ValidateForBackfillCommitMetadata()
 	if err != nil {
 		t.Errorf("ValidateForBackfillCommitMetadata() error = %v, want nil (upload mode skips days/concurrency)", err)
+	}
+}
+
+func TestConfigValidateForBackfill_OidcFallback(t *testing.T) {
+	// When AccessToken is unset and OIDC is enabled, the validator should
+	// mint a token via buildkite-agent (mirrors the validate() path used
+	// by run/plan, added in test-engine-client#507).
+	c := createBackfillConfig()
+	c.AccessToken = ""
+	c.OIDC = true
+	c.BuildkiteAgentCommand = "./mock-buildkite-agent"
+
+	err := c.ValidateForBackfillCommitMetadata()
+	if err != nil {
+		t.Errorf("ValidateForBackfillCommitMetadata() error = %v, want nil", err)
+	}
+
+	expectedToken := "mocktoken"
+	if c.AccessToken != expectedToken {
+		t.Errorf("c.AccessToken expected %v, got %v", expectedToken, c.AccessToken)
+	}
+}
+
+func TestConfigValidateForBackfill_OidcDisabled(t *testing.T) {
+	// --no-oidc (OIDC=false) disables the fallback. With AccessToken
+	// also blank, validation should surface the blank-token error rather
+	// than attempting to mint.
+	c := createBackfillConfig()
+	c.AccessToken = ""
+	c.OIDC = false
+	c.BuildkiteAgentCommand = "./mock-buildkite-agent"
+
+	err := c.ValidateForBackfillCommitMetadata()
+
+	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Fatalf("ValidateForBackfillCommitMetadata() error = %v, want InvalidConfigError", err)
+	}
+
+	key := "--access-token / BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN"
+	if len(invConfigError[key]) != 1 {
+		t.Errorf("ValidateForBackfillCommitMetadata() error for %s length = %d, want 1", key, len(invConfigError[key]))
+	}
+
+	expectedMsg := "must not be blank"
+	if invConfigError[key][0].Error() != expectedMsg {
+		t.Errorf("ValidateForBackfillCommitMetadata() error message = %q, want %q", invConfigError[key][0].Error(), expectedMsg)
+	}
+}
+
+func TestConfigValidateForBackfill_OidcMintError(t *testing.T) {
+	// When buildkite-agent fails (here: the binary doesn't exist), the
+	// mint error should surface as an --access-token validation error,
+	// not as a generic "must not be blank".
+	c := createBackfillConfig()
+	c.AccessToken = ""
+	c.OIDC = true
+	c.BuildkiteAgentCommand = "/nonexistent/buildkite-agent"
+
+	err := c.ValidateForBackfillCommitMetadata()
+
+	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Fatalf("ValidateForBackfillCommitMetadata() error = %v, want InvalidConfigError", err)
+	}
+
+	key := "--access-token / BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN"
+	// Expect two errors keyed under --access-token: the mint failure, then
+	// the blank-token check that follows it. The first is the actionable one.
+	if len(invConfigError[key]) < 1 {
+		t.Fatalf("ValidateForBackfillCommitMetadata() error for %s length = %d, want >= 1", key, len(invConfigError[key]))
+	}
+
+	if !strings.Contains(invConfigError[key][0].Error(), "error generating token") {
+		t.Errorf("ValidateForBackfillCommitMetadata() first error = %q, want substring %q", invConfigError[key][0].Error(), "error generating token")
 	}
 }
 


### PR DESCRIPTION
## Description

Rename `## Unreleased` to `## 2.6.1 - 2026-05-28` so the release pipeline picks it up. The entry covers a single change:

- OIDC token fallback extended to `bktec tools backfill-commit-metadata`, shipped by [TE-5984](https://linear.app/buildkite/issue/TE-5984) (#523).

Step 3 of the [TE-5984 release-cut sequence](https://linear.app/buildkite/issue/TE-5984#comment-dc80b2b3): land #523, then this, then cut `v2.6.1` from the release pipeline.

## Context

This PR is **stacked on top of #523** ([TE-5984] Extend OIDC token fallback to backfill-commit-metadata). Merge #523 first; this PR will then automatically retarget to `main` and show only the CHANGELOG diff.

## Verification

Diff against #523 is a single heading rename — visually reviewable. The release pipeline is what actually validates the new `2.6.1` heading.

AI assisted.

## Rollback

Yes.
