### PR TITLE
[TE-6006] Update bktec docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ bktec uses the following Buildkite Pipeline provided environment variables.
 > [!IMPORTANT]
 > Please make sure that the above environment variables are available in your testing environment, particularly if you use Docker or some other type of containerization to run your tests.
 
-### Create API access token
-To use bktec, you need a Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes. You can generate this token from your [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite. After creating the token, set the `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` environment variable with the token value.
+### Authentication
+
+From bktec 2.6.0, bktec automatically requests a [Buildkite Agent OIDC token](https://buildkite.com/docs/agent/cli/reference/oidc) for authentication. You don't need to create or configure an API access token. You will need to [configure an OIDC policy for your Test Engine suite](https://buildkite.com/docs/test-engine/test-collection/oidc) to allow this.
+
+If you're running bktec older than 2.6.0, or if you want to use an API access token instead, you can create a Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes from your [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite, then set:
 
 ```sh
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=token
@@ -208,7 +211,6 @@ steps:
     parallelism: 10
     env:
       BUILDKITE_TEST_ENGINE_SUITE_SLUG: my-suite
-      BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-secret-token
       BUILDKITE_TEST_ENGINE_TEST_RUNNER: rspec
       BUILDKITE_TEST_ENGINE_RESULT_PATH: tmp/result.json
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ bktec run --tag env=production --tag region=us-east-1
 export BUILDKITE_TEST_ENGINE_TAGS="env=production,region=us-east-1"
 ```
 
+> [!NOTE]
+> `BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS` is not supported for the `pytest-pants` runner. Use Option 2 below instead.
+
 **Option 2: Install a [Buildkite Test Collector](https://buildkite.com/docs/test-engine/test-collection)**
 
 Test collectors are available for many languages and frameworks. Some collectors also provide richer data collection such as execution-level tagging and span tracing. See the [test collector docs](https://buildkite.com/docs/test-engine/test-collection) for details on what's available for your framework.

--- a/docs/gotest.md
+++ b/docs/gotest.md
@@ -77,16 +77,12 @@ export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
   commands:
     - bktec run
   env:
-    BUILDKITE_ANALYTICS_TOKEN: your-suite-token # For test collector
+    BUILDKITE_ANALYTICS_TOKEN: your-suite-token # For uploading test data to Test Engine
+    BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS: "true" # This will upload test results to Test Engine using the BUILDKITE_ANALYTICS_TOKEN
     BUILDKITE_TEST_ENGINE_SUITE_SLUG: your-suite-slug
-    BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-api-token # For state management
+    BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-api-token
     BUILDKITE_TEST_ENGINE_TEST_RUNNER: gotest
     BUILDKITE_TEST_ENGINE_RESULT_PATH: tmp/gotest-result.xml
     BUILDKITE_TEST_ENGINE_RETRY_COUNT: 1
   parallelism: 2
-  plugins:
-    # This will make sure test result are sent to buildkite.
-    - test-collector#v1.11.0:
-        files: "tmp/gotest-result.xml"
-        format: "junit"
 ```

--- a/docs/nunit.md
+++ b/docs/nunit.md
@@ -82,14 +82,11 @@ steps:
       - bktec run
     env:
       BUILDKITE_TEST_ENGINE_SUITE_SLUG: your-suite-slug
+      BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS: "true" # This will upload test results to Test Engine using the BUILDKITE_ANALYTICS_TOKEN
       BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-api-token
       BUILDKITE_TEST_ENGINE_TEST_RUNNER: nunit
       BUILDKITE_TEST_ENGINE_RESULT_PATH: test-results/results.xml
       BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN: "tests/**/*Tests.cs"
       BUILDKITE_TEST_ENGINE_RETRY_COUNT: 1
     parallelism: 4
-    plugins:
-      - test-collector#v1.11.0:
-          files: "test-results/results.xml"
-          format: "junit"
 ```

--- a/docs/nunit.md
+++ b/docs/nunit.md
@@ -82,7 +82,7 @@ steps:
       - bktec run
     env:
       BUILDKITE_TEST_ENGINE_SUITE_SLUG: your-suite-slug
-      BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS: "true" # This will upload test results to Test Engine using the BUILDKITE_ANALYTICS_TOKEN
+      BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS: "true" # This will upload test results to Test Engine
       BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: your-api-token
       BUILDKITE_TEST_ENGINE_TEST_RUNNER: nunit
       BUILDKITE_TEST_ENGINE_RESULT_PATH: test-results/results.xml


### PR DESCRIPTION
### Description

The test collector plugin is now optional following recent changes (OIDC auth in 2.6.0, built-in upload in 2.7.0). The docs hadn't been updated to reflect this, so users setting up bktec for the first time would still see outdated instructions.

### Context

https://linear.app/buildkite/issue/TE-6006/update-bktec-docs

### Changes

- Updated the Authentication section in the README to document OIDC token auth as the default and API token as a fallback
- Added a new "Upload test results to Test Engine" section to the README covering `BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS` and `--tag`
- Removed the `test-collector` plugin step from the gotest and nunit examples
- Updated the pytest-pants docs to explain both collector and JUnit fallback modes

### Testing

Docs-only change, reviewed manually.