### PR TITLE
Upload pytest test results to Upload API

### DIFF
--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -90,6 +90,13 @@ func NewPytest(c RunnerConfig) Pytest {
 	}
 }
 
+func (p Pytest) ResultFormat() string {
+	if p.useJUnit {
+		return "junit"
+	}
+	return ""
+}
+
 func (p Pytest) SupportedFeatures() SupportedFeatures {
 	return SupportedFeatures{
 		SplitByFile:     true,

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -514,3 +514,17 @@ test_auth.py::test_param[value1]
 		t.Errorf("parsePytestCollectOutput() diff (-got +want):\n%s", diff)
 	}
 }
+
+func TestPytestResultFormat_JUnit(t *testing.T) {
+	pytest := Pytest{useJUnit: true}
+	if got := pytest.ResultFormat(); got != "junit" {
+		t.Errorf("ResultFormat() = %q, want %q", got, "junit")
+	}
+}
+
+func TestPytestResultFormat_JSON(t *testing.T) {
+	pytest := Pytest{useJUnit: false}
+	if got := pytest.ResultFormat(); got != "" {
+		t.Errorf("ResultFormat() = %q, want %q (empty, test collector handles upload)", got, "")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `ResultFormat()` on the `Pytest` runner to hook into the existing `uploadResults` flow in `run.go`
- Returns `"junit"` when using JUnit XML output (the default), triggering an upload to the Upload API
- Returns `""` when using JSON output (buildkite-test-collector plugin), skipping the upload to avoid duplicates — the collector handles it itself

Closes TE-5957
Depends on TE-5956 (already merged)

## Test plan

- [ ] `TestPytestResultFormat_JUnit` — verifies `"junit"` is returned when `useJUnit: true`
- [ ] `TestPytestResultFormat_JSON` — verifies `""` is returned when `useJUnit: false`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)