### PR TITLE
feat: Emit Go selector tags for Test Engine Client validation

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -34,6 +34,9 @@ export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 export BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS=true
+# Temporary dogfood switch for selector-based smart splitting validation in
+# Buildkite's test-engine-client pipeline. Remove once selector tags are core tags.
+export BUILDKITE_TEST_ENGINE_CLIENT_EMIT_SELECTOR_TAGS=true
 
 "${bktec_bin}" run
 

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -282,8 +282,23 @@ func uploadResults(ctx context.Context, apiClient *api.Client, cfg *config.Confi
 	if _, err := os.Stat(testRunner.ResultFilePath()); err != nil {
 		return
 	}
+	uploadResult := runner.UploadResult{Path: testRunner.ResultFilePath(), Format: format}
+	if preparer, ok := testRunner.(runner.UploadResultPreparer); ok {
+		var err error
+		uploadResult, err = preparer.PrepareUploadResult()
+		if err != nil {
+			fmt.Printf("Buildkite Test Engine Client: Failed to prepare test results upload: %v\n", err)
+			return
+		}
+	}
+	if uploadResult.Cleanup != nil {
+		defer uploadResult.Cleanup()
+	}
+	if uploadResult.Format == "" {
+		return
+	}
 	fmt.Println("Buildkite Test Engine Client: Uploading test results to Test Engine")
-	if err := apiClient.UploadTestResults(ctx, cfg.UploadToken, testRunner.ResultFilePath(), format, testRunner.LocationPrefix(), cfg.UploadTags); err != nil {
+	if err := apiClient.UploadTestResults(ctx, cfg.UploadToken, uploadResult.Path, uploadResult.Format, testRunner.LocationPrefix(), cfg.UploadTags); err != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to upload test results to Test Engine: %v\n", err)
 	}
 }

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -968,6 +968,51 @@ func TestRunTestsWithRetry_UploadsResults(t *testing.T) {
 	assert.Equal(t, "./", gotLocationPrefix)
 }
 
+func TestUploadResults_UsesPreparedUploadResult(t *testing.T) {
+	rawResult := filepath.Join(t.TempDir(), "raw.xml")
+	preparedResult := filepath.Join(t.TempDir(), "prepared.json")
+	assert.NoError(t, os.WriteFile(rawResult, []byte("raw"), 0600))
+	assert.NoError(t, os.WriteFile(preparedResult, []byte(`[{"name":"prepared"}]`), 0600))
+
+	var uploadRequests int
+	var gotFormat, gotData string
+	uploadSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploadRequests++
+		assert.NoError(t, r.ParseMultipartForm(1<<20))
+		gotFormat = r.FormValue("format")
+
+		file, _, err := r.FormFile("data")
+		assert.NoError(t, err)
+		defer file.Close()
+
+		data, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		gotData = string(data)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer uploadSvr.Close()
+
+	cleanupCalled := false
+	testRunner := preparedUploadTestRunner{
+		metadataTestRunner: metadataTestRunner{name: "prepared-upload-test"},
+		rawPath:            rawResult,
+		preparedPath:       preparedResult,
+		cleanup:            func() { cleanupCalled = true },
+	}
+	cfg := &config.Config{
+		UploadResults: true,
+		UploadToken:   "test-token",
+	}
+	apiClient := api.NewClient(api.ClientConfig{UploadBaseURL: uploadSvr.URL})
+
+	uploadResults(context.Background(), apiClient, cfg, testRunner)
+
+	assert.Equal(t, 1, uploadRequests)
+	assert.Equal(t, "json", gotFormat)
+	assert.Equal(t, `[{"name":"prepared"}]`, gotData)
+	assert.True(t, cleanupCalled)
+}
+
 func TestRunTestsWithRetry_SkipsUploadWhenNoToken(t *testing.T) {
 	var uploadRequests int
 	uploadSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1051,4 +1096,23 @@ func TestRunTestsWithRetry_UploadErrorDoesNotFailBuild(t *testing.T) {
 	result, err := runTestsWithRetry(context.Background(), apiClient, cfg, testRunner, &testCases, 0, []plan.TestCase{}, &timeline, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, runner.RunStatusPassed, result.Status(), "build should pass even when upload fails")
+}
+
+type preparedUploadTestRunner struct {
+	metadataTestRunner
+	rawPath      string
+	preparedPath string
+	cleanup      func()
+}
+
+func (r preparedUploadTestRunner) ResultFormat() string {
+	return "junit"
+}
+
+func (r preparedUploadTestRunner) ResultFilePath() string {
+	return r.rawPath
+}
+
+func (r preparedUploadTestRunner) PrepareUploadResult() (runner.UploadResult, error) {
+	return runner.UploadResult{Path: r.preparedPath, Format: "json", Cleanup: r.cleanup}, nil
 }

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -2,9 +2,12 @@ package runner
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/buildkite/test-engine-client/v2/internal/config"
 )
