### PR TITLE
[PS-2065] Fall back to mute when skip is unsupported

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -60,6 +60,22 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
 
+	// When a runner can mute tests but cannot skip them, fall back to muting the
+	// tests Test Engine wanted to skip.
+	//
+	// Test Engine excludes skipped tests from a node's task list, but runners that
+	// split by file (e.g. Jest) still receive the whole file and run every test in
+	// it, including the ones marked for skipping. Such runners have no way to skip
+	// an individual test, so the skipped test executes anyway and its failure would
+	// fail the build. Treating it as muted lets it run while suppressing its
+	// failure. Muting is matched by scope and name, so the skipped test is muted
+	// regardless of which file or node it belongs to.
+	features := testRunner.SupportedFeatures()
+	if !features.Skip && features.Mute && len(testPlan.SkippedTests) > 0 {
+		testPlan.MutedTests = append(testPlan.MutedTests, testPlan.SkippedTests...)
+		testPlan.SkippedTests = nil
+	}
+
 	// File paths sent to the API for test plan creation include the location prefix to match Test Engine records.
 	// However, the test runner expects file paths without the prefix, so we need to remove it before running the tests.
 	locationPrefix := testRunner.LocationPrefix()

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1021,3 +1021,33 @@ func TestRunTestsWithRetry_UploadErrorDoesNotFailBuild(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, runner.RunStatusPassed, result.Status(), "build should pass even when upload fails")
 }
+
+// TestSkipToMuteFallback_FailedSkippedTestDoesNotFailBuild verifies the core
+// behaviour: for a runner that mutes but cannot skip (e.g. Jest), a test that
+// Test Engine wanted to skip still executes (the runner has no way to skip it),
+// but because it is treated as muted, its failure does not fail the build.
+func TestSkipToMuteFallback_FailedSkippedTestDoesNotFailBuild(t *testing.T) {
+	// Test Engine reports this test as skipped, but Jest can't skip it.
+	skippedTest := plan.TestCase{Path: "fruits.spec.js", Scope: "Fruits", Name: "is forbidden"}
+
+	// Emulate the fallback applied in Run: skipped tests become muted tests.
+	mutedTests := []plan.TestCase{skippedTest}
+	result := runner.NewRunResult(mutedTests)
+
+	// The runner executes the test (because it couldn't be skipped) and it fails.
+	result.RecordTestResult(skippedTest, runner.TestStatusFailed)
+
+	// The failure is treated as muted, so the build still passes.
+	if got := result.Status(); got != runner.RunStatusPassed {
+		t.Errorf("Status() = %v, want %v", got, runner.RunStatusPassed)
+	}
+	if !result.OnlyMutedFailures() {
+		t.Error("OnlyMutedFailures() = false, want true")
+	}
+	if len(result.FailedTests()) != 0 {
+		t.Errorf("FailedTests() = %v, want none (failure should be muted)", result.FailedTests())
+	}
+	if len(result.FailedMutedTests()) != 1 {
+		t.Errorf("FailedMutedTests() = %v, want 1", result.FailedMutedTests())
+	}
+}


### PR DESCRIPTION
> **Demonstration PR, not for merge.** Opened as a draft to show this approach as an option for PS-2065 / PS-2061.

For runners that can mute but cannot skip (e.g. Jest), bktec now falls back to muting the tests Test Engine wanted to skip, so their failures no longer fail the build.

Test Engine excludes skipped tests from a node's task list. File-splitting runners like Jest still receive the whole file and run every test in it, including the ones marked for skipping. Jest has no way to skip an individual test, so the test executes and its failure fails the build — the behaviour Highspot hit in PS-2061.

### Decisions Made

**Mute rather than re-run-and-discard.** Muting is matched by scope and name and reuses the existing muted-failure suppression (`OnlyMutedFailures`), so no new result-handling path is introduced. The skipped tests are left in the task list and simply registered as muted; they were already running.

**Runners that genuinely support skip are untouched.** RSpec splits by example and never receives the skipped cases, so the fallback only applies when `SupportedFeatures{Skip: false, Mute: true}`.

## Context

Linear: PS-2065, related to PS-2061

## Verification

`go test ./internal/command/` — backed by specs. New test `TestSkipToMuteFallback_FailedSkippedTestDoesNotFailBuild` asserts a failing skipped-then-muted test yields `RunStatusPassed` with the failure recorded as muted. AI assisted.

## Rollback

Yes. Single self-contained change behind a runner-capability check; reverting the commit restores prior behaviour.
