### PR TITLE
Treat go test build failures as terminal; don't retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+- Treat Go test build failures (`FAIL <pkg> [build failed]`) as terminal: bktec no longer retries when a package fails to compile, and exits non-zero with the failing package named in the report. Previously the build failure was recorded as a retryable "TestMain" failure that was silently dropped from the retry command, so a flaky test passing on retry could make the job pass despite the compile error.
+- Stop retrying when a run reports an error outside of the tests (e.g. RSpec errors outside of examples, Jest runtime errors, Playwright report errors) even when retryable failed tests are also present. Retrying cannot fix such errors, and the passing retry could previously mask them.
+
 ## 2.8.0 - 2026-06-05
 - Add `--tag` flag and `BUILDKITE_TEST_ENGINE_TAGS` env var to `bktec run` to tag the run when uploading to Test Engine. Tags are `key=value` pairs and can be repeated.
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -281,6 +281,13 @@ func runTestsWithRetry(ctx context.Context, apiClient *api.Client, cfg *config.C
 			})
 		}
 
+		// An error outside of the tests (such as a Go compilation failure, or a
+		// runner crashing before running any tests) cannot be fixed by
+		// retrying the failed tests, so the run is terminal.
+		if runResult.Status() == runner.RunStatusError {
+			return *runResult, err
+		}
+
 		// Don't retry if we've reached max retries.
 		if attemptCount == maxRetries {
 			return *runResult, err

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -370,6 +371,37 @@ func TestRunTestsWithRetry_RunResultError(t *testing.T) {
 	}
 
 	// If RunResult.Status() is RunStatusError, and there are no failed tests, it shouldn't do retry.
+	if len(timeline) != 2 {
+		t.Errorf("timeline length = %v, want %d", len(timeline), 2)
+	}
+}
+
+func TestRunTestsWithRetry_GoTestBuildFailed(t *testing.T) {
+	t.Chdir("../runner/testdata/go")
+
+	testRunner := runner.NewGoTest(runner.RunnerConfig{
+		ResultPath: filepath.Join(t.TempDir(), "gotest.xml"),
+	})
+	maxRetries := 2
+	testCases := []plan.TestCase{
+		// A package with a real failing test, which on its own would be retried...
+		{Path: "example.com/hello/bad"},
+		// ...and a package that fails to build, which must make the run
+		// terminal: retrying cannot fix a build failure.
+		{Path: "example.com/hello/broken"},
+	}
+	timeline := []api.Timeline{}
+	testResult, err := runTestsWithRetry(context.Background(), nil, &config.Config{}, testRunner, &testCases, maxRetries, []plan.TestCase{}, &timeline, false, false)
+
+	exitErr := new(exec.ExitError)
+	assert.ErrorAs(t, err, &exitErr)
+
+	if testResult.Status() != runner.RunStatusError {
+		t.Errorf("runTestsWithRetry(...) testResult.Status = %v, want %v", testResult.Status(), runner.RunStatusError)
+	}
+
+	// A build failure is terminal: no retry should happen, so the timeline
+	// should only contain test_start and test_end.
 	if len(timeline) != 2 {
 		t.Errorf("timeline length = %v, want %d", len(timeline), 2)
 	}

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -81,6 +81,19 @@ func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	}
 
 	for _, test := range testResults {
+		// A package that fails to build is reported by gotestsum as a synthetic
+		// testcase named "TestMain" with an empty classname, whose failure
+		// message contains "[build failed]" (printed by the go tool itself).
+		// A build failure cannot be fixed by retrying, so treat it as an error
+		// outside of the tests instead of recording it as a test result.
+		// Recording it would select it for retry, where its empty package path
+		// would silently drop it from the retry command, allowing the build
+		// failure to go unnoticed.
+		if isBuildFailure(test) {
+			result.error = fmt.Errorf("go test failed to build %s", test.SuiteName)
+			continue
+		}
+
 		result.RecordTestResult(plan.TestCase{
 			Format: plan.TestCaseFormatExample,
 			Scope:  test.Classname,
@@ -92,6 +105,18 @@ func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 
 	// Return any command error after processing the report
 	return cmdErr
+}
+
+// isBuildFailure reports whether a JUnit testcase is gotestsum's synthetic
+// representation of a Go package that failed to build. The "TestMain" name and
+// empty classname signature is also produced by package-level failures such as
+// a crashing TestMain or a test timeout, so the failure content is checked for
+// the "[build failed]" marker to identify build failures specifically.
+func isBuildFailure(test JUnitXMLTestCase) bool {
+	return test.Name == "TestMain" &&
+		test.Classname == "" &&
+		test.Failure != nil &&
+		strings.Contains(test.Failure.Content, "[build failed]")
 }
 
 // GetFiles discovers Go packages using `go list ./...`.

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -57,6 +57,35 @@ func TestGotestRun_TestFailed(t *testing.T) {
 	}
 }
 
+func TestGotestRun_BuildFailed(t *testing.T) {
+	changeCwd(t, "./testdata/go")
+
+	gotest := NewGoTest(RunnerConfig{
+		ResultPath: getRandomXMLTempFilename(),
+	})
+	testCases := []plan.TestCase{
+		{Path: "example.com/hello/broken"},
+	}
+	result := NewRunResult([]plan.TestCase{})
+	err := gotest.Run(result, testCases, false)
+
+	exitError := new(exec.ExitError)
+	assert.ErrorAs(t, err, &exitError)
+
+	// A build failure is an error outside of the tests, not a test failure.
+	if result.Status() != RunStatusError {
+		t.Errorf("Gotest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
+	}
+
+	// The synthetic "TestMain" testcase that gotestsum emits for a build
+	// failure must not be recorded as a failed test, otherwise it would be
+	// selected for retry but silently dropped from the retry command
+	// (its package path is empty).
+	if failed := result.FailedTests(); len(failed) != 0 {
+		t.Errorf("Gotest.Run(%q) RunResult.FailedTests() = %v, want none", testCases, failed)
+	}
+}
+
 func TestGotestRun_CommandFailed(t *testing.T) {
 	changeCwd(t, "./testdata/go")
 
@@ -91,6 +120,7 @@ func TestGotestGetFiles(t *testing.T) {
 	want := []string{
 		"example.com/hello",
 		"example.com/hello/bad",
+		"example.com/hello/broken",
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/internal/runner/junit_xml.go
+++ b/internal/runner/junit_xml.go
@@ -15,6 +15,8 @@ type JUnitXMLTestCase struct {
 	Failure   *JUnitXMLFailure `xml:"failure"`
 	Error     *JUnitXMLError   `xml:"error"`
 	Skipped   *JUnitXMLSkipped `xml:"skipped"`
+	// SuiteName is the name attribute of the enclosing <testsuite> element.
+	SuiteName string `xml:"-"`
 }
 
 // JUnitXMLFailure represents the <failure> element in JUnit XML
@@ -69,6 +71,7 @@ func loadAndParseJUnitXML(path string) ([]JUnitXMLTestCase, error) {
 	for _, suite := range testSuites.TestSuites {
 		for _, tc := range suite.TestCases {
 			testCase := tc
+			testCase.SuiteName = suite.Name
 			if testCase.Failure != nil || testCase.Error != nil {
 				testCase.Result = TestStatusFailed
 			} else if testCase.Skipped != nil {

--- a/internal/runner/testdata/go/broken/broken_test.go
+++ b/internal/runner/testdata/go/broken/broken_test.go
@@ -1,0 +1,13 @@
+// Package broken deliberately fails to compile. It regression-tests bktec's
+// handling of `go test` build failures, which gotestsum reports in JUnit XML
+// as a synthetic testcase named "TestMain" with an empty classname and a
+// failure message containing "[build failed]".
+package broken
+
+import (
+	"testing"
+)
+
+func TestBroken(t *testing.T) {
+	_ = undefinedSymbol
+}


### PR DESCRIPTION
### Description

When a Go package fails to compile, gotestsum reports it in JUnit XML as a synthetic testcase named `TestMain` with an empty classname. bktec recorded that as a retryable test failure, but the empty classname means an empty package path, so it was silently dropped from the retry command. If the remaining failures were flaky and passed on retry, the final attempt exited 0 and the job passed despite the compile error — even though bktec's own report said tests had failed.

Two changes:

- The gotest runner detects the build-failure signature (`TestMain` + empty classname + `[build failed]` in the failure text) and records it as an error outside of the tests, using the same `RunResult.error` mechanism rspec, jest, and playwright already use for things like syntax errors.
- The retry loop treats an error outside of the tests as terminal and returns the current attempt's command error instead of retrying. Retrying can't fix such errors, and a passing retry could previously mask them — this also closes the same latent hole for the rspec/jest/playwright error conditions when they coexist with retryable failures.

The `[build failed]` content check distinguishes build failures from other package-level failures that share the same testcase shape (a crashed `TestMain`, test timeouts); those keep their existing behaviour, as does `[setup failed]`. The string is stable: it's been a literal in cmd/go since at least Go 1.5 and is asserted byte-for-byte by Go's own script tests, and gotestsum's synthesis is unchanged since before v1.8.0.

Out of scope for now: the broader question of deriving bktec's final exit status from the run result, so that *any* failed test that never makes it into the final attempt fails the step. This closes the build-failure instance of that class.

### Testing

Added `testdata/go/broken/`, a deliberately uncompilable package, so the regression tests exercise the real go toolchain and gotestsum rather than canned XML — if a future Go or gotestsum version changes the build-failure output, these tests fail at version-bump time rather than in a user's pipeline.

Tests were written first and confirmed to fail. The loop-level test reproduces the original incident shape (a broken package alongside a genuinely failing test): before the fix, the retry visibly drops the broken package and re-runs only the other package.