+
+const temporaryTestEngineClientSelectorTagsEnv = "BUILDKITE_TEST_ENGINE_CLIENT_EMIT_SELECTOR_TAGS"
 
 func DetectRunner(cfg *config.Config) (TestRunner, error) {
 	runnerConfig := RunnerConfig{
@@ -17,6 +20,7 @@ func DetectRunner(cfg *config.Config) (TestRunner, error) {
 		TestCommand:            cfg.TestCommand,
 		TestFileExcludePattern: cfg.TestFileExcludePattern,
 		TestFilePattern:        cfg.TestFilePattern,
+		EmitSelectorTags:       emitSelectorTagsForTestEngineClient(),
 		uploadToken:            cfg.UploadToken,
 	}
 
@@ -45,4 +49,13 @@ func DetectRunner(cfg *config.Config) (TestRunner, error) {
 		// Update the error message to include the new runner
 		return nil, fmt.Errorf("runner value %q is invalid, possible values are 'rspec', 'jest', 'cypress', 'playwright', 'pytest', 'pytest-pants', 'gotest', 'cucumber', 'nunit', or 'custom'", testRunner)
 	}
+}
+
+func emitSelectorTagsForTestEngineClient() bool {
+	// Temporary dogfood switch for validating selector-based smart splitting with
+	// execution custom tags in Buildkite's own test-engine-client pipeline. This
+	// should be removed when selector tags are promoted to core tags.
+	return os.Getenv(temporaryTestEngineClientSelectorTagsEnv) == "true" &&
+		os.Getenv("BUILDKITE_ORGANIZATION_SLUG") == "buildkite" &&
+		os.Getenv("BUILDKITE_PIPELINE_SLUG") == "test-engine-client"
 }

--- a/internal/runner/detector_test.go
+++ b/internal/runner/detector_test.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmitSelectorTagsForTestEngineClient(t *testing.T) {
+	t.Setenv(temporaryTestEngineClientSelectorTagsEnv, "true")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "buildkite")
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "test-engine-client")
+	assert.True(t, emitSelectorTagsForTestEngineClient())
+
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "other-pipeline")
+	assert.False(t, emitSelectorTagsForTestEngineClient())
+}

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -9,6 +10,11 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/debug"
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/kballard/go-shellquote"
+)
+
+const (
+	goTestSelectorTagKey       = "test.selector.primary"
+	maxTestEngineTagValueBytes = 127
 )
 
 type GoTest struct {
@@ -50,6 +56,80 @@ func (g GoTest) Name() string {
 
 func (g GoTest) ResultFormat() string {
 	return "junit"
+}
+
+func (g GoTest) PrepareUploadResult() (UploadResult, error) {
+	if !g.EmitSelectorTags {
+		return UploadResult{
+			Path:   g.ResultFilePath(),
+			Format: g.ResultFormat(),
+		}, nil
+	}
+
+	tests, err := loadAndParseJUnitXML(g.ResultPath)
+	if err != nil {
+		return UploadResult{}, err
+	}
+
+	uploadTests := make([]TestEngineTest, 0, len(tests))
+	for _, test := range tests {
+		if isBuildFailure(test) {
+			continue
+		}
+
+		uploadTest, err := goTestEngineTest(test)
+		if err != nil {
+			return UploadResult{}, err
+		}
+		uploadTests = append(uploadTests, uploadTest)
+	}
+	if len(uploadTests) == 0 {
+		return UploadResult{
+			Path:   g.ResultFilePath(),
+			Format: g.ResultFormat(),
+		}, nil
+	}
+
+	return writeTestEngineUploadResult(uploadTests, "bktec-gotest-upload-*.json")
+}
+
+func goTestEngineTest(test JUnitXMLTestCase) (TestEngineTest, error) {
+	testID, err := randomUUID()
+	if err != nil {
+		return TestEngineTest{}, err
+	}
+
+	return TestEngineTest{
+		ID:     testID,
+		Scope:  test.Classname,
+		Name:   test.Name,
+		Result: test.Result,
+		History: &TestEngineHistory{
+			StartAt:  0,
+			EndAt:    test.Time,
+			Duration: test.Time,
+		},
+		Tags: goTestSelectorTags(test),
+	}, nil
+}
+
+func goTestSelectorTags(test JUnitXMLTestCase) map[string]string {
+	if test.Classname == "" || len(test.Classname) > maxTestEngineTagValueBytes {
+		return nil
+	}
+	return map[string]string{goTestSelectorTagKey: test.Classname}
+}
+
+func randomUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate upload test ID: %w", err)
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }
 
 func (g GoTest) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -1,10 +1,12 @@
 package runner
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
@@ -105,6 +107,89 @@ func TestGotestRun_CommandFailed(t *testing.T) {
 	if result.Status() != RunStatusFailed {
 		t.Errorf("Gotest.Run(%q) RunResult.Status = %v, want %v", testCases, result.Status(), RunStatusFailed)
 	}
+}
+
+func TestGotestPrepareUploadResult_EmitSelectorTags(t *testing.T) {
+	resultFile := filepath.Join(t.TempDir(), "junit.xml")
+	err := os.WriteFile(resultFile, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" errors="0" time="0.123000">
+	<testsuite tests="1" failures="0" time="0.123000" name="github.com/buildkite/test-engine-client/v2/internal/runner" timestamp="2026-06-24T08:58:51+10:00">
+		<properties>
+			<property name="go.version" value="go1.25.10 darwin/arm64"></property>
+		</properties>
+		<testcase classname="github.com/buildkite/test-engine-client/v2/internal/runner" name="TestGotest" time="0.123000"></testcase>
+	</testsuite>
+</testsuites>`), 0600)
+	assert.NoError(t, err)
+
+	gotest := NewGoTest(RunnerConfig{
+		ResultPath:       resultFile,
+		EmitSelectorTags: true,
+	})
+
+	uploadResult, err := gotest.PrepareUploadResult()
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer uploadResult.Cleanup()
+
+	assert.Equal(t, "json", uploadResult.Format)
+	assert.NotEqual(t, resultFile, uploadResult.Path)
+
+	data, err := os.ReadFile(uploadResult.Path)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"start_at":`)
+
+	var tests []TestEngineTest
+	assert.NoError(t, json.Unmarshal(data, &tests))
+
+	if assert.Len(t, tests, 1) {
+		assert.Equal(t, "github.com/buildkite/test-engine-client/v2/internal/runner", tests[0].Tags["test.selector.primary"])
+		assert.Equal(t, "github.com/buildkite/test-engine-client/v2/internal/runner", tests[0].Scope)
+		assert.Equal(t, "TestGotest", tests[0].Name)
+		assert.Equal(t, TestStatusPassed, tests[0].Result)
+		if assert.NotNil(t, tests[0].History) {
+			assert.Equal(t, 0.0, tests[0].History.StartAt)
+			assert.Equal(t, 0.123, tests[0].History.EndAt)
+			assert.Equal(t, 0.123, tests[0].History.Duration)
+		}
+	}
+}
+
+func TestGotestPrepareUploadResult_OnlyBuildFailures(t *testing.T) {
+	resultFile := filepath.Join(t.TempDir(), "junit.xml")
+	err := os.WriteFile(resultFile, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="1" errors="1" time="0.000000">
+	<testsuite tests="1" failures="1" time="0.000000" name="github.com/buildkite/test-engine-client/v2/internal/runner/testdata/go/broken" timestamp="2026-06-24T08:58:51+10:00">
+		<testcase classname="" name="TestMain" time="0.000000">
+			<failure message="Failed" type="">FAIL	github.com/buildkite/test-engine-client/v2/internal/runner/testdata/go/broken [build failed]</failure>
+		</testcase>
+	</testsuite>
+</testsuites>`), 0600)
+	assert.NoError(t, err)
+
+	gotest := NewGoTest(RunnerConfig{
+		ResultPath:       resultFile,
+		EmitSelectorTags: true,
+	})
+
+	uploadResult, err := gotest.PrepareUploadResult()
+	assert.NoError(t, err)
+	assert.Equal(t, "junit", uploadResult.Format)
+	assert.Equal(t, resultFile, uploadResult.Path)
+	assert.Nil(t, uploadResult.Cleanup)
+}
+
+func TestGoTestSelectorTags(t *testing.T) {
+	test := JUnitXMLTestCase{
+		Classname: "github.com/buildkite/test-engine-client/v2/internal/runner",
+		Name:      "TestGotest",
+	}
+
+	assert.Equal(t, map[string]string{goTestSelectorTagKey: "github.com/buildkite/test-engine-client/v2/internal/runner"}, goTestSelectorTags(test))
+	assert.Equal(t, map[string]string{goTestSelectorTagKey: strings.Repeat("a", 127)}, goTestSelectorTags(JUnitXMLTestCase{Classname: strings.Repeat("a", 127)}))
+	assert.Nil(t, goTestSelectorTags(JUnitXMLTestCase{Name: "TestMain"}))
+	assert.Nil(t, goTestSelectorTags(JUnitXMLTestCase{Classname: strings.Repeat("a", 128)}))
 }
 
 func TestGotestGetFiles(t *testing.T) {

--- a/internal/runner/junit_xml.go
+++ b/internal/runner/junit_xml.go
@@ -11,6 +11,7 @@ import (
 type JUnitXMLTestCase struct {
 	Classname string           `xml:"classname,attr"`
 	Name      string           `xml:"name,attr"`
+	Time      float64          `xml:"time,attr"`
 	Result    TestStatus       // passed | failed | skipped
 	Failure   *JUnitXMLFailure `xml:"failure"`
 	Error     *JUnitXMLError   `xml:"error"`

--- a/internal/runner/run_result.go
+++ b/internal/runner/run_result.go
@@ -232,18 +232,23 @@ func (r *RunResult) Statistics() RunStatistics {
 }
 
 // TestEngineTest represents a Test Engine test result object.
-// Some attributes such as `history` and `failure_reason` are omitted as they are not needed by bktec.
-// Ref: https://buildkite.com/docs/test-engine/importing-json#json-test-results-data-reference-test-result-objects
-//
-// Currently, only pytest and custom runner uses result from test collector.
+// Some attributes such as `failure_reason` are omitted as they are not needed by bktec.
+// Ref: https://buildkite.com/docs/pipelines/configure/tests/test-collection/importing-json#json-test-results-data-reference-test-result-objects
 type TestEngineTest struct {
-	ID       string
-	Name     string
-	Scope    string
-	Location string
-	FileName string `json:"file_name,omitempty"`
-	Result   TestStatus
-	Tags     map[string]string `json:"tags,omitempty"`
+	ID       string             `json:"id"`
+	Name     string             `json:"name"`
+	Scope    string             `json:"scope,omitempty"`
+	Location string             `json:"location,omitempty"`
+	FileName string             `json:"file_name,omitempty"`
+	Result   TestStatus         `json:"result"`
+	History  *TestEngineHistory `json:"history,omitempty"`
+	Tags     map[string]string  `json:"tags,omitempty"`
+}
+
+type TestEngineHistory struct {
+	StartAt  float64 `json:"start_at"`
+	EndAt    float64 `json:"end_at,omitempty"`
+	Duration float64 `json:"duration"`
 }
 
 func parseTestEngineTestResult(path string) ([]TestEngineTest, error) {
@@ -258,4 +263,28 @@ func parseTestEngineTestResult(path string) ([]TestEngineTest, error) {
 	}
 
 	return results, nil
+}
+
+func writeTestEngineUploadResult(results []TestEngineTest, tempPattern string) (UploadResult, error) {
+	f, err := os.CreateTemp("", tempPattern)
+	if err != nil {
+		return UploadResult{}, fmt.Errorf("failed to create test engine upload file: %w", err)
+	}
+	cleanup := func() { os.Remove(f.Name()) }
+
+	if err := json.NewEncoder(f).Encode(results); err != nil {
+		f.Close()
+		cleanup()
+		return UploadResult{}, fmt.Errorf("failed to write test engine upload file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return UploadResult{}, fmt.Errorf("failed to close test engine upload file: %w", err)
+	}
+
+	return UploadResult{
+		Path:    f.Name(),
+		Format:  "json",
+		Cleanup: cleanup,
+	}, nil
 }

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -13,6 +13,7 @@ type RunnerConfig struct {
 	TestCommand            string
 	TestFileExcludePattern string
 	TestFilePattern        string
+	EmitSelectorTags       bool
 	uploadToken            string
 }
 

--- a/internal/runner/test_runner.go
+++ b/internal/runner/test_runner.go
@@ -18,3 +18,13 @@ type TestRunner interface {
 	// ResultFilePath returns the path to the runner's raw result file.
 	ResultFilePath() string
 }
+
+type UploadResultPreparer interface {
+	PrepareUploadResult() (UploadResult, error)
+}
+
+type UploadResult struct {
+	Path    string
+	Format  string
+	Cleanup func()
+}


### PR DESCRIPTION
## Description

Temporarily emit `test.selector.primary` on our repo’s Go test executions so we can validate selector-based smart splitting before promoting selector tags to core tags.

## Context

Go test planning in bktec operates at package granularity, so the selector identity we want to validate is the Go package import path, for example:

```text
test.selector.primary=github.com/buildkite/test-engine-client/v2/internal/runner
```

This is intentionally scoped to Buildkite’s test-engine-client pipeline only. It is a dogfood/validation path, not a public bktec feature.

## Why JSON

Go currently uploads gotestsum JUnit XML. JUnit uploads support upload-level custom tags, but the docs direct per-execution custom tags to JSON import:

`If you need to import per-execution level custom tags, consider using JSON import.`

So this temporary path converts Go JUnit results to Buildkite JSON only when enabled, then attaches `test.selector.primary` on each execution.

This JSON path also adds the required history payload. That isn’t the feature we’re targeting, but it’s part of the JSON import contract needed to submit executions with per-execution tags.

## Docs:
- JUnit XML imports: https://buildkite.com/docs/pipelines/configure/tests/test-collection/importing-junit-xml
- JSON imports: https://buildkite.com/docs/pipelines/configure/tests/test-collection/importing-json

## Changes

- Added a temporary Buildkite test-engine-client pipeline gate for selector tag validation.
- Added upload-result preparation support for runners.
- Converts Go JUnit results to Buildkite JSON only for this validation path.
- Emits `test.selector.primary` using the Go package import path.
- Keeps generated JSON aligned with the documented JSON structure.

## Verification

<img width="873" height="445" alt="image" src="https://github.com/user-attachments/assets/8ea253c1-a304-4003-ba08-dfefbf098fb3" />