### PR TITLE
Add CHANGELOG for 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
-## Unreleased
+## 2.7.0 - 2026-05-29
+- Upload test results to the Test Engine Upload API after each run, replacing the need to install `buildkite-test-collector` alongside `bktec`. Opt-in via `BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS`; disabled by default to avoid double-uploading for customers already running the collector.
+- Change the Pytest runner default output to JUnit XML when `buildkite-test-collector` is not installed. When the plugin is present, the existing Test Engine JSON output and `--tag-filters` behaviour are unchanged. Using `--tag-filters` without the plugin now exits with a clear error.
+- Handle `<error>` elements in JUnit XML test reports as failures. Previously, tests that errored during setup/teardown or raised uncaught exceptions were misclassified as passed and were never retried.
 - Extend the OIDC token fallback added in 2.6.0 to cover `bktec tools backfill-commit-metadata`. When `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` is blank, the backfill subcommand now mints a token via `buildkite-agent oidc request-token` instead of failing config validation.
+- Include the working directory (`cwd`) in the `run_env` field of uploaded test results when running inside Buildkite, so the receiving side can resolve absolute file paths emitted by runners like Jest back to repo-relative paths.
 - Custom runner now accepts both Test Engine JSON (default) and JUnit XML result files. Set `BUILDKITE_TEST_ENGINE_RESULT_PATH` to a path ending in `.xml` to use JUnit XML; any other extension uses Test Engine JSON.
 
 ## 2.6.0 - 2026-05-20


### PR DESCRIPTION
## Description

Rename `## Unreleased` to `## 2.7.0 - 2026-05-29` and add the user-visible changes that have landed on `main` since v2.6.0:

- Opt-in test result upload to the Upload API (#519, #527).
- Pytest default output switched to JUnit XML when `buildkite-test-collector` is absent (#524).
- JUnit XML parser now treats `<error>` elements as failures (#526).
- OIDC token fallback extended to `bktec tools backfill-commit-metadata` (#523).
- `cwd` included in `run_env` for uploaded results, so the receiving side can resolve absolute paths back to repo-relative (#522).
- Custom runner now accepts both Test Engine JSON (default) and JUnit XML result files (#528).

### Decisions Made

**Minor version bump to 2.7.0, not patch to 2.6.1.** The original release-cut sequence for [TE-5984](https://linear.app/buildkite/issue/TE-5984) anticipated a 2.6.x patch carrying only the OIDC fallback extension. PRs #519 and #527 add a new opt-in feature (test result upload), and #524 changes default behaviour for the Pytest runner. Semver puts both in minor-bump territory.

**Bundle the rest of `main` into this release.** The alternative is to cut 2.7.0 with only the upload work and follow up with 2.7.1 for the OIDC fallback. Bundling minimises the number of bktec versions downstream consumers (notably `test-prediction-backfill`, which TE-5860 will pin) need to consider, and the upload work is already verified on `main`.

## Context

Resolves [TE-5984](https://linear.app/buildkite/issue/TE-5984)'s release-cut step. This is step 3 of the [release-cut sequence](https://linear.app/buildkite/issue/TE-5984#comment-dc80b2b3): land #523, then this, then cut `v2.7.0` from the release pipeline.

#523 has now merged to `main`, so this PR is no longer stacked and targets `main` directly. The branch has been rebased onto the latest `main` (which also includes #528); the diff is CHANGELOG-only.

## Verification

Diff is CHANGELOG-only — visually reviewable. The release pipeline is what actually validates the new `2.7.0` heading.

AI assisted.

## Rollback

Yes.
