### PR TITLE
[PS-2066] Warn when skip is unsupported for the runner

### DIFF
--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -14,8 +14,16 @@ type FilterTestsParams struct {
 	Env   *config.Config  `json:"env"`
 }
 
+// FilterReasonSkippedTests is the reason value the server attaches to a
+// filtered file when the file contains one or more skipped tests. It must match
+// TestSplitting::TestPlan::TestFilesFilter::Reason::SKIP on the server.
+const FilterReasonSkippedTests = "file contains 1 or more skipped tests"
+
 type FilteredTest struct {
 	Path string `json:"path"`
+	// Reason explains why the server returned this file, e.g. "slow file" or
+	// "file contains 1 or more skipped tests".
+	Reason string `json:"reason"`
 }
 
 type FilteredTestResponse struct {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -48,6 +48,13 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 		OrganizationSlug: cfg.OrganizationSlug,
 	})
 
+	// Skipped tests are honoured server-side by excluding them from a node's task
+	// list, which only works for runners that skip by example. File-splitting
+	// runners (e.g. Jest) receive the whole file and run every test in it, so a
+	// test marked for skipping runs anyway and its failure fails the build. Warn
+	// loudly so the behaviour isn't silent; we don't change what runs.
+	warnIfSkipUnsupported(ctx, apiClient, cfg, files, testRunner)
+
 	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, files, testRunner)
 	if err != nil {
 		return err
@@ -107,6 +114,63 @@ func printStartUpMessage() {
 	const reset = "\033[0m"
 	fmt.Println("+++ Buildkite Test Engine Client: bktec " + version.Version + "\n")
 	fmt.Println(green + Logo + reset)
+}
+
+// warnIfSkipUnsupported warns when the suite has tests marked for skipping but
+// the runner cannot skip them.
+//
+// Test Engine honours skips by omitting tests from a node's task list, which
+// only works for runners that split by example. File-splitting runners receive
+// the whole file and run every test in it, so a skipped test runs anyway and
+// its failure fails the build. We detect this via the filter_tests endpoint,
+// which returns the discovered test files tagged with a reason; files whose
+// reason is "file contains 1 or more skipped tests" hold tests the runner will
+// run despite the skip.
+//
+// This is advisory only: it never changes what runs and never fails the build.
+// Any error talking to filter_tests is logged to debug and otherwise ignored.
+func warnIfSkipUnsupported(ctx context.Context, apiClient *api.Client, cfg *config.Config, files []string, testRunner runner.TestRunner) {
+	if testRunner.SupportedFeatures().Skip {
+		return
+	}
+
+	prefix := testRunner.LocationPrefix()
+	testFiles := make([]plan.TestCase, len(files))
+	for i, file := range files {
+		testFiles[i] = plan.TestCase{Path: prefixPath(file, prefix)}
+	}
+
+	filtered, err := apiClient.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
+		Files: testFiles,
+		Env:   cfg,
+	})
+	if err != nil {
+		debug.Printf("Skip-support check skipped: filter_tests failed: %v", err)
+		return
+	}
+
+	var skippedFiles []string
+	for _, file := range filtered {
+		if file.Reason != api.FilterReasonSkippedTests {
+			continue
+		}
+		// Trim the prefix back off so the path matches what the user sees locally.
+		path := file.Path
+		if trimmed, trimErr := trimFilePathPrefix(path, prefix); trimErr == nil {
+			path = trimmed
+		}
+		skippedFiles = append(skippedFiles, path)
+	}
+
+	if len(skippedFiles) == 0 {
+		return
+	}
+
+	fmt.Printf("~~~ ⚠️ Buildkite Test Engine Client: %s does not support skipping tests\n", testRunner.Name())
+	fmt.Printf("Test Engine has tests marked for skipping in the following files, but %s cannot skip individual tests. These tests will run, and a failure will fail the build:\n", testRunner.Name())
+	for _, path := range skippedFiles {
+		fmt.Printf("- %s\n", path)
+	}
 }
 
 func printReport(runResult runner.RunResult, testsSkippedByTestEngine []plan.TestCase, runnerName string) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -1020,4 +1022,98 @@ func TestRunTestsWithRetry_UploadErrorDoesNotFailBuild(t *testing.T) {
 	result, err := runTestsWithRetry(context.Background(), apiClient, cfg, testRunner, &testCases, 0, []plan.TestCase{}, &timeline, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, runner.RunStatusPassed, result.Status(), "build should pass even when upload fails")
+}
+
+// captureStdout redirects os.Stdout to a pipe and returns a function that,
+// when called, closes the write end and returns everything written to stdout.
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+	return func() string {
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		r.Close()
+		return buf.String()
+	}
+}
+
+func TestWarnIfSkipUnsupported_WarnsForSkipReasonFiles(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		io.WriteString(w, `{"tests": [
+			{"path": "fruits.spec.js", "reason": "file contains 1 or more skipped tests"},
+			{"path": "slow.spec.js", "reason": "slow file"}
+		]}`)
+	}))
+	defer svr.Close()
+
+	cfg := &config.Config{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite", SuiteSlug: "jest"}
+	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite"})
+	testRunner := runner.NewJest(runner.RunnerConfig{})
+
+	getOutput := captureStdout(t)
+	warnIfSkipUnsupported(context.Background(), apiClient, cfg, []string{"fruits.spec.js", "slow.spec.js"}, testRunner)
+	out := getOutput()
+
+	if !strings.Contains(out, "does not support skipping tests") {
+		t.Errorf("expected skip-unsupported warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fruits.spec.js") {
+		t.Errorf("expected skip-reason file in warning, got:\n%s", out)
+	}
+	if strings.Contains(out, "slow.spec.js") {
+		t.Errorf("slow file should not be named in the skip warning, got:\n%s", out)
+	}
+}
+
+func TestWarnIfSkipUnsupported_NoWarningWithoutSkipReasonFiles(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		io.WriteString(w, `{"tests": [{"path": "slow.spec.js", "reason": "slow file"}]}`)
+	}))
+	defer svr.Close()
+
+	cfg := &config.Config{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite", SuiteSlug: "jest"}
+	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite"})
+	testRunner := runner.NewJest(runner.RunnerConfig{})
+
+	getOutput := captureStdout(t)
+	warnIfSkipUnsupported(context.Background(), apiClient, cfg, []string{"slow.spec.js"}, testRunner)
+	out := getOutput()
+
+	if strings.Contains(out, "does not support skipping tests") {
+		t.Errorf("did not expect a warning when no skip-reason files, got:\n%s", out)
+	}
+}
+
+func TestWarnIfSkipUnsupported_SkipsCheckForSkipCapableRunner(t *testing.T) {
+	called := false
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		io.WriteString(w, `{"tests": []}`)
+	}))
+	defer svr.Close()
+
+	cfg := &config.Config{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite", SuiteSlug: "rspec"}
+	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL, OrganizationSlug: "buildkite"})
+	// RSpec supports skipping (by example), so the check should be a no-op.
+	testRunner := runner.NewRspec(runner.RunnerConfig{})
+
+	getOutput := captureStdout(t)
+	warnIfSkipUnsupported(context.Background(), apiClient, cfg, []string{"fruits_spec.rb"}, testRunner)
+	out := getOutput()
+
+	if called {
+		t.Error("filter_tests should not be called for a skip-capable runner")
+	}
+	if out != "" {
+		t.Errorf("expected no output for skip-capable runner, got:\n%s", out)
+	}
 }


