### PR TITLE
Retry uploading test results on transient failures

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -144,9 +144,10 @@ type httpRequest struct {
 // shared retry mechanics used by doJSONWithRetry and UploadTestResults.
 //
 // The request is retried when the server returns 429, 409, or 5xx, or when there
-// is a network error. After reaching the retry timeout, the function returns
-// ErrRetryTimeout. newRequest builds a fresh request for each attempt (so a body
-// can be re-sent on retry).
+// is a network error. retryTimeout caps the total time spent across all attempts,
+// and perAttemptTimeout caps each individual attempt. After exhausting the retry
+// timeout, the function returns ErrRetryTimeout. newRequest builds a fresh request
+// for each attempt (so a body can be re-sent on retry).
 //
 // On a response that is not retried, doWithRetry returns it with a nil error
 // and the caller is responsible for reading and closing the response body. When
@@ -154,6 +155,7 @@ type httpRequest struct {
 func (c *Client) doWithRetry(
 	ctx context.Context,
 	perAttemptTimeout time.Duration,
+	retryTimeout time.Duration,
 	newRequest func(ctx context.Context) (*http.Request, error),
 ) (*http.Response, error) {
 	r := roko.NewRetrier(
@@ -249,7 +251,7 @@ func (c *Client) doJSONWithRetry(ctx context.Context, reqOptions httpRequest, v 
 
 	// Each request times out after 15 seconds, chosen to provide some
 	// headroom on top of the goal p99 time to fetch of 10s.
-	timeOut := 15 * time.Second
+	perAttemptTimeout := 15 * time.Second
 	newRequest := func(reqContext context.Context) (*http.Request, error) {
 		req, err := http.NewRequestWithContext(reqContext, reqOptions.Method, reqOptions.URL, nil)
 		if err != nil {
@@ -269,7 +271,7 @@ func (c *Client) doJSONWithRetry(ctx context.Context, reqOptions httpRequest, v 
 		return req, nil
 	}
 
-	resp, err := c.doWithRetry(ctx, timeOut, newRequest)
+	resp, err := c.doWithRetry(ctx, perAttemptTimeout, retryTimeout, newRequest)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -148,8 +148,9 @@ type httpRequest struct {
 // ErrRetryTimeout. newRequest builds a fresh request for each attempt (so a body
 // can be re-sent on retry).
 //
-// On a response that is not retried, doWithRetry returns it with a nil error;
-// the caller is responsible for reading and closing the response body.
+// On a response that is not retried, doWithRetry returns it with a nil error
+// and the caller is responsible for reading and closing the response body. When
+// it returns an error, any response body has already been closed.
 func (c *Client) doWithRetry(
 	ctx context.Context,
 	perAttemptTimeout time.Duration,
@@ -196,17 +197,20 @@ func (c *Client) doWithRetry(
 			if rateLimitReset, err := strconv.Atoi(resp.Header.Get("RateLimit-Reset")); err == nil {
 				r.SetNextInterval(time.Duration(rateLimitReset) * time.Second)
 			}
+			drainAndCloseBody(resp)
 			return resp, fmt.Errorf("response code: 429")
 		}
 
 		// If we get a 409, we aren't the first client to create the plan so return
 		// and retry
 		if resp.StatusCode == http.StatusConflict {
+			drainAndCloseBody(resp)
 			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
 		}
 
 		// If we get a 5xx, we should return and retry
 		if resp.StatusCode >= 500 {
+			drainAndCloseBody(resp)
 			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
 		}
 
@@ -221,6 +225,16 @@ func (c *Client) doWithRetry(
 	}
 
 	return resp, err
+}
+
+// drainAndCloseBody reads resp.Body to the end and closes it. An HTTP request
+// reuses an existing network connection only if the previous response body was
+// fully read and closed, so draining lets the next retry reuse the connection
+// instead of opening a new one. Errors are ignored: draining is best-effort, and
+// a failed drain just means the connection won't be reused.
+func drainAndCloseBody(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 }
 
 // doJSONWithRetry sends a JSON HTTP request via doWithRetry.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -140,13 +140,21 @@ type httpRequest struct {
 	Body   any
 }
 
-// DoWithRetry sends http request with retries.
-// Successful API response (status code 200) is JSON decoded and stored in the value pointed to by v.
-// The request will be retried when the server returns 429 or 5xx status code, or when there is a network error.
-// After reaching the retry timeout, the function will return ErrRetryTimeout.
-// The request will not be retried when the server returns 4xx status code,
-// and the error message will be returned as an error.
-func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v interface{}) (*http.Response, error) {
+// doWithRetry runs the request built by newRequest with retries. It holds the
+// shared retry mechanics used by doJSONWithRetry and UploadTestResults.
+//
+// The request is retried when the server returns 429, 409, or 5xx, or when there
+// is a network error. After reaching the retry timeout, the function returns
+// ErrRetryTimeout. newRequest builds a fresh request for each attempt (so a body
+// can be re-sent on retry).
+//
+// On a response that is not retried, doWithRetry returns it with a nil error;
+// the caller is responsible for reading and closing the response body.
+func (c *Client) doWithRetry(
+	ctx context.Context,
+	perAttemptTimeout time.Duration,
+	newRequest func(ctx context.Context) (*http.Request, error),
+) (*http.Response, error) {
 	r := roko.NewRetrier(
 		roko.TryForever(),
 		roko.WithStrategy(roko.ExponentialSubsecond(initialDelay)),
@@ -157,34 +165,19 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 	defer cancelRetryContext()
 
 	// retry loop
-	debug.Printf("Sending request %s %s", reqOptions.Method, reqOptions.URL)
 	resp, err := roko.DoFunc(retryContext, r, func(r *roko.Retrier) (*http.Response, error) {
 		if r.AttemptCount() > 0 {
 			debug.Printf("Retrying requests, attempt %d", r.AttemptCount())
 		}
 
-		// Each request times out after 15 seconds, chosen to provide some
-		// headroom on top of the goal p99 time to fetch of 10s.
-		reqContext, cancelReqContext := context.WithTimeout(ctx, 15*time.Second)
+		reqContext, cancelReqContext := context.WithTimeout(ctx, perAttemptTimeout)
 		defer cancelReqContext()
 
-		req, err := http.NewRequestWithContext(reqContext, reqOptions.Method, reqOptions.URL, nil)
+		req, err := newRequest(reqContext)
 		if err != nil {
 			r.Break()
-			return nil, fmt.Errorf("creating request: %w", err)
+			return nil, err
 		}
-
-		if reqOptions.Method != http.MethodGet && reqOptions.Body != nil {
-			// add body to request
-			reqBody, err := json.Marshal(reqOptions.Body)
-			if err != nil {
-				r.Break()
-				return nil, fmt.Errorf("converting body to json: %w", err)
-			}
-			req.Body = io.NopCloser(bytes.NewReader(reqBody))
-		}
-
-		req.Header.Add("Content-Type", "application/json")
 
 		resp, err := c.httpClient.Do(req)
 
@@ -217,51 +210,9 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
 		}
 
-		// Other than above cases, we should break from the retry loop.
+		// Other than above cases, we stop retrying and let the caller handle the
+		// response.
 		r.Break()
-
-		responseBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("reading response body: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			var respError responseError
-			err = json.Unmarshal(responseBody, &respError)
-			if err != nil {
-				return resp, fmt.Errorf("parsing response: %w", err)
-			}
-
-			// 5xx and 429 are handled above and trigger retries; here we only
-			// classify 4xx responses into typed errors.
-			switch resp.StatusCode {
-			case http.StatusUnauthorized:
-				return resp, &AuthError{Message: respError.Message}
-			case http.StatusForbidden:
-				if strings.HasPrefix(respError.Message, "Billing Error") {
-					return resp, &BillingError{Message: respError.Message}
-				}
-				return resp, &ForbiddenError{Message: respError.Message}
-			case http.StatusNotFound:
-				return resp, &NotFoundError{Message: respError.Message}
-			case http.StatusBadRequest:
-				return resp, &BadRequestError{Message: respError.Message}
-			case http.StatusUnprocessableEntity:
-				return resp, &UnprocessableEntityError{Message: respError.Message}
-			default:
-				return resp, &respError
-			}
-		}
-
-		// parse response
-		if v != nil && len(responseBody) > 0 {
-			err = json.Unmarshal(responseBody, v)
-			if err != nil {
-				return nil, fmt.Errorf("parsing response: %w", err)
-			}
-		}
-
 		return resp, nil
 	})
 
@@ -270,4 +221,86 @@ func (c *Client) DoWithRetry(ctx context.Context, reqOptions httpRequest, v inte
 	}
 
 	return resp, err
+}
+
+// doJSONWithRetry sends a JSON HTTP request via doWithRetry.
+// The request body (if any) is JSON encoded with a Content-Type of
+// application/json, and a successful API response (status code 200) is JSON
+// decoded and stored in the value pointed to by v. A non-200 response is
+// returned as a typed error.
+// For non-JSON requests (e.g. multipart uploads), use doWithRetry directly.
+// See doWithRetry for the retry behavior.
+func (c *Client) doJSONWithRetry(ctx context.Context, reqOptions httpRequest, v interface{}) (*http.Response, error) {
+	debug.Printf("Sending request %s %s", reqOptions.Method, reqOptions.URL)
+
+	// Each request times out after 15 seconds, chosen to provide some
+	// headroom on top of the goal p99 time to fetch of 10s.
+	timeOut := 15 * time.Second
+	newRequest := func(reqContext context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(reqContext, reqOptions.Method, reqOptions.URL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		if reqOptions.Method != http.MethodGet && reqOptions.Body != nil {
+			// add body to request
+			reqBody, err := json.Marshal(reqOptions.Body)
+			if err != nil {
+				return nil, fmt.Errorf("converting body to json: %w", err)
+			}
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
+
+		req.Header.Add("Content-Type", "application/json")
+		return req, nil
+	}
+
+	resp, err := c.doWithRetry(ctx, timeOut, newRequest)
+	if err != nil {
+		return resp, err
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var respError responseError
+		err = json.Unmarshal(responseBody, &respError)
+		if err != nil {
+			return resp, fmt.Errorf("parsing response: %w", err)
+		}
+
+		// 5xx and 429 are handled by doWithRetry and trigger retries; here we
+		// only classify 4xx responses into typed errors.
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			return resp, &AuthError{Message: respError.Message}
+		case http.StatusForbidden:
+			if strings.HasPrefix(respError.Message, "Billing Error") {
+				return resp, &BillingError{Message: respError.Message}
+			}
+			return resp, &ForbiddenError{Message: respError.Message}
+		case http.StatusNotFound:
+			return resp, &NotFoundError{Message: respError.Message}
+		case http.StatusBadRequest:
+			return resp, &BadRequestError{Message: respError.Message}
+		case http.StatusUnprocessableEntity:
+			return resp, &UnprocessableEntityError{Message: respError.Message}
+		default:
+			return resp, &respError
+		}
+	}
+
+	// parse response
+	if v != nil && len(responseBody) > 0 {
+		err = json.Unmarshal(responseBody, v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing response: %w", err)
+		}
+	}
+
+	return resp, nil
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -107,7 +107,7 @@ func TestHttpClient_AttachUserAgentToRequest(t *testing.T) {
 	}
 }
 
-func TestDoWithRetry_Succesful_POST(t *testing.T) {
+func TestDoJSONWithRetry_Succesful_POST(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		io.Copy(w, r.Body)
@@ -121,27 +121,27 @@ func TestDoWithRetry_Succesful_POST(t *testing.T) {
 
 	var got map[string]string
 
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodPost,
 		URL:    svr.URL,
 		Body:   map[string]string{"message": "hello"},
 	}, &got)
 
 	if err != nil {
-		t.Errorf("DoWithRetry() error = %v", err)
+		t.Errorf("doJSONWithRetry() error = %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusOK)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusOK)
 	}
 
 	want := map[string]string{"message": "hello"}
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("DoWithRetry() diff (-got +want):\n%s", diff)
+		t.Errorf("doJSONWithRetry() diff (-got +want):\n%s", diff)
 	}
 }
 
-func TestDoWithRetry_Succesful_GET(t *testing.T) {
+func TestDoJSONWithRetry_Succesful_GET(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
@@ -164,21 +164,21 @@ func TestDoWithRetry_Succesful_GET(t *testing.T) {
 
 	var got map[string]string
 
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, &got)
 
 	if err != nil {
-		t.Errorf("DoWithRetry() error = %v", err)
+		t.Errorf("doJSONWithRetry() error = %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusOK)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusOK)
 	}
 }
 
-func TestDoWithRetry_RequestError(t *testing.T) {
+func TestDoJSONWithRetry_RequestError(t *testing.T) {
 	originalTimeout := retryTimeout
 	retryTimeout = 300 * time.Millisecond
 	t.Cleanup(func() {
@@ -191,7 +191,7 @@ func TestDoWithRetry_RequestError(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    "http://build.kite",
 	}, nil)
@@ -200,15 +200,15 @@ func TestDoWithRetry_RequestError(t *testing.T) {
 
 	// it retries the request and returns ErrRetryTimeout with nil response.
 	if !errors.Is(err, ErrRetryTimeout) {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, ErrRetryTimeout)
 	}
 
 	if resp != nil {
-		t.Errorf("DoWithRetry() = %v, want nil", resp)
+		t.Errorf("doJSONWithRetry() = %v, want nil", resp)
 	}
 }
 
-func TestDoWithRetry_429(t *testing.T) {
+func TestDoJSONWithRetry_429(t *testing.T) {
 	originalTimeout := retryTimeout
 	retryTimeout = 1500 * time.Millisecond
 	t.Cleanup(func() {
@@ -231,7 +231,7 @@ func TestDoWithRetry_429(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -242,15 +242,15 @@ func TestDoWithRetry_429(t *testing.T) {
 	}
 
 	if !errors.Is(err, ErrRetryTimeout) {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, ErrRetryTimeout)
 	}
 
 	if resp.StatusCode != http.StatusTooManyRequests {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusTooManyRequests)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusTooManyRequests)
 	}
 }
 
-func TestDoWithRetry_409(t *testing.T) {
+func TestDoJSONWithRetry_409(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
 
@@ -278,7 +278,7 @@ func TestDoWithRetry_409(t *testing.T) {
 
 	c := NewClient(cfg)
 
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -289,15 +289,15 @@ func TestDoWithRetry_409(t *testing.T) {
 	}
 
 	if !errors.Is(err, ErrRetryTimeout) {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, ErrRetryTimeout)
 	}
 
 	if resp.StatusCode != http.StatusConflict {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusConflict)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusConflict)
 	}
 }
 
-func TestDoWithRetry_500(t *testing.T) {
+func TestDoJSONWithRetry_500(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
 
@@ -325,7 +325,7 @@ func TestDoWithRetry_500(t *testing.T) {
 
 	c := NewClient(cfg)
 
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -336,15 +336,15 @@ func TestDoWithRetry_500(t *testing.T) {
 	}
 
 	if !errors.Is(err, ErrRetryTimeout) {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, ErrRetryTimeout)
 	}
 
 	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusInternalServerError)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusInternalServerError)
 	}
 }
 
-func TestDoWithRetry_403(t *testing.T) {
+func TestDoJSONWithRetry_403(t *testing.T) {
 	requestCount := 0
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +360,7 @@ func TestDoWithRetry_403(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -371,19 +371,19 @@ func TestDoWithRetry_403(t *testing.T) {
 	}
 
 	if forbiddenError := new(ForbiddenError); !errors.As(err, &forbiddenError) {
-		t.Errorf("DoWithRetry() error type = %T, want %T", err, ForbiddenError{})
+		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, ForbiddenError{})
 	}
 
 	if err.Error() != "forbidden" {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, "forbidden")
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, "forbidden")
 	}
 
 	if resp.StatusCode != http.StatusForbidden {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
 	}
 }
 
-func TestDoWithRetry_401(t *testing.T) {
+func TestDoJSONWithRetry_401(t *testing.T) {
 	requestCount := 0
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -399,7 +399,7 @@ func TestDoWithRetry_401(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -409,19 +409,19 @@ func TestDoWithRetry_401(t *testing.T) {
 	}
 
 	if authError := new(AuthError); !errors.As(err, &authError) {
-		t.Errorf("DoWithRetry() error type = %T, want %T", err, AuthError{})
+		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, AuthError{})
 	}
 
 	if err.Error() != "Unauthorized" {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, "Unauthorized")
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, "Unauthorized")
 	}
 
 	if resp.StatusCode != http.StatusUnauthorized {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusUnauthorized)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusUnauthorized)
 	}
 }
 
-func TestDoWithRetry_404(t *testing.T) {
+func TestDoJSONWithRetry_404(t *testing.T) {
 	requestCount := 0
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -437,7 +437,7 @@ func TestDoWithRetry_404(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -447,19 +447,19 @@ func TestDoWithRetry_404(t *testing.T) {
 	}
 
 	if notFoundError := new(NotFoundError); !errors.As(err, &notFoundError) {
-		t.Errorf("DoWithRetry() error type = %T, want %T", err, NotFoundError{})
+		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, NotFoundError{})
 	}
 
 	if err.Error() != "Not Found" {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, "Not Found")
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, "Not Found")
 	}
 
 	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusNotFound)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusNotFound)
 	}
 }
 
-func TestDoWithRetry_400(t *testing.T) {
+func TestDoJSONWithRetry_400(t *testing.T) {
 	requestCount := 0
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -475,7 +475,7 @@ func TestDoWithRetry_400(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -485,19 +485,19 @@ func TestDoWithRetry_400(t *testing.T) {
 	}
 
 	if badRequestError := new(BadRequestError); !errors.As(err, &badRequestError) {
-		t.Errorf("DoWithRetry() error type = %T, want %T", err, BadRequestError{})
+		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, BadRequestError{})
 	}
 
 	if err.Error() != "Bad Request" {
-		t.Errorf("DoWithRetry() error = %v, want %v", err, "Bad Request")
+		t.Errorf("doJSONWithRetry() error = %v, want %v", err, "Bad Request")
 	}
 
 	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusBadRequest)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 
-func TestDoWithRetry_BillingError(t *testing.T) {
+func TestDoJSONWithRetry_BillingError(t *testing.T) {
 	requestCount := 0
 	message := "Billing Error: Test Splitting is not enabled in your plan"
 
@@ -514,7 +514,7 @@ func TestDoWithRetry_BillingError(t *testing.T) {
 	}
 
 	c := NewClient(cfg)
-	resp, err := c.DoWithRetry(context.Background(), httpRequest{
+	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
@@ -525,10 +525,10 @@ func TestDoWithRetry_BillingError(t *testing.T) {
 	}
 
 	if resp.StatusCode != http.StatusForbidden {
-		t.Errorf("DoWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
+		t.Errorf("doJSONWithRetry() status code = %v, want %v", resp.StatusCode, http.StatusForbidden)
 	}
 
 	if billingError := new(BillingError); !errors.As(err, &billingError) {
-		t.Errorf("DoWithRetry() error type = %T, want %T", err, BillingError{})
+		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, BillingError{})
 	}
 }

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -37,7 +37,7 @@ func (c Client) CreateTestPlan(ctx context.Context, suiteSlug string, params Tes
 	postURL := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var testPlan plan.TestPlan
-	_, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,
 		URL:    postURL,
 		Body:   params,

--- a/internal/api/fetch_commit_list.go
+++ b/internal/api/fetch_commit_list.go
@@ -18,11 +18,11 @@ import (
 // Endpoint: GET /v2/analytics/organizations/:org/suites/:suite/commits?days=N
 // Uses Accept: text/plain to receive newline-delimited SHAs for simpler parsing.
 //
-// This method does not use DoWithRetry because DoWithRetry assumes JSON
-// responses and sets Content-Type: application/json. This endpoint requires a
-// custom Accept: text/plain header and returns a plain-text body. Adding retry
-// support would require refactoring DoWithRetry to support custom headers and
-// non-JSON response parsing, which isn't warranted for this single call site.
+// This method does not use doJSONWithRetry because that assumes JSON responses
+// and sets Content-Type: application/json, while this endpoint needs a custom
+// Accept: text/plain header and returns a plain-text body. It could be wired
+// through the generic doWithRetry engine with its own request/response handlers,
+// but that isn't warranted for this single, non-retried call site.
 // The authTransport middleware (Bearer token + User-Agent) is still applied
 // via the client's httpClient.
 func (c Client) FetchCommitList(ctx context.Context, suiteSlug string, days int) ([]string, error) {

--- a/internal/api/fetch_files_timing.go
+++ b/internal/api/fetch_files_timing.go
@@ -18,7 +18,7 @@ func (c Client) FetchFilesTiming(ctx context.Context, suiteSlug string, files []
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_files", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var filesTiming map[string]int
-	_, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,
 		URL:    url,
 		Body: fetchFilesTimingParams{

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -16,7 +16,7 @@ func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier 
 
 	var testPlan plan.TestPlan
 
-	_, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodGet,
 		URL:    url,
 	}, &testPlan)

--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -35,7 +35,7 @@ func (c Client) FilterTests(ctx context.Context, suiteSlug string, params Filter
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan/filter_tests", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
 	var response FilteredTestResponse
-	_, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,
 		URL:    url,
 		Body:   params,

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -24,7 +24,7 @@ type TestPlanMetadataParams struct {
 func (c Client) PostTestPlanMetadata(ctx context.Context, suiteSlug string, identifier string, params TestPlanMetadataParams) error {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
 
-	_, err := c.DoWithRetry(ctx, httpRequest{
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodPost,
 		URL:    url,
 		Body:   params,

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -99,7 +99,7 @@ func TestPostTestPlanMetadata(t *testing.T) {
 		ServerBaseURL:    svr.URL,
 	})
 
-	_, err := c.DoWithRetry(context.Background(), httpRequest{
+	_, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodPost,
 		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, "rspec"),
 		Body:   params,
@@ -139,7 +139,7 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 		ServerBaseURL:    svr.URL,
 	})
 
-	_, err := c.DoWithRetry(context.Background(), httpRequest{
+	_, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodPost,
 		URL:    fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan_metadata", c.ServerBaseURL, c.OrganizationSlug, "rspec"),
 		Body:   params,

--- a/internal/api/presign_upload.go
+++ b/internal/api/presign_upload.go
@@ -24,7 +24,7 @@ func (c Client) PresignUpload(ctx context.Context, suiteSlug string) (PresignedU
 		c.ServerBaseURL, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug))
 
 	var resp PresignedUploadResponse
-	_, err := c.DoWithRetry(ctx, httpRequest{Method: http.MethodPost, URL: reqURL}, &resp)
+	_, err := c.doJSONWithRetry(ctx, httpRequest{Method: http.MethodPost, URL: reqURL}, &resp)
 	if err != nil {
 		return PresignedUploadResponse{}, fmt.Errorf("presigning upload: %w", err)
 	}

--- a/internal/api/upload_test_results.go
+++ b/internal/api/upload_test_results.go
@@ -19,26 +19,34 @@ import (
 // (e.g. "rspec-json", "jest-json").
 // Errors are returned to the caller to be logged and suppressed — this upload
 // is best-effort and must not fail the build.
+//
+// Transient failures (network errors, 429, 5xx) are retried via doWithRetry
+// before giving up. The multipart body is built once and re-sent on each attempt.
 func (c *Client) UploadTestResults(ctx context.Context, token string, filePath string, format string, locationPrefix string, tags map[string]string) error {
 	body, contentType, err := buildTestResultsMultipartBody(filePath, format, locationPrefix, tags)
 	if err != nil {
 		return err
 	}
+	// Keep the body content so newRequest can wrap it in a fresh bytes.Reader
+	// for each attempt. We can't reuse one reader across retries because a reader
+	// is drained once it's read, leaving nothing to re-send.
+	bodyBytes := body.Bytes()
 
 	uploadURL := strings.TrimRight(c.UploadBaseURL, "/") + "/v1/uploads"
-	uploadCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
-	req, err := http.NewRequestWithContext(uploadCtx, http.MethodPost, uploadURL, body)
-	if err != nil {
-		return fmt.Errorf("creating upload request: %w", err)
+	newRequest := func(reqCtx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, uploadURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("creating upload request: %w", err)
+		}
+		req.Header.Set("Authorization", fmt.Sprintf("Token token=%s", token))
+		req.Header.Set("Content-Type", contentType)
+		return req, nil
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Token token=%s", token))
-	req.Header.Set("Content-Type", contentType)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doWithRetry(ctx, 30*time.Second, newRequest)
 	if err != nil {
-		return fmt.Errorf("uploading test results: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/internal/api/upload_test_results.go
+++ b/internal/api/upload_test_results.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+var (
+	uploadRetryTimeout = 30 * time.Second
+)
+
 // UploadTestResults POSTs the raw result file from the runner to the
 // Test Engine analytics API at <c.UploadBaseURL>/v1/uploads.
 // The format parameter tells the ingestion gear how to parse the file
@@ -44,7 +48,11 @@ func (c *Client) UploadTestResults(ctx context.Context, token string, filePath s
 		return req, nil
 	}
 
-	resp, err := c.doWithRetry(ctx, 30*time.Second, newRequest)
+	// Upload requests are usually faster than Test Plan requests, so each attempt
+	// uses a shorter timeout (5s instead of 15s).
+	// This is a best-effort call, so retries also use a smaller total budget
+	// (30s instead of 130s) to avoid delaying the build.
+	resp, err := c.doWithRetry(ctx, 5*time.Second, uploadRetryTimeout, newRequest)
 	if err != nil {
 		return err
 	}

--- a/internal/api/upload_test_results_test.go
+++ b/internal/api/upload_test_results_test.go
@@ -21,11 +21,11 @@ import (
 // via t.Cleanup.
 func shortenUploadRetries(t *testing.T) {
 	t.Helper()
-	origTimeout, origDelay := retryTimeout, initialDelay
-	retryTimeout = 1 * time.Second
+	origTimeout, origDelay := uploadRetryTimeout, initialDelay
+	uploadRetryTimeout = 1 * time.Second
 	initialDelay = 1 * time.Millisecond
 	t.Cleanup(func() {
-		retryTimeout = origTimeout
+		uploadRetryTimeout = origTimeout
 		initialDelay = origDelay
 	})
 }

--- a/internal/api/upload_test_results_test.go
+++ b/internal/api/upload_test_results_test.go
@@ -8,11 +8,27 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// shortenUploadRetries overrides the package-level retry timing so retry-driven
+// tests don't block for the full retry window. The original values are restored
+// via t.Cleanup.
+func shortenUploadRetries(t *testing.T) {
+	t.Helper()
+	origTimeout, origDelay := retryTimeout, initialDelay
+	retryTimeout = 1 * time.Second
+	initialDelay = 1 * time.Millisecond
+	t.Cleanup(func() {
+		retryTimeout = origTimeout
+		initialDelay = origDelay
+	})
+}
 
 func TestUploadTestResults(t *testing.T) {
 	resultFile, err := os.CreateTemp("", "results-*.json")
@@ -61,6 +77,8 @@ func TestUploadTestResults(t *testing.T) {
 }
 
 func TestUploadTestResults_ServerError(t *testing.T) {
+	shortenUploadRetries(t)
+
 	resultFile, err := os.CreateTemp("", "results-*.json")
 	require.NoError(t, err)
 	defer os.Remove(resultFile.Name())
@@ -74,7 +92,62 @@ func TestUploadTestResults_ServerError(t *testing.T) {
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
 	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
-	assert.ErrorContains(t, err, "upload failed with status 500")
+	// 5xx is retried until the retry timeout, after which doWithRetry returns
+	// ErrRetryTimeout.
+	assert.ErrorIs(t, err, ErrRetryTimeout)
+}
+
+func TestUploadTestResults_RetriesThenSucceeds(t *testing.T) {
+	shortenUploadRetries(t)
+
+	resultFile, err := os.CreateTemp("", "results-*.json")
+	require.NoError(t, err)
+	defer os.Remove(resultFile.Name())
+	_, err = resultFile.WriteString(`{"examples":[]}`)
+	require.NoError(t, err)
+	resultFile.Close()
+
+	var attempts atomic.Int32
+	var lastBodyLen atomic.Int64
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		lastBodyLen.Store(int64(len(body)))
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer svr.Close()
+
+	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), attempts.Load())
+	// The multipart body is re-sent in full on the retry.
+	assert.Greater(t, lastBodyLen.Load(), int64(0))
+}
+
+func TestUploadTestResults_NoRetryOn4xx(t *testing.T) {
+	shortenUploadRetries(t)
+
+	resultFile, err := os.CreateTemp("", "results-*.json")
+	require.NoError(t, err)
+	defer os.Remove(resultFile.Name())
+	resultFile.Close()
+
+	var attempts atomic.Int32
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request"))
+	}))
+	defer svr.Close()
+
+	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
+	assert.ErrorContains(t, err, "upload failed with status 400")
+	assert.Equal(t, int32(1), attempts.Load())
 }
 
 func TestUploadTestResults_MissingFile(t *testing.T) {


### PR DESCRIPTION
### Description

Right now `UploadTestResults` makes a single attempt and just logs the error if it
fails. A transient network blip or a temporary 5xx from the server means the upload
is lost with no recovery.

This adds retry logic so transient failures (network errors, 429, 5xx) are retried
before giving up, the same way our other API calls already retry.

Rather than copy the retry loop into `UploadTestResults`, I pulled the reusable part
out of the existing `DoWithRetry` into a shared helper so both paths share the same
retry mechanics. The catch is that `DoWithRetry` was hardwired for JSON (it marshals
the body and decodes the response), while uploads send a multipart body and don't
need JSON handling. So the JSON-specific bits stay in the JSON wrapper and the
generic retry engine sits underneath.

### Context

- [TE-5983](https://linear.app/buildkite/issue/TE-5983)
- Came out of this PR discussion: https://github.com/buildkite/test-engine-client/pull/519#discussion_r3300327782

### Changes

- Pulled the retry logic out of `DoWithRetry` into a shared `doWithRetry` helper so
  uploads can reuse it instead of duplicating it. The JSON encode/decode bits stay in
  a thin wrapper (`doJSONWithRetry`) on top.
- `UploadTestResults` now retries transient failures, re-sending the multipart body
  each attempt.

### Testing

- `go test ./internal/api/...` passes.
- Added tests for retry-then-succeed (500 then 202) and no-retry-on-4xx, plus updated
  the existing server-error test to expect `ErrRetryTimeout` after the retry window.