### PR TITLE
chore: restore gotest JUnit output for bktec pipeline

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -30,9 +30,9 @@ echo '+++ Running tests'
 
 export BUILDKITE_TEST_ENGINE_SUITE_SLUG=bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
-export BUILDKITE_TEST_ENGINE_RESULT_PATH="gotest-${BUILDKITE_JOB_ID}.jsonl"
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
-export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --jsonfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
+export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 export BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS=true
 
 "${bktec_bin}" run


### PR DESCRIPTION
Summary

Restore the bktec CI test step to use JUnit output again.

Why

main runs the released bktec binary from the CI image, not the latest RC/source build. That binary still expects JUnit results, so switching the pipeline to gotestsum JSONL broke result parsing and uploads.

Testing

- bash -n .buildkite/steps/tests.sh