### PR DESCRIPTION
> **Demonstration PR, not for merge.** Opened as a draft to show this approach as an option for PS-2066 / PS-2061.

For runners that cannot skip tests (e.g. Jest), bktec now warns loudly when the suite has tests marked for skipping in files the runner will run, instead of failing the build silently.

Test Engine honours skips by omitting tests from a node's task list, which only works for runners that split by example. File-splitting runners like Jest receive the whole file and run every test in it, so a "skipped" test runs anyway and its failure fails the build with no indication that skip is unsupported — the behaviour a customer hit in PS-2061.

Detection uses the `filter_tests` endpoint rather than `testPlan.SkippedTests`. The server tags each returned file with a `reason` (`"slow file"` or `"file contains 1 or more skipped tests"`); skipped files are always returned, slow files only when `split_by_example` is true. The client previously decoded only `path` and discarded `reason`. This change decodes `reason` and, for non-skip runners, warns when any file carries the skip reason.

### Decisions Made

**`filter_tests`, not the Quarantine REST API.** `GET .../tests/skipped` returns example-level data but is suite-wide, so it over-reports tests from files this build doesn't run. `filter_tests` is build-scoped (filters against the POSTed files).

**Advisory only.** The warning never mutes, never alters the task list, and never changes the exit code. Errors from `filter_tests` (including the endpoint's retryable "still filtering" responses) are logged to debug and ignored, since this is off the critical path.

**File-level, not test-level.** `filter_tests` returns files, not examples, so the warning names the affected files but not the individual skipped tests. This is the same client-side limitation that made the PS-2065 mute-fallback unworkable.

## Context

Linear: PS-2066, related to PS-2061. Alternative to PS-2065 (#531, closed).

## Verification

`go test ./internal/command/ ./internal/api/` — backed by specs. New tests cover: a skip-reason file produces a warning (and a slow-reason file in the same response does not), no warning when only slow files are returned, and skip-capable runners (RSpec) skip the check entirely (no `filter_tests` call). Server contract (`reason` values, skip-vs-slow gating) fact-checked against the `buildkite` Rails app. AI assisted.

## Rollback

Yes. Additive, advisory-only change behind a runner-capability check; reverting the commit removes the warning with no behavioural change.
