### PR TITLE
Treat pytest collection errors as terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.8.2 - 2026-06-19
+- Treat pytest collection errors reported by `buildkite-test-collector` as terminal, and preserve their file-only node IDs when recording JSON results. Previously bktec could construct invalid retry selectors like `::tests/test_broken.py` for collection failures with empty scopes, then waste a retry on a failure that cannot be fixed by rerunning individual tests.
+
 ## 2.8.1 - 2026-06-16
 - Treat Go test build failures (`FAIL <pkg> [build failed]`) as terminal: bktec no longer retries when a package fails to compile, and exits non-zero with the failing package named in the report. Previously the build failure was recorded as a retryable "TestMain" failure that was silently dropped from the retry command, so a flaky test passing on retry could make the job pass despite the compile error.
 - Stop retrying when a run reports an error outside of the tests (e.g. RSpec errors outside of examples, Jest runtime errors, Playwright report errors) even when retryable failed tests are also present. Retrying cannot fix such errors, and the passing retry could previously mask them.

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -143,18 +143,39 @@ func (p Pytest) runParseJSON(result *RunResult) error {
 	}
 
 	for _, test := range tests {
-		result.RecordTestResult(plan.TestCase{
-			Identifier: test.ID,
-			Format:     plan.TestCaseFormatExample,
-			Scope:      test.Scope,
-			Name:       test.Name,
-			// pytest can execute individual test using node id, which is a filename, classname (if any), and function, separated by `::`.
-			// Ref: https://docs.pytest.org/en/6.2.x/usage.html#nodeids
-			Path: fmt.Sprintf("%s::%s", test.Scope, test.Name),
-		}, test.Result)
+		recordPytestJSONTestResult(result, test)
 	}
 
 	return nil
+}
+
+const pytestCollectionErrorTag = "test.pytest_collection_error"
+
+func recordPytestJSONTestResult(result *RunResult, test TestEngineTest) {
+	path := pytestPathFromTestEngineResult(test.Scope, test.Name)
+
+	result.RecordTestResult(plan.TestCase{
+		Identifier: test.ID,
+		Format:     plan.TestCaseFormatExample,
+		Scope:      test.Scope,
+		Name:       test.Name,
+		// pytest can execute individual tests using node IDs, which are filenames,
+		// class names (if any), and functions separated by `::`.
+		// Ref: https://docs.pytest.org/en/6.2.x/usage.html#nodeids
+		Path: path,
+	}, test.Result)
+
+	if test.Tags[pytestCollectionErrorTag] == "true" {
+		result.error = fmt.Errorf("pytest collection failed: %s", path)
+	}
+}
+
+func pytestPathFromTestEngineResult(scope, name string) string {
+	if scope == "" {
+		return name
+	}
+
+	return fmt.Sprintf("%s::%s", scope, name)
 }
 
 func (p Pytest) runParseJUnit(result *RunResult) error {

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -120,7 +120,11 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	// Only rescue exit code 1 because it indicates a test failures.
 	// Ref: https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
 	if exitError := new(exec.ExitError); errors.As(cmdErr, &exitError) && exitError.ExitCode() != 1 {
-		return cmdErr
+		// pytest exits 2 for collection errors, and buildkite-test-collector can
+		// still write tagged JSON results for those errors.
+		if p.useJUnit || exitError.ExitCode() != 2 {
+			return cmdErr
+		}
 	}
 
 	var parseErr error

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -116,6 +116,7 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	}
 
 	cmdErr := runAndForwardSignal(cmd)
+	parseExit2JSON := false
 
 	// Only rescue exit code 1 because it indicates a test failures.
 	// Ref: https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
@@ -125,6 +126,7 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 		if p.useJUnit || exitError.ExitCode() != 2 {
 			return cmdErr
 		}
+		parseExit2JSON = true
 	}
 
 	var parseErr error
