### PR TITLE
docs: fix Test Engine OIDC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bktec uses the following Buildkite Pipeline provided environment variables.
 
 ### Authentication
 
-From bktec 2.6.0, bktec automatically requests a [Buildkite Agent OIDC token](https://buildkite.com/docs/agent/cli/reference/oidc) for authentication. You don't need to create or configure an API access token. You will need to [configure an OIDC policy for your Test Engine suite](https://buildkite.com/docs/test-engine/test-collection/oidc) to allow this.
+From bktec 2.6.0, bktec automatically requests a [Buildkite Agent OIDC token](https://buildkite.com/docs/agent/cli/reference/oidc) for authentication. You don't need to create or configure an API access token. You will need to [configure an OIDC policy for your Test Engine suite](https://buildkite.com/docs/pipelines/configure/tests/test-collection/oidc) to allow this.
 
 If you're running bktec older than 2.6.0, or if you want to use an API access token instead, you can create a Buildkite API access token with `read_suites`, `read_test_plan`, and `write_test_plan` scopes from your [Personal Settings](https://buildkite.com/user/api-access-tokens) in Buildkite, then set:
 


### PR DESCRIPTION
## Summary

- Fixes the broken Test Engine OIDC policy link in the README.
- Points readers to the current Buildkite documentation path after the docs information architecture changed.
- Changes only the affected README URL.

## Validation

- `curl.exe --http1.1 -L https://buildkite.com/docs/test-engine/test-collection/oidc` - old URL returns HTTP 404.
- `curl.exe --http1.1 -L https://buildkite.com/docs/pipelines/configure/tests/test-collection/oidc` - replacement URL returns HTTP 200 and the OIDC authentication page.
- `go test . ./internal/api` - passed.
- `git diff --check` - passed.
- `go test ./...` - not fully passing on Windows because the suite expects Unix path separators and commands, plus external runner binaries such as `rspec`, `cucumber`, `yarn`, and `gotestsum`.

## Notes

- Fixes #544.
- No compatibility impact; this is a documentation-only URL correction.
- No follow-up work is required.
