### PR TITLE
ci: use HEAD bktec for CI test splitting

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,17 +1,12 @@
 FROM ruby:4.0.5-slim-bookworm AS ruby
 FROM cypress/included:14.5.3 AS cypress
 FROM python:3.15.0b1-bookworm AS python
-# Latest released bktec image. This is used to split tests on `main`. On other
-# branches the test step builds bktec from source instead (see
-# .buildkite/steps/tests.sh). The `latest` tag only points at stable releases.
-FROM public.ecr.aws/buildkite/test-engine-client:latest AS bktec
 
 FROM golang:1.26.4-bookworm AS golang
 
 COPY --from=ruby / /
 COPY --from=cypress / /
 COPY --from=python / /
-COPY --from=bktec /usr/local/bin/bktec /usr/local/bin/bktec
 
 RUN gem install rspec cucumber base64
 RUN gem install bigdecimal -v 3.2.0
@@ -19,5 +14,3 @@ RUN yarn global add jest
 RUN pip install pytest
 RUN pip install buildkite-test-collector>=1.3.0
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -s -- --bin-dir /usr/local/bin
-
-RUN echo "bktec installed successfully:" && bktec --version

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -13,18 +13,10 @@ cd playwright
 yarn playwright install
 cd ../../../..
 
-# On feature branches, build bktec from the current source so the pipeline
-# splits its own tests using the code under test. This way a change that breaks
-# bktec's test splitting fails the pipeline before it can be merged to main.
-# On main we use the released binary installed in the image (see Dockerfile).
-bktec_bin="bktec"
-if [[ "${BUILDKITE_BRANCH:-}" != "main" ]]; then
-  echo '+++ Building bktec from source'
-  go build \
-    -ldflags "-X 'github.com/buildkite/test-engine-client/v2/internal/version.Version=${BUILDKITE_COMMIT:-dev}'" \
-    -o /tmp/bktec .
-  bktec_bin="/tmp/bktec"
-fi
+echo '+++ Building bktec from source'
+go build \
+  -ldflags "-X 'github.com/buildkite/test-engine-client/v2/internal/version.Version=${BUILDKITE_COMMIT:-dev}'" \
+  -o /tmp/bktec .
 
 echo '+++ Running tests'
 
@@ -35,7 +27,7 @@ export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
 export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 export BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS=true
 
-"${bktec_bin}" run
+/tmp/bktec run
 
 echo 'Producing coverage report'
 go tool cover -html cover.out -o cover.html


### PR DESCRIPTION
### Description

Use the `bktec` binary built from the current checkout for CI test splitting on all branches, including `main`.

Previously, `main` used the latest released `bktec` binary from the CI image, while branch builds used the source version. That meant a change could pass on a branch but behave differently once merged to `main`.

### Context

[Slack Thread](https://buildkite-corp.slack.com/archives/C05MSVDKQRG/p1782443464792039?thread_ts=1782442264.103269&cid=C05MSVDKQRG)

### Changes

- Always build `bktec` from source in `.buildkite/steps/tests.sh`.
- Run tests through `/tmp/bktec` instead of the image-installed `bktec`.
- Remove the released `bktec` image stage from the CI Dockerfile.

### Testing

- Ran `bash -n .buildkite/steps/tests.sh`.
- Ran a local `go build` with the CI-style version ldflag and confirmed `bktec --version` works.