### PR TITLE
fix: use gotestsum JSONL results in CI

### DIFF
--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -22,9 +22,9 @@ echo '+++ Running tests'
 
 export BUILDKITE_TEST_ENGINE_SUITE_SLUG=bktec
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=gotest
-export BUILDKITE_TEST_ENGINE_RESULT_PATH="junit-${BUILDKITE_JOB_ID}.xml"
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="gotest-${BUILDKITE_JOB_ID}.jsonl"
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=1
-export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --junitfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
+export BUILDKITE_TEST_ENGINE_TEST_CMD='gotestsum --jsonfile={{resultPath}} -- -count=1 -coverprofile=cover.out -failfast -race {{packages}}'
 export BUILDKITE_TEST_ENGINE_UPLOAD_RESULTS=true
 
 /tmp/bktec run


### PR DESCRIPTION
## Summary

This PR switches the CI Go test step to use gotestsum JSONL output and upload those results through Test Engine.

It works on main now because CI runs the bktec binary built from HEAD, not the latest stable binary from the Docker image.

## Changes

- Configure the Go test runner to write gotestsum JSONL results.
- Upload those JSONL results through Test Engine.
- Ensure CI uses the HEAD-built bktec binary instead of the stable Docker image binary.

## Testing

- bash -n .buildkite/steps/tests.sh
- Local go build with the CI-style version ldflag
- Confirmed bktec --version works