### PR TITLE
Filter out Go packages with no tests from split units

### DIFF
--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -308,14 +308,19 @@ func isBuildFailure(test JUnitXMLTestCase) bool {
 		strings.Contains(test.Failure.Content, "[build failed]")
 }
 
-// GetFiles discovers Go packages using `go list ./...`.
+// GetFiles discovers Go packages that contain tests.
 // Note that "file" does not exist as a first level concept in Golang projects
 // So this func is returning a list of packages instead of files.
 // The implication is that the Server-side smart test splitting will never work.
 // It almost will always fallback to simple splitting.
+//
+// We use a format template so `go list` only emits packages that actually have
+// test files (_test.go). Packages with zero tests would otherwise be sent to the
+// test plan API as split units that run no tests, taking up a bin packing slot
+// for nothing.
 func (g GoTest) GetFiles() ([]string, error) {
-	debug.Println("Discovering Go packages with `go list ./...`")
-	cmd := exec.Command("go", "list", "./...")
+	debug.Println("Discovering Go packages with tests using `go list`")
+	cmd := exec.Command("go", "list", "-f", "{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}", "./...")
 	output, err := cmd.Output()
 	if err != nil {
 		// Handle stderr for better error messages
@@ -325,16 +330,16 @@ func (g GoTest) GetFiles() ([]string, error) {
 		return nil, fmt.Errorf("failed to run go list: %w", err)
 	}
 	packages := strings.Split(strings.TrimSpace(string(output)), "\n")
-	// Filter out empty strings if any
+	// Packages without tests produce an empty line in the output, so filter them out.
 	validPackages := []string{}
 	for _, pkg := range packages {
 		if pkg != "" {
 			validPackages = append(validPackages, pkg)
 		}
 	}
-	debug.Println("Discovered", len(validPackages), "packages")
+	debug.Println("Discovered", len(validPackages), "packages with tests")
 	if len(validPackages) == 0 {
-		return nil, fmt.Errorf("no Go packages found using `go list ./...`")
+		return nil, fmt.Errorf("no Go packages with tests found using `go list`")
 	}
 	return validPackages, nil
 }

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -377,6 +377,8 @@ func TestGotestGetFiles(t *testing.T) {
 		t.Errorf("Gotest.GetFiles() error = %v", err)
 	}
 
+	// example.com/hello/notest has source files but no tests, so it must be
+	// excluded from the discovered packages.
 	want := []string{
 		"example.com/hello",
 		"example.com/hello/bad",

--- a/internal/runner/testdata/go/notest/notest.go
+++ b/internal/runner/testdata/go/notest/notest.go
@@ -1,0 +1,8 @@
+// Package notest has source files but no tests. It exists so GetFiles can be
+// verified to exclude packages that contain zero tests.
+package notest
+
+// Add returns the sum of two integers.
+func Add(a, b int) int {
+	return a + b
+}


### PR DESCRIPTION
### Description

For the `go test` runner, bktec discovers packages with `go list ./...`, which lists every package in the module. That includes packages with no tests at all (interfaces, generated code, `main` packages, constants, and so on). So we end up requesting a test plan for packages that have zero tests. Each one takes up a slot in the bin packing but runs nothing, which makes the packing less optimal than it should be.

For example, running against this repo itself, 2 of 12 packages we send had no tests (`internal/version` and `util/supported_features`). The effect grows with how many non-test packages a module has.

This changes `GetFiles()` to use a format template so `go list` only emits packages that actually have test files:

```
go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./...
```

I checked the two paths the ticket flagged as a risk and both are fine. Build-failure detection and the retry path both work off `go test` results for the packages we select, and we only ever select packages that have tests, so dropping zero-test packages does not change either one. A build failure in a non-test dependency still surfaces, because compiling a test package compiles everything it imports.

### Context

- Linear: [TE-6224](https://linear.app/buildkite/issue/TE-6224)

### Testing

- Added a `notest` testdata package that has source but no tests, so `TestGotestGetFiles` verifies it gets excluded. Confirmed the old command leaked it and the new one drops it.
- `TestGotestGetFiles`, `TestGotestRun_GoJSONL`, and `TestGotestRun_BuildFailed` pass. `gofmt` and `go vet` are clean.
- Verified the split summary in CI on this repo. Before the change, the last main build asked for 12 selectors and only 10 had history. After the change, this branch asks for exactly 10 selectors and all 10 have history. The 2 zero-test packages are gone.
  - Before ([build #2313](https://buildkite.com/buildkite/test-engine-client/builds/2313)): `12 selectors across 2 nodes`, `10 selectors (83%) estimated from past historical durations` 
  <img width="589" height="111" alt="Screenshot 2026-06-29 at 9 59 29 AM" src="https://github.com/user-attachments/assets/ba578c87-c692-4af6-a45b-8af401453cb6" />

  - After ([build #2315](https://buildkite.com/buildkite/test-engine-client/builds/2315)): `10 selectors across 2 nodes`, `10 selectors (100%) estimated from past historical durations`
  <img width="583" height="86" alt="Screenshot 2026-06-29 at 10 21 06 AM" src="https://github.com/user-attachments/assets/2caa210f-5a01-4500-bbb4-5170fec53025" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)