### PR TITLE
Release hotfix v2.8.1

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,12 @@ release:
   prerelease: auto
   make_latest: "{{not .Prerelease}}"
   mode: replace
+  # The release pipeline tags the commit locally but never pushes the tag. When
+  # GoReleaser publishes the release, GitHub creates the missing tag at
+  # target_commitish, which defaults to the repo's default branch (main). That
+  # puts the tag on the wrong commit when releasing from a vX.Y.x branch, so pin
+  # it to the checked-out commit where the release was actually built.
+  target_commitish: '{{ .Commit }}'
 
 changelog:
   use: github-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 2.8.1 - 2026-06-16
 - Treat Go test build failures (`FAIL <pkg> [build failed]`) as terminal: bktec no longer retries when a package fails to compile, and exits non-zero with the failing package named in the report. Previously the build failure was recorded as a retryable "TestMain" failure that was silently dropped from the retry command, so a flaky test passing on retry could make the job pass despite the compile error.
 - Stop retrying when a run reports an error outside of the tests (e.g. RSpec errors outside of examples, Jest runtime errors, Playwright report errors) even when retryable failed tests are also present. Retrying cannot fix such errors, and the passing retry could previously mask them.
 


### PR DESCRIPTION
Release what's in 2ff2b094bb1cf3067f17c27511ee772b500bb924 as Hotfix v2.8.1.
We don't want to release what's in `main` yet, as it contains https://github.com/buildkite/test-engine-client/pull/539 that will be included in the next minor release (v2.9.0) instead.


### PRs
- https://github.com/buildkite/test-engine-client/pull/518
- https://github.com/buildkite/test-engine-client/pull/536
- https://github.com/buildkite/test-engine-client/pull/540

This PR https://github.com/buildkite/test-engine-client/pull/538 is reverted in https://github.com/buildkite/test-engine-client/pull/541 and won't be included in the release.

### Full changes
https://github.com/buildkite/test-engine-client/compare/v2.8.0...v2.8.x