### PR TITLE
chore: Add manual version override to release pipeline

### DIFF
--- a/.buildkite/steps/prepare-release.sh
+++ b/.buildkite/steps/prepare-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 current=$(svu current)
-
+overrideOptionValue="__override__"
 
 options() {
   if [[ "$current" =~ "-rc" ]]; then
@@ -46,7 +46,13 @@ cat <<YAML | buildkite-agent pipeline upload
   fields:
     - select: "Version"
       key: "release-version"
-      hint: "Select the version to release. Current version is $current"
+      hint: "Select the version to release, or choose Version override to use the exact version below. Current version is $current"
       options:
 $(options)
+        - label: "Version override"
+          value: "$overrideOptionValue"
+    - text: "Version override"
+      key: "release-version-override"
+      hint: "Exact version to release when Version is set to Version override, e.g. v2.9.0-rc.3"
+      required: false
 YAML

--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -1,7 +1,40 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
-tag=$(buildkite-agent meta-data get "release-version")
+override_option_value="__override__"
+version_number='(0|[1-9][0-9]*)'
+prerelease_identifier='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+version_pattern="^v${version_number}\\.${version_number}\\.${version_number}(-${prerelease_identifier}(\\.${prerelease_identifier})*)?$"
+
+selected_tag=$(buildkite-agent meta-data get "release-version")
+override_tag=$(buildkite-agent meta-data get "release-version-override" 2>/dev/null || true)
+override_tag=$(printf '%s' "${override_tag}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+if [[ "${selected_tag}" == "${override_option_value}" ]]; then
+  if [[ -z "${override_tag}" ]]; then
+    echo "Release version override selected, but no override was provided"
+    exit 1
+  fi
+  tag="${override_tag}"
+  echo "Using release version override: ${tag}"
+else
+  tag="${selected_tag}"
+fi
+
+if [[ "$(printf '%s' "${tag}" | tr -d '\n\r')" != "${tag}" ]]; then
+  echo "Invalid release version: ${tag}"
+  exit 1
+fi
+
+if ! printf '%s\n' "${tag}" | grep -Eq "${version_pattern}"; then
+  echo "Invalid release version: ${tag}"
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+  echo "Release version already exists: ${tag}"
+  exit 1
+fi
 
 git tag "${tag}"
 


### PR DESCRIPTION
## Summary

This adds a manual version override to the release pipeline.

We hit this while trying to cut `v2.9.0-rc.3`: the release prompt only showed the versions suggested by `svu`, and because there was a `feat:` conventional commit, `svu` suggested the next minor pre-release instead of the RC version we wanted.

With this change, the release block still shows the normal generated version options, but also includes a “Version override” option. When selected, the release job uses the exact version entered in the override field.

The release script also validates the final version and fails early if the override is missing, invalid, or already exists as a tag.

## Testing

- Ran shell syntax checks for the release scripts
- Verified the diff has no whitespace errors
- Spot-checked version validation for valid and invalid RC examples

## UI Screenshot

<img width="749" height="668" alt="image" src="https://github.com/user-attachments/assets/38e4421e-1624-44d3-81e7-cf387c57aaa1" />
