### PR TITLE
Merge `v2.8.x` to `main`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,12 @@ release:
   prerelease: auto
   make_latest: "{{not .Prerelease}}"
   mode: replace
+  # The release pipeline tags the commit locally but never pushes the tag. When
+  # GoReleaser publishes the release, GitHub creates the missing tag at
+  # target_commitish, which defaults to the repo's default branch (main). That
+  # puts the tag on the wrong commit when releasing from a vX.Y.x branch, so pin
+  # it to the checked-out commit where the release was actually built.
+  target_commitish: '{{ .Commit }}'
 
 changelog:
   use: github-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## 2.8.1 - 2026-06-16
 - Treat Go test build failures (`FAIL <pkg> [build failed]`) as terminal: bktec no longer retries when a package fails to compile, and exits non-zero with the failing package named in the report. Previously the build failure was recorded as a retryable "TestMain" failure that was silently dropped from the retry command, so a flaky test passing on retry could make the job pass despite the compile error.
 - Stop retrying when a run reports an error outside of the tests (e.g. RSpec errors outside of examples, Jest runtime errors, Playwright report errors) even when retryable failed tests are also present. Retrying cannot fix such errors, and the passing retry could previously mask them.
 


### PR DESCRIPTION
We've released a hotfix [v2.8.1](https://github.com/buildkite/test-engine-client/releases/tag/v2.8.1) from `v2.8.x` branch. This PR merge the branch back to `main`. It's just CHANGELOG changes and goreleaser config since everything included in `v2.8.1` is already on `main`.