@@ -135,6 +137,9 @@ func (p Pytest) Run(result *RunResult, testCases []plan.TestCase, retry bool) er
 	}
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read test output, failed tests will not be retried: %v\n", parseErr)
+	}
+	if parseExit2JSON && result.Status() != RunStatusError {
+		result.error = cmdErr
 	}
 
 	return cmdErr

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -86,15 +86,7 @@ func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry boo
 	}
 
 	for _, test := range tests {
-		result.RecordTestResult(plan.TestCase{
-			Identifier: test.ID,
-			Format:     plan.TestCaseFormatExample,
-			Scope:      test.Scope,
-			Name:       test.Name,
-			// pytest can execute individual test using node id, which is a filename, classname (if any), and function, separated by `::`.
-			// Ref: https://docs.pytest.org/en/6.2.x/usage.html#nodeids
-			Path: fmt.Sprintf("%s::%s", test.Scope, test.Name),
-		}, test.Result)
+		recordPytestJSONTestResult(result, test)
 	}
 
 	// Return any command error after processing the report

--- a/internal/runner/pytest_pants.go
+++ b/internal/runner/pytest_pants.go
@@ -69,17 +69,26 @@ func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry boo
 	}
 
 	cmdErr := runAndForwardSignal(cmd)
+	parseExit2JSON := false
 
 	// Only rescue exit code 1 because it indicates a test failures.
 	// Ref: https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
 	if exitError := new(exec.ExitError); errors.As(cmdErr, &exitError) && exitError.ExitCode() != 1 {
-		return cmdErr
+		// pytest exits 2 for collection errors, and buildkite-test-collector can
+		// still write tagged JSON results for those errors.
+		if exitError.ExitCode() != 2 {
+			return cmdErr
+		}
+		parseExit2JSON = true
 	}
 
 	tests, parseErr := parseTestEngineTestResult(p.ResultPath)
 
 	if parseErr != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to read json output, failed tests will not be retried: %v\n", parseErr)
+		if parseExit2JSON {
+			result.error = cmdErr
+		}
 		// We don't want to fail the build if we fail to parse the report,
 		// therefore we return the command error (which can be nil), instead of the parse error.
 		return cmdErr
