### PR TITLE
Handle <error> elements in JUnit XML parser

### DIFF
--- a/internal/runner/junit_xml.go
+++ b/internal/runner/junit_xml.go
@@ -13,11 +13,19 @@ type JUnitXMLTestCase struct {
 	Name      string           `xml:"name,attr"`
 	Result    TestStatus       // passed | failed | skipped
 	Failure   *JUnitXMLFailure `xml:"failure"`
+	Error     *JUnitXMLError   `xml:"error"`
 	Skipped   *JUnitXMLSkipped `xml:"skipped"`
 }
 
 // JUnitXMLFailure represents the <failure> element in JUnit XML
 type JUnitXMLFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Content string `xml:",chardata"`
+}
+
+// JUnitXMLError represents the <error> element in JUnit XML
+type JUnitXMLError struct {
 	Message string `xml:"message,attr"`
 	Type    string `xml:"type,attr"`
 	Content string `xml:",chardata"`
@@ -61,7 +69,7 @@ func loadAndParseJUnitXML(path string) ([]JUnitXMLTestCase, error) {
 	for _, suite := range testSuites.TestSuites {
 		for _, tc := range suite.TestCases {
 			testCase := tc
-			if testCase.Failure != nil {
+			if testCase.Failure != nil || testCase.Error != nil {
 				testCase.Result = TestStatusFailed
 			} else if testCase.Skipped != nil {
 				testCase.Result = TestStatusSkipped

--- a/internal/runner/junit_xml_test.go
+++ b/internal/runner/junit_xml_test.go
@@ -23,6 +23,16 @@ const exampleJUnitXML = `<?xml version="1.0" encoding="UTF-8"?>
 	</testsuite>
 </testsuites>`
 
+const exampleJUnitXMLWithError = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0" errors="1" time="0.5">
+	<testsuite tests="2" failures="0" errors="1" time="0.5" name="mypackage">
+		<testcase classname="mypackage" name="TestSetupCrash" time="0.000000">
+			<error message="panic in setup" type="RuntimeError">goroutine 1 [running]: panic...</error>
+		</testcase>
+		<testcase classname="mypackage" name="TestOK" time="0.000000"></testcase>
+	</testsuite>
+</testsuites>`
+
 func TestLoadAndParseJUnitXML(t *testing.T) {
 	tmpfile, err := os.CreateTemp("", "junit.*.xml")
 	require.NoError(t, err)
@@ -61,4 +71,32 @@ func TestLoadAndParseJUnitXML(t *testing.T) {
 	assert.Equal(t, TestStatusPassed, results[3].Result)
 	assert.Nil(t, results[3].Failure)
 	assert.Nil(t, results[3].Skipped)
+}
+
+func TestLoadAndParseJUnitXML_Error(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "junit.*.xml")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.WriteString(exampleJUnitXMLWithError)
+	require.NoError(t, err)
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	results, err := loadAndParseJUnitXML(tmpfile.Name())
+	require.NoError(t, err)
+
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "TestSetupCrash", results[0].Name)
+	assert.Equal(t, TestStatusFailed, results[0].Result)
+	assert.Nil(t, results[0].Failure)
+	assert.NotNil(t, results[0].Error)
+	assert.Equal(t, "panic in setup", results[0].Error.Message)
+	assert.Equal(t, "RuntimeError", results[0].Error.Type)
+
+	assert.Equal(t, "TestOK", results[1].Name)
+	assert.Equal(t, TestStatusPassed, results[1].Result)
+	assert.Nil(t, results[1].Failure)
+	assert.Nil(t, results[1].Error)
 }


### PR DESCRIPTION
## Summary

- Add `JUnitXMLError` struct mapping the `<error>` child element of `<testcase>`
- Treat `<error>` presence as `TestStatusFailed` (alongside existing `<failure>` handling)
- Add test covering a JUnit XML report with an `<error>` test case

Fixes TE-5994. Per the JUnit XML convention, `<error>` means the test couldn't run to completion (setup/teardown crash, uncaught exception, collection error) — distinct from `<failure>` (assertion failed) but equally a non-pass result. Previously these fell through to `TestStatusPassed` and would never be retried.

## Test plan

- [ ] `go test ./internal/runner/ -run TestLoadAndParseJUnitXML` passes (both `TestLoadAndParseJUnitXML` and `TestLoadAndParseJUnitXML_Error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)