### PR TITLE
Build `bktec` from source to split its own tests on feature branches

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,12 +1,17 @@
 FROM ruby:4.0.4-slim-bookworm AS ruby
 FROM cypress/included:14.5.3 AS cypress
 FROM python:3.15.0b1-bookworm AS python
+# Latest released bktec image. This is used to split tests on `main`. On other
+# branches the test step builds bktec from source instead (see
+# .buildkite/steps/tests.sh). The `latest` tag only points at stable releases.
+FROM public.ecr.aws/buildkite/test-engine-client:latest AS bktec
 
 FROM golang:1.26.3-bookworm AS golang
 
 COPY --from=ruby / /
 COPY --from=cypress / /
 COPY --from=python / /
+COPY --from=bktec /usr/local/bin/bktec /usr/local/bin/bktec
 
 RUN gem install rspec cucumber base64
 RUN gem install bigdecimal -v 3.2.0
@@ -15,12 +20,4 @@ RUN pip install pytest
 RUN pip install buildkite-test-collector>=1.3.0
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -s -- --bin-dir /usr/local/bin
 
-# Install curl, download bktec binary, make it executable, place it, and cleanup
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends curl && \
-  echo "Downloading bktec..." && \
-  curl -L -o /usr/local/bin/bktec "https://github.com/buildkite/test-engine-client/releases/download/v1.5.0-rc.1/bktec_1.5.0-rc.1_linux_amd64" && \
-  echo "Setting execute permissions..." && \
-  chmod +x /usr/local/bin/bktec && \
-  echo "bktec installed successfully:" && \
-  bktec --version
+RUN echo "bktec installed successfully:" && bktec --version

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,30 +17,12 @@ steps:
     artifact_paths:
       - cover.{html,out}
     plugins:
-      - aws-assume-role-with-web-identity#v1.4.0:
-          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-test-engine-client
-          session-tags:
-            - organization_slug
-            - organization_id
-            - pipeline_slug
-      - aws-ssm#v1.0.0:
-          parameters:
-            BUILDKITE_TEST_ENGINE_SUITE_TOKEN: /pipelines/buildkite/test-engine-client/SUITE_TOKEN
-            BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN: /pipelines/buildkite/test-engine-client/API_ACCESS_TOKEN
       - docker-compose#v4.14.0:
           config: .buildkite/docker-compose.yml
           cli-version: 2
           run: ci
           propagate-environment: true
-          environment:
-            - BUILDKITE_TEST_ENGINE_SUITE_TOKEN
-            - BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN
-      - test-collector#v1.11.0:
-          files: "junit-*.xml"
-          format: "junit"
-          # This is to prevent the test runner as part of our test fixture trigger test collection
-          # such as pytest + python test collector
-          api-token-env-name: "BUILDKITE_TEST_ENGINE_SUITE_TOKEN"
+          mount-buildkite-agent: true
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     artifact_paths:
       - cover.{html,out}
     plugins:
-      - docker-compose#v4.14.0:
+      - docker-compose#v5.12.1:
           config: .buildkite/docker-compose.yml
           cli-version: 2
           run: ci

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-env:
-  AWS_DEFAULT_REGION: us-east-1
-
 steps:
   - name: ":golangci-lint: Lint"
     plugins:

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -33,6 +33,7 @@ export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
 export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
+export BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS=true
 
 "${bktec_bin}" run
 

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -13,6 +13,19 @@ cd playwright
 yarn playwright install
 cd ../../../..
 
+# On feature branches, build bktec from the current source so the pipeline
+# splits its own tests using the code under test. This way a change that breaks
+# bktec's test splitting fails the pipeline before it can be merged to main.
+# On main we use the released binary installed in the image (see Dockerfile).
+bktec_bin="bktec"
+if [[ "${BUILDKITE_BRANCH:-}" != "main" ]]; then
+  echo '+++ Building bktec from source'
+  go build \
+    -ldflags "-X 'github.com/buildkite/test-engine-client/v2/internal/version.Version=${BUILDKITE_COMMIT:-dev}'" \
+    -o /tmp/bktec .
+  bktec_bin="/tmp/bktec"
+fi
+
 echo '+++ Running tests'
 
 export BUILDKITE_TEST_ENGINE_SUITE_SLUG=bktec
@@ -21,7 +34,7 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 
-bktec
+"${bktec_bin}"
 
 echo 'Producing coverage report'
 go tool cover -html cover.out -o cover.html

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -34,7 +34,7 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 
-"${bktec_bin}"
+"${bktec_bin}" run
 
 echo 'Producing coverage report'
 go tool cover -html cover.out -o cover.html


### PR DESCRIPTION
### Description

The bktec pipeline uses `bktec` to split its own tests, but it ran a fixed released binary baked into the CI image, so the source under test was never exercised by the split. That's how #538 (reverted by #541) broke `main` without CI catching it.

Now feature branches build `bktec` from source (versioned with the commit SHA) and use that binary to split the tests, so a change that breaks bktec's splitting fails the pipeline before merge. `main` keeps using the released binary, pulled as the `latest` published image so we still find out if something broke on `main`.

I also moved the pipeline to OIDC. bktec 2.x runs under `bktec run` and mints its own token via `buildkite-agent` when none is set, so I dropped the static SSM tokens and related plugins. That needs the agent Job API socket inside docker-compose, which the plugin mounts automatically from v5.3.0 (buildkite-plugins/docker-compose-buildkite-plugin#444), so I bumped it to v5.12.1.

### Context

- Linear: [TE-6085](https://linear.app/buildkite/issue/TE-6085/use-bktec-to-split-its-own-tests-in-the-bktec-pipeline)
- Slack thread where `main` broke: https://buildkite-corp.slack.com/archives/C05MSVDKQRG/p1781127812458559
- Breaking PR #538, revert #541

### Changes

- Build `bktec` from source on feature branches to split the tests; `main` uses the `latest` released image.
- Call `bktec run` and upload test results from bktec.
- Drop the static SSM tokens and `aws-assume-role` / `aws-ssm` / `test-collector` plugins in favour of OIDC tokens minted by bktec.
- Bump the docker-compose plugin v4.14.0 -> v5.12.1 to mount the agent Job API socket.

### Testing

Verified the source build and version injection locally. The real test is the pipeline run on this branch.