@@ -87,6 +96,9 @@ func (p PytestPants) Run(result *RunResult, testCases []plan.TestCase, retry boo
 
 	for _, test := range tests {
 		recordPytestJSONTestResult(result, test)
+	}
+	if parseExit2JSON && result.Status() != RunStatusError {
+		result.error = cmdErr
 	}
 
 	// Return any command error after processing the report

--- a/internal/runner/pytest_pants_test.go
+++ b/internal/runner/pytest_pants_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
@@ -96,6 +97,80 @@ func TestPytestPantsRun_TestFailed(t *testing.T) {
 
 	if diff := cmp.Diff(failedTest, wantFailedTests); diff != "" {
 		t.Errorf("PytestPants.Run(%q) RunResult.FailedTests() diff (-got +want):\n%s", testCases, diff)
+	}
+}
+
+func TestPytestPantsRun_JSONExit2ParsesCollectionError(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "collection-error-id",
+			"scope": "",
+			"name": "tests/test_broken.py",
+			"result": "failed",
+			"tags": {"test.pytest_collection_error": "true"}
+		}
+	]`
+	pytest := NewPytestPants(RunnerConfig{
+		TestCommand: "sh -c 'printf %s \"$1\" > \"$2\"; exit 2' sh " + shellquote.Join(json) + " {{resultPath}} -- --json={{resultPath}} --merge-json",
+		ResultPath:  resultPath,
+	})
+	result := NewRunResult([]plan.TestCase{})
+
+	err := pytest.Run(result, nil, false)
+
+	exitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, err, &exitError) {
+		return
+	}
+	if exitError.ExitCode() != 2 {
+		t.Errorf("PytestPants.Run() exit code = %d, want 2", exitError.ExitCode())
+	}
+	if result.Status() != RunStatusError {
+		t.Errorf("PytestPants.Run() RunResult.Status = %v, want %v", result.Status(), RunStatusError)
+	}
+	if result.Error() == nil {
+		t.Fatal("PytestPants.Run() RunResult.Error = nil, want error")
+	}
+	if got, want := result.Error().Error(), "pytest collection failed: tests/test_broken.py"; got != want {
+		t.Errorf("PytestPants.Run() RunResult.Error = %q, want %q", got, want)
+	}
+}
+
+func TestPytestPantsRun_JSONExit2WithoutCollectionErrorIsTerminal(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "failed-test-id",
+			"scope": "tests/test_sample.py",
+			"name": "test_failed",
+			"result": "failed"
+		}
+	]`
+	pytest := NewPytestPants(RunnerConfig{
+		TestCommand: "sh -c 'printf %s \"$1\" > \"$2\"; exit 2' sh " + shellquote.Join(json) + " {{resultPath}} -- --json={{resultPath}} --merge-json",
+		ResultPath:  resultPath,
+	})
+	result := NewRunResult([]plan.TestCase{})
+
+	err := pytest.Run(result, nil, false)
+
+	exitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, err, &exitError) {
+		return
+	}
+	if exitError.ExitCode() != 2 {
+		t.Errorf("PytestPants.Run() exit code = %d, want 2", exitError.ExitCode())
+	}
+	if result.Status() != RunStatusError {
+		t.Errorf("PytestPants.Run() RunResult.Status = %v, want %v", result.Status(), RunStatusError)
+	}
+	resultExitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, result.Error(), &resultExitError) {
+		return
+	}
+	if resultExitError.ExitCode() != 2 {
+		t.Errorf("PytestPants.Run() RunResult.Error exit code = %d, want 2", resultExitError.ExitCode())
 	}
 }
 

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -192,6 +192,45 @@ func TestPytestRun_JSONExit2ParsesCollectionError(t *testing.T) {
 	}
 }
 
+func TestPytestRun_JSONExit2WithoutCollectionErrorIsTerminal(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "failed-test-id",
+			"scope": "tests/test_sample.py",
+			"name": "test_failed",
+			"result": "failed"
+		}
+	]`
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "sh -c 'printf %s \"$1\" > \"$2\"; exit 2' sh " + shellquote.Join(json) + " {{resultPath}}",
+			ResultPath:  resultPath,
+		},
+	}
+	result := NewRunResult([]plan.TestCase{})
+
+	err := pytest.Run(result, nil, false)
+
+	exitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, err, &exitError) {
+		return
+	}
+	if exitError.ExitCode() != 2 {
+		t.Errorf("Pytest.Run() exit code = %d, want 2", exitError.ExitCode())
+	}
+	if result.Status() != RunStatusError {
+		t.Errorf("Pytest.Run() RunResult.Status = %v, want %v", result.Status(), RunStatusError)
+	}
+	resultExitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, result.Error(), &resultExitError) {
+		return
+	}
+	if resultExitError.ExitCode() != 2 {
+		t.Errorf("Pytest.Run() RunResult.Error exit code = %d, want 2", resultExitError.ExitCode())
+	}
+}
+
 func TestPytestRunParseJSON_CollectionError(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	json := `[

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
@@ -92,6 +94,186 @@ func TestPytestRun_TestFailed(t *testing.T) {
 
 	if diff := cmp.Diff(failedTest, wantFailedTests); diff != "" {
 		t.Errorf("Pytest.Run(%q) RunResult.FailedTests() diff (-got +want):\n%s", testCases, diff)
+	}
+}
+
+func TestPytestRun_CollectionError(t *testing.T) {
+	if !checkPythonPackageInstalled("pytest") {
+		t.Skip("pytest Python package is not installed")
+	}
+	if !checkPythonPackageInstalled("buildkite_test_collector") {
+		t.Skip("buildkite-test-collector Python package is not installed")
+	}
+
+	changeCwd(t, "./testdata/pytest_collection_error")
+
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			// Plain pytest exits 2 for collection errors, while pytest-xdist reports
+			// them as exit 1. Force the command error to exit 1 so this test exercises
+			// bktec's retryable-exit-code path while still using real pytest and
+			// buildkite-test-collector output.
+			TestCommand: "sh -c 'python -m pytest {{testExamples}} --json={{resultPath}} || exit 1'",
+			ResultPath:  resultPath,
+		},
+	}
+	testCases := []plan.TestCase{{Path: "test_broken_import.py"}}
+	result := NewRunResult([]plan.TestCase{})
+
+	err := pytest.Run(result, testCases, false)
+
+	exitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, err, &exitError) {
+		return
+	}
+	if exitError.ExitCode() != 1 {
+		t.Errorf("Pytest.Run(%q) exit code = %d, want 1", testCases, exitError.ExitCode())
+	}
+
+	if result.Status() != RunStatusError {
+		t.Errorf("Pytest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusError)
+	}
+	if result.Error() == nil {
+		t.Fatalf("Pytest.Run(%q) RunResult.Error = nil, want error", testCases)
+	}
+	if got, want := result.Error().Error(), "pytest collection failed: test_broken_import.py"; got != want {
+		t.Errorf("Pytest.Run(%q) RunResult.Error = %q, want %q", testCases, got, want)
+	}
+
+	failedTests := result.FailedTests()
+	if len(failedTests) != 1 {
+		t.Fatalf("len(result.FailedTests()) = %d, want 1", len(failedTests))
+	}
+	failedTest := failedTests[0]
+	if failedTest.Scope != "" {
+		t.Errorf("Pytest.Run(%q) failed test scope = %q, want empty", testCases, failedTest.Scope)
+	}
+	if failedTest.Name != "test_broken_import.py" {
+		t.Errorf("Pytest.Run(%q) failed test name = %q, want %q", testCases, failedTest.Name, "test_broken_import.py")
+	}
+	if failedTest.Path != "test_broken_import.py" {
+		t.Errorf("Pytest.Run(%q) failed test path = %q, want %q", testCases, failedTest.Path, "test_broken_import.py")
+	}
+}
+
+func TestPytestRunParseJSON_CollectionError(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "collection-error-id",
+			"scope": "",
+			"name": "tests/test_broken.py",
+			"file_name": "tests/test_broken.py",
+			"location": "tests/test_broken.py",
+			"result": "failed",
+			"tags": {"test.pytest_collection_error": "true"}
+		}
+	]`
+	if err := os.WriteFile(resultPath, []byte(json), 0600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", resultPath, err)
+	}
+
+	pytest := Pytest{RunnerConfig: RunnerConfig{ResultPath: resultPath}}
+	result := NewRunResult([]plan.TestCase{})
+
+	if err := pytest.runParseJSON(result); err != nil {
+		t.Fatalf("Pytest.runParseJSON() error = %v", err)
+	}
+
+	if result.Status() != RunStatusError {
+		t.Errorf("Pytest.runParseJSON() RunResult.Status = %v, want %v", result.Status(), RunStatusError)
+	}
+	if result.Error() == nil {
+		t.Fatal("Pytest.runParseJSON() RunResult.Error = nil, want error")
+	}
+	if got, want := result.Error().Error(), "pytest collection failed: tests/test_broken.py"; got != want {
+		t.Errorf("Pytest.runParseJSON() RunResult.Error = %q, want %q", got, want)
+	}
+
+	wantFailedTests := []plan.TestCase{
+		{
+			Identifier: "collection-error-id",
+			Format:     plan.TestCaseFormatExample,
+			Scope:      "",
+			Name:       "tests/test_broken.py",
+			Path:       "tests/test_broken.py",
+		},
+	}
+
+	if diff := cmp.Diff(result.FailedTests(), wantFailedTests); diff != "" {
+		t.Errorf("Pytest.runParseJSON() RunResult.FailedTests() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestPytestRunParseJSON_EmptyScopeWithoutCollectionErrorTag(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "empty-scope-id",
+			"scope": "",
+			"name": "tests/test_file.py",
+			"result": "failed"
+		}
+	]`
+	if err := os.WriteFile(resultPath, []byte(json), 0600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", resultPath, err)
+	}
+
+	pytest := Pytest{RunnerConfig: RunnerConfig{ResultPath: resultPath}}
+	result := NewRunResult([]plan.TestCase{})
+
+	if err := pytest.runParseJSON(result); err != nil {
+		t.Fatalf("Pytest.runParseJSON() error = %v", err)
+	}
+
+	if result.Status() != RunStatusFailed {
+		t.Errorf("Pytest.runParseJSON() RunResult.Status = %v, want %v", result.Status(), RunStatusFailed)
+	}
+
+	wantFailedTests := []plan.TestCase{
+		{
+			Identifier: "empty-scope-id",
+			Format:     plan.TestCaseFormatExample,
+			Scope:      "",
+			Name:       "tests/test_file.py",
+			Path:       "tests/test_file.py",
+		},
+	}
+
+	if diff := cmp.Diff(result.FailedTests(), wantFailedTests); diff != "" {
+		t.Errorf("Pytest.runParseJSON() RunResult.FailedTests() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestPytestPathFromTestEngineResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		scope    string
+		testName string
+		wantPath string
+	}{
+		{
+			name:     "scoped test",
+			scope:    "tests/test_sample.py",
+			testName: "test_happy",
+			wantPath: "tests/test_sample.py::test_happy",
+		},
+		{
+			name:     "collection error",
+			scope:    "",
+			testName: "tests/test_broken.py",
+			wantPath: "tests/test_broken.py",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pytestPathFromTestEngineResult(tt.scope, tt.testName)
+			if got != tt.wantPath {
+				t.Errorf("pytestPathFromTestEngineResult(%q, %q) = %q, want %q", tt.scope, tt.testName, got, tt.wantPath)
+			}
+		})
 	}
 }
 

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -110,11 +110,7 @@ func TestPytestRun_CollectionError(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	pytest := Pytest{
 		RunnerConfig: RunnerConfig{
-			// Plain pytest exits 2 for collection errors, while pytest-xdist reports
-			// them as exit 1. Force the command error to exit 1 so this test exercises
-			// bktec's retryable-exit-code path while still using real pytest and
-			// buildkite-test-collector output.
-			TestCommand: "sh -c 'python -m pytest {{testExamples}} --json={{resultPath}} || exit 1'",
+			TestCommand: "python -m pytest {{testExamples}} --json={{resultPath}}",
 			ResultPath:  resultPath,
 		},
 	}
@@ -127,8 +123,8 @@ func TestPytestRun_CollectionError(t *testing.T) {
 	if !assert.ErrorAs(t, err, &exitError) {
 		return
 	}
-	if exitError.ExitCode() != 1 {
-		t.Errorf("Pytest.Run(%q) exit code = %d, want 1", testCases, exitError.ExitCode())
+	if exitError.ExitCode() != 2 {
+		t.Errorf("Pytest.Run(%q) exit code = %d, want 2", testCases, exitError.ExitCode())
 	}
 
 	if result.Status() != RunStatusError {
@@ -154,6 +150,45 @@ func TestPytestRun_CollectionError(t *testing.T) {
 	}
 	if failedTest.Path != "test_broken_import.py" {
 		t.Errorf("Pytest.Run(%q) failed test path = %q, want %q", testCases, failedTest.Path, "test_broken_import.py")
+	}
+}
+
+func TestPytestRun_JSONExit2ParsesCollectionError(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	json := `[
+		{
+			"id": "collection-error-id",
+			"scope": "",
+			"name": "tests/test_broken.py",
+			"result": "failed",
+			"tags": {"test.pytest_collection_error": "true"}
+		}
+	]`
+	pytest := Pytest{
+		RunnerConfig: RunnerConfig{
+			TestCommand: "sh -c 'printf %s \"$1\" > \"$2\"; exit 2' sh " + shellquote.Join(json) + " {{resultPath}}",
+			ResultPath:  resultPath,
+		},
+	}
+	result := NewRunResult([]plan.TestCase{})
+
+	err := pytest.Run(result, nil, false)
+
+	exitError := new(exec.ExitError)
+	if !assert.ErrorAs(t, err, &exitError) {
+		return
+	}
+	if exitError.ExitCode() != 2 {
+		t.Errorf("Pytest.Run() exit code = %d, want 2", exitError.ExitCode())
+	}
+	if result.Status() != RunStatusError {
+		t.Errorf("Pytest.Run() RunResult.Status = %v, want %v", result.Status(), RunStatusError)
+	}
+	if result.Error() == nil {
+		t.Fatal("Pytest.Run() RunResult.Error = nil, want error")
+	}
+	if got, want := result.Error().Error(), "pytest collection failed: tests/test_broken.py"; got != want {
+		t.Errorf("Pytest.Run() RunResult.Error = %q, want %q", got, want)
 	}
 }
 

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -243,6 +243,7 @@ type TestEngineTest struct {
 	Location string
 	FileName string `json:"file_name,omitempty"`
 	Result   TestStatus
+	Tags     map[string]string `json:"tags,omitempty"`
 }
 
 func parseTestEngineTestResult(path string) ([]TestEngineTest, error) {

--- a/internal/runner/testdata/pytest_collection_error/test_broken_import.py
+++ b/internal/runner/testdata/pytest_collection_error/test_broken_import.py
@@ -1,0 +1,5 @@
+from missing_bktec_collection_error_dependency import does_not_exist
+
+
+def test_never_collected():
+    assert does_not_exist


### PR DESCRIPTION
### Description

When `buildkite-test-collector` reports a pytest collection error, the JSON result has an empty `scope` and a file-only `name` such as `tests/test_broken.py`. bktec was rebuilding every pytest JSON result path as `scope::name`, producing invalid retry selectors like `::tests/test_broken.py`.

This fixes the selector and treats explicitly tagged pytest collection errors as terminal errors outside of tests. Retrying individual pytest node IDs cannot fix import/syntax/collection failures, so this aligns pytest with the Go build-failure behavior from #540.

### Context

`buildkite/test-collector-python#108` made collection errors visible in the JSON report and tags them with `test.pytest_collection_error=true`. bktec can now use that explicit tag instead of guessing from empty scope alone.

### Changes

- Preserve file-only pytest node IDs when Test Engine JSON results have an empty scope.
- Mark tagged pytest collection errors as `RunStatusError`, which uses the existing terminal retry guard.
- Reuse the same JSON result mapping for `pytest-pants`.
- Add parser regression tests for tagged collection errors, untagged empty-scope results, and normal scoped pytest node IDs.
- Add a real pytest fixture with a collection-time import error so CI exercises actual pytest/collector output.

### Testing

- `go test ./internal/runner -run '^TestPytestRun_CollectionError$' -v` in a temporary `mise`/`uv` virtualenv with `pytest` and `buildkite-test-collector>=1.3.0` installed
- `go test ./internal/runner -run 'TestPytestRunParseJSON|TestPytestPathFromTestEngineResult'`
- `go test ./internal/runner -run '^TestPytestPantsRun_TestFailed$'`
- `go test ./internal/command -run 'TestRunTestsWithRetry_RunResultError|TestRunTestsWithRetry_GoTestBuildFailed'`

I also attempted `go test ./internal/runner ./internal/command`, but this local environment is missing some runner dependencies such as `cypress` and the broader runner integration suite is not green here.

### Related

- Fixes #485
- Related to buildkite/test-collector-python#108
- Aligns with #540
