### PR TITLE
Decouple CLI config from the API env payload

### DIFF
--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -10,8 +10,8 @@ import (
 )
 
 type FilterTestsParams struct {
-	Files []plan.TestCase `json:"files"`
-	Env   *config.Config  `json:"env"`
+	Files []plan.TestCase   `json:"files"`
+	Env   config.EnvPayload `json:"env"`
 }
 
 type FilteredTest struct {

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -25,7 +25,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 			{Path: "./dog_spec.rb"},
 			{Path: "./turtle_spec.rb"},
 		},
-		Env: &cfg,
+		Env: cfg.EnvPayload(),
 	}
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/post_test_plan_metadata.go
+++ b/internal/api/post_test_plan_metadata.go
@@ -16,7 +16,7 @@ type Timeline struct {
 
 type TestPlanMetadataParams struct {
 	Version    string               `json:"version"`
-	Env        *config.Config       `json:"env"`
+	Env        config.EnvPayload    `json:"env"`
 	Timeline   []Timeline           `json:"timeline"`
 	Statistics runner.RunStatistics `json:"statistics"`
 }

--- a/internal/api/post_test_plan_metadata_test.go
+++ b/internal/api/post_test_plan_metadata_test.go
@@ -21,7 +21,7 @@ func TestPostTestPlanMetadata(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		Env:     &cfg,
+		Env:     cfg.EnvPayload(),
 		Timeline: []Timeline{
 			{Event: "test_start", Timestamp: "2024-06-20T04:46:13.60977Z"},
 			{Event: "test_end", Timestamp: "2024-06-20T04:49:09.609793Z"},
@@ -120,7 +120,7 @@ func TestPostTestPlanMetadata_NotFound(t *testing.T) {
 
 	params := TestPlanMetadataParams{
 		Version: "0.7.0",
-		Env:     &cfg,
+		Env:     cfg.EnvPayload(),
 		Timeline: []Timeline{
 			{Event: "test_start", Timestamp: "2024-06-20T04:46:13.60977Z"},
 			{Event: "test_end", Timestamp: "2024-06-20T04:49:09.609793Z"},

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -180,7 +180,7 @@ func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Cli
 	debug.Printf("Filtering %d files", len(allTestFiles))
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
 		Files: allTestFiles,
-		Env:   cfg,
+		Env:   cfg.EnvPayload(),
 	})
 	if err != nil {
 		return api.TestPlanParamsTest{}, fmt.Errorf("filter tests: %w", err)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -252,7 +252,7 @@ func uploadResults(ctx context.Context, apiClient *api.Client, cfg *config.Confi
 func sendMetadata(ctx context.Context, apiClient *api.Client, cfg *config.Config, timeline []api.Timeline, statistics runner.RunStatistics) {
 	err := apiClient.PostTestPlanMetadata(ctx, cfg.SuiteSlug, cfg.Identifier, api.TestPlanMetadataParams{
 		Timeline:   timeline,
-		Env:        cfg,
+		Env:        cfg.EnvPayload(),
 		Version:    version.Version,
 		Statistics: statistics,
 	})

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/runner"
 	"github.com/buildkite/test-engine-client/v2/internal/version"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -823,13 +822,13 @@ func TestSendMetadata(t *testing.T) {
 		want := api.TestPlanMetadataParams{
 			Version:  "0.1.0",
 			Timeline: timeline,
-			Env:      &cfg,
+			Env:      cfg.EnvPayload(),
 			Statistics: runner.RunStatistics{
 				Total: 3,
 			},
 		}
 
-		if diff := cmp.Diff(got, want, cmpopts.IgnoreUnexported(config.Config{})); diff != "" {
+		if diff := cmp.Diff(got, want); diff != "" {
 			t.Errorf("sendMetadata() request params diff (-got +want):\n%s", diff)
 			w.WriteHeader(http.StatusBadRequest)
 		} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,12 @@ package config
 import "time"
 
 // Config is the internal representation of the complete test engine client configuration.
+//
+// Config is never serialized to the wire: every field is tagged json:"-". The
+// data sent to the API in the "env" request field is represented by the
+// separate EnvPayload type and built via Config.EnvPayload. This keeps internal
+// configuration decoupled from the API contract, so adding a field here does not
+// cause it to be sent to the API unless it is also added to EnvPayload.
 type Config struct {
 	// AccessToken is the access token for the API.
 	AccessToken string `json:"-"`
@@ -11,15 +17,15 @@ type Config struct {
 	AgentAccessToken string `json:"-"`
 	// AgentEndpoint is the base URL of the Buildkite Agent API (e.g. https://agent.buildkite.com/v3).
 	// Injected into the job env as BUILDKITE_AGENT_ENDPOINT.
-	AgentEndpoint string `json:"BUILDKITE_AGENT_ENDPOINT"`
+	AgentEndpoint string `json:"-"`
 	// PromiseFailure, when true, makes bktec declare an early failure to the
 	// Buildkite Agent API once retries are exhausted and hard failures remain.
-	PromiseFailure bool `json:"BUILDKITE_TEST_ENGINE_PROMISE_FAILURE"`
+	PromiseFailure bool `json:"-"`
 	// UploadBaseURL is the base URL for the Test Engine analytics API.
 	UploadBaseURL string `json:"-"`
 	// Branch is the string value of the git branch name, used by Buildkite only.
-	Branch                string `json:"BUILDKITE_BRANCH"`
-	BuildID               string `json:"BUILDKITE_BUILD_ID"`
+	Branch                string `json:"-"`
+	BuildID               string `json:"-"`
 	BuildkiteAgentCommand string `json:"-"`
 	// CollectGitMetadata enables git metadata auto-collection on plan without requiring --selection-strategy to be set.
 	CollectGitMetadata bool `json:"-"`
@@ -28,49 +34,49 @@ type Config struct {
 	// Days is the lookback window in days for the commit list API (1-90, default 90).
 	Days int `json:"-"`
 	// Enable debug output
-	DebugEnabled bool `json:"BUILDKITE_TEST_ENGINE_DEBUG_ENABLED"`
+	DebugEnabled bool `json:"-"`
 	// FailOnNoTests causes the client to exit with an error if no tests are assigned to the node
-	FailOnNoTests bool `json:"BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS"`
+	FailOnNoTests bool `json:"-"`
 	// Identifier is the identifier of the build.
-	Identifier string `json:"BUILDKITE_TEST_ENGINE_IDENTIFIER"`
-	JobID      string `json:"BUILDKITE_JOB_ID"`
+	Identifier string `json:"-"`
+	JobID      string `json:"-"`
 	// JobRetryCount is the count of the number of times the job has been retried.
-	JobRetryCount int `json:"BUILDKITE_RETRY_COUNT"`
+	JobRetryCount int `json:"-"`
 	// LocationPrefix is prepended to test file paths when requesting a test plan.
 	// Use this when the test collector is configured to report files with a path prefix,
 	// so the test plan API can correctly match and bin-pack them across nodes.
-	LocationPrefix string `json:"BUILDKITE_TEST_ENGINE_LOCATION_PREFIX"`
+	LocationPrefix string `json:"-"`
 	// MaxParallelism is the maximum parallelism when calculating parallelism dynamically.
-	MaxParallelism int `json:"BUILDKITE_TEST_ENGINE_MAX_PARALLELISM"`
+	MaxParallelism int `json:"-"`
 	// MaxRetries is the maximum number of retries for a failed test.
-	MaxRetries int `json:"BUILDKITE_TEST_ENGINE_RETRY_COUNT"`
+	MaxRetries int `json:"-"`
 	// Metadata is additional key/value data sent to the test plan API.
 	Metadata map[string]string `json:"-"`
 	// Node index is index of the current node.
-	NodeIndex int `json:"BUILDKITE_PARALLEL_JOB"`
+	NodeIndex int `json:"-"`
 	// Enable OIDC token generation
-	OIDC bool `json:"BUILDKITE_TEST_ENGINE_OIDC"`
+	OIDC bool `json:"-"`
 	// Lifetime of OIDC tokens
-	OIDCLifetime time.Duration `json:"BUILDKITE_TEST_ENGINE_OIDC_LIFETIME"`
+	OIDCLifetime time.Duration `json:"-"`
 	// OrganizationSlug is the slug of the organization.
-	OrganizationSlug string `json:"BUILDKITE_ORGANIZATION_SLUG"`
+	OrganizationSlug string `json:"-"`
 	// Output is the local file path for the export tarball. If set, skip S3 upload.
 	Output string `json:"-"`
 	// Parallelism is the number of parallel tasks to run.
-	Parallelism int `json:"BUILDKITE_PARALLEL_JOB_COUNT"`
+	Parallelism int `json:"-"`
 	// Remote is the git remote name for fetching missing commits and detecting default branch (default "origin").
 	Remote string `json:"-"`
 	// ResultPath is the path to the result file.
 	ResultPath string `json:"-"`
 	// RetryCommand is the command to run the retry tests.
-	RetryCommand string `json:"BUILDKITE_TEST_ENGINE_RETRY_CMD"`
+	RetryCommand string `json:"-"`
 	// RetryForMutedTest indicates whether a failed muted test should be retried.
 	// This is default to true because we want more signal for our flaky detection system.
 	RetryForMutedTest bool `json:"-"`
 	// SelectionParams are additional key/value parameters for the strategy.
 	SelectionParams map[string]string `json:"-"`
 	// SelectionStrategy is the selection strategy sent to the test plan API.
-	SelectionStrategy string `json:"BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY"`
+	SelectionStrategy string `json:"-"`
 	// ServerBaseURL is the base URL of the test plan server.
 	ServerBaseURL string `json:"-"`
 	// SkipDiffs omits git_diff and git_diff_raw from the export to reduce upload size.
@@ -84,22 +90,22 @@ type Config struct {
 	// UploadToken is the token used by test collectors. From `BUILDKITE_ANALYTICS_TOKEN` if present, otherwise generated by `buildkite-agent oidc request-token`.
 	UploadToken string `json:"-"`
 	// SplitByExample is the flag to enable split the test by example.
-	SplitByExample bool   `json:"BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE"`
-	StepID         string `json:"BUILDKITE_STEP_ID"`
+	SplitByExample bool   `json:"-"`
+	StepID         string `json:"-"`
 	// SuiteSlug is the slug of the suite.
-	SuiteSlug string `json:"BUILDKITE_TEST_ENGINE_SUITE_SLUG"`
+	SuiteSlug string `json:"-"`
 	// TagFilters filters test examples by execution tags.
-	TagFilters string `json:"BUILDKITE_TEST_ENGINE_TAG_FILTERS"`
+	TagFilters string `json:"-"`
 	// TargetTime is the target time in seconds for the test plan.
-	TargetTime time.Duration `json:"BUILDKITE_TEST_ENGINE_TARGET_TIME"`
+	TargetTime time.Duration `json:"-"`
 	// TestCommand is the command to run the tests.
-	TestCommand string `json:"BUILDKITE_TEST_ENGINE_TEST_CMD"`
+	TestCommand string `json:"-"`
 	// TestFileExcludePattern is the pattern to exclude the test files.
-	TestFileExcludePattern string `json:"BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN"`
+	TestFileExcludePattern string `json:"-"`
 	// TestFilePattern is the pattern to match the test files.
-	TestFilePattern string `json:"BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN"`
+	TestFilePattern string `json:"-"`
 	// TestRunner is the name of the runner.
-	TestRunner string `json:"BUILDKITE_TEST_ENGINE_TEST_RUNNER"`
+	TestRunner string `json:"-"`
 
 	// Set to true if AccessToken was unset and an OIDC token was generated instead
 	accessTokenIsOIDC bool

--- a/internal/config/env_payload.go
+++ b/internal/config/env_payload.go
@@ -1,0 +1,83 @@
+package config
+
+import "time"
+
+// EnvPayload is the data the client sends to the Test Engine API in the "env"
+// field of requests (currently the filter_tests and test_plan_metadata
+// endpoints).
+//
+// It is deliberately a separate type from Config so that the API contract is
+// explicit and opt-in: Config is the client's internal configuration and is
+// never serialized to the wire, whereas every field here is intentionally part
+// of the request payload. Adding a new field to Config does NOT cause it to be
+// sent to the API; it must be added here and mapped in Config.EnvPayload.
+//
+// The JSON keys below preserve the exact wire format that was previously
+// produced by serializing Config directly, so existing API calls are
+// unaffected.
+type EnvPayload struct {
+	AgentEndpoint          string        `json:"BUILDKITE_AGENT_ENDPOINT"`
+	PromiseFailure         bool          `json:"BUILDKITE_TEST_ENGINE_PROMISE_FAILURE"`
+	Branch                 string        `json:"BUILDKITE_BRANCH"`
+	BuildID                string        `json:"BUILDKITE_BUILD_ID"`
+	DebugEnabled           bool          `json:"BUILDKITE_TEST_ENGINE_DEBUG_ENABLED"`
+	FailOnNoTests          bool          `json:"BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS"`
+	Identifier             string        `json:"BUILDKITE_TEST_ENGINE_IDENTIFIER"`
+	JobID                  string        `json:"BUILDKITE_JOB_ID"`
+	JobRetryCount          int           `json:"BUILDKITE_RETRY_COUNT"`
+	LocationPrefix         string        `json:"BUILDKITE_TEST_ENGINE_LOCATION_PREFIX"`
+	MaxParallelism         int           `json:"BUILDKITE_TEST_ENGINE_MAX_PARALLELISM"`
+	MaxRetries             int           `json:"BUILDKITE_TEST_ENGINE_RETRY_COUNT"`
+	NodeIndex              int           `json:"BUILDKITE_PARALLEL_JOB"`
+	OIDC                   bool          `json:"BUILDKITE_TEST_ENGINE_OIDC"`
+	OIDCLifetime           time.Duration `json:"BUILDKITE_TEST_ENGINE_OIDC_LIFETIME"`
+	OrganizationSlug       string        `json:"BUILDKITE_ORGANIZATION_SLUG"`
+	Parallelism            int           `json:"BUILDKITE_PARALLEL_JOB_COUNT"`
+	RetryCommand           string        `json:"BUILDKITE_TEST_ENGINE_RETRY_CMD"`
+	SelectionStrategy      string        `json:"BUILDKITE_TEST_ENGINE_SELECTION_STRATEGY"`
+	SplitByExample         bool          `json:"BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE"`
+	StepID                 string        `json:"BUILDKITE_STEP_ID"`
+	SuiteSlug              string        `json:"BUILDKITE_TEST_ENGINE_SUITE_SLUG"`
+	TagFilters             string        `json:"BUILDKITE_TEST_ENGINE_TAG_FILTERS"`
+	TargetTime             time.Duration `json:"BUILDKITE_TEST_ENGINE_TARGET_TIME"`
+	TestCommand            string        `json:"BUILDKITE_TEST_ENGINE_TEST_CMD"`
+	TestFileExcludePattern string        `json:"BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN"`
+	TestFilePattern        string        `json:"BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN"`
+	TestRunner             string        `json:"BUILDKITE_TEST_ENGINE_TEST_RUNNER"`
+}
+
+// EnvPayload builds the API "env" payload from the client configuration. This
+// is the single, deliberate boundary where internal configuration crosses into
+// an API request body.
+func (c *Config) EnvPayload() EnvPayload {
+	return EnvPayload{
+		AgentEndpoint:          c.AgentEndpoint,
+		PromiseFailure:         c.PromiseFailure,
+		Branch:                 c.Branch,
+		BuildID:                c.BuildID,
+		DebugEnabled:           c.DebugEnabled,
+		FailOnNoTests:          c.FailOnNoTests,
+		Identifier:             c.Identifier,
+		JobID:                  c.JobID,
+		JobRetryCount:          c.JobRetryCount,
+		LocationPrefix:         c.LocationPrefix,
+		MaxParallelism:         c.MaxParallelism,
+		MaxRetries:             c.MaxRetries,
+		NodeIndex:              c.NodeIndex,
+		OIDC:                   c.OIDC,
+		OIDCLifetime:           c.OIDCLifetime,
+		OrganizationSlug:       c.OrganizationSlug,
+		Parallelism:            c.Parallelism,
+		RetryCommand:           c.RetryCommand,
+		SelectionStrategy:      c.SelectionStrategy,
+		SplitByExample:         c.SplitByExample,
+		StepID:                 c.StepID,
+		SuiteSlug:              c.SuiteSlug,
+		TagFilters:             c.TagFilters,
+		TargetTime:             c.TargetTime,
+		TestCommand:            c.TestCommand,
+		TestFileExcludePattern: c.TestFileExcludePattern,
+		TestFilePattern:        c.TestFilePattern,
+		TestRunner:             c.TestRunner,
+	}
+}


### PR DESCRIPTION
### Description

`config.Config` was doing two unrelated jobs: the client's internal CLI/env configuration *and* the `env` payload serialized into API requests. The same struct was passed as the `Env` field of the `filter_tests` and `test_plan_metadata` requests, and which fields were sent was decided implicitly by JSON struct tags.

Because Go serializes exported fields by default, the safe default was backwards — a new config field would be sent to the API unless someone remembered to tag it `json:"-"`.

This introduces a dedicated `config.EnvPayload` type holding exactly the fields we send today, plus a `Config.EnvPayload()` mapper that is the single deliberate boundary between internal config and the request body. `Config` is now fully severed from JSON serialization, so future config fields are private by default — sending one requires an explicit addition to `EnvPayload`.

Alternatives considered: a custom `MarshalJSON` on `Config` (keeps one struct doing two jobs) and an allowlist map (loses type safety and a clear contract).

### Changes

- Add `config.EnvPayload` type and `Config.EnvPayload()` mapper.
- Switch `FilterTestsParams.Env` and `TestPlanMetadataParams.Env` to `config.EnvPayload`; update the two call sites.
- Tag every `Config` field `json:"-"` so `Config` is never serialized.

Before:

```mermaid
flowchart LR
    C1["config.Config<br/>(all CLI/env config)"]
    E1["&quot;env&quot;: { ... }<br/>API request body"]
    C1 -- "serialized directly<br/>(json tags)" --> E1
```

After:

```mermaid
flowchart LR
    C2["config.Config<br/>(all CLI/env config)<br/>json:&quot;-&quot; — never serialized"]
    P2["config.EnvPayload<br/>(explicit wire type)"]
    E2["&quot;env&quot;: { ... }<br/>API request body"]
    C2 -- "EnvPayload()<br/>explicit mapper" --> P2 --> E2
```

### Testing

- `go build ./...` and `go vet` clean.
- The existing golden-body tests for `filter_tests` and `test_plan_metadata` pass unchanged, confirming the wire format is identical byte for byte. No behavior change.

### Note

A possible follow-up is to prune `EnvPayload` down to the subset the server actually consumes; that's out of scope here. This change just draws the line so the two concepts can evolve independently.
