### PR TITLE
[TE-6228] Add --plan-identifier flag to the plan command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Add `--plan-identifier` (env: `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`. The identifier sets the plan's server-side cache key, and supplying it lets `plan` run off-agent without `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`. Previously this flag was only available on `bktec run`.
+
 ## 2.8.2 - 2026-06-19
 - Treat pytest collection errors reported by `buildkite-test-collector` as terminal, and preserve their file-only node IDs when recording JSON results. Previously bktec could construct invalid retry selectors like `::tests/test_broken.py` for collection failures with empty scopes, then waste a retry on a failure that cannot be fixed by rerunning individual tests.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ need to set `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, which are otherwise
 required. Use a unique value per request (a UUIDv7 works well) so plans don't
 collide or silently return a stale cached plan.
 
+> [!IMPORTANT]
+> The identifier must be unique per **step**, not just per build. It is the
+> cache key for the plan, so two steps sharing an identifier get the *same*
+> cached plan, and the second step runs the first step's test split instead of
+> its own. The default `${BUILDKITE_BUILD_ID}/${BUILDKITE_STEP_ID}` includes the
+> step id for exactly this reason.
 ```sh
 ./bktec plan --json --plan-identifier 01919f1e-0000-7000-8000-000000000000
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ export BUILDKITE_TEST_ENGINE_TAGS="env=production,region=us-east-1"
 
 Test collectors are available for many languages and frameworks. Some collectors also provide richer data collection such as execution-level tagging and span tracing. See the [test collector docs](https://buildkite.com/docs/test-engine/test-collection) for details on what's available for your framework.
 
+### Plan identifier
+
+`--plan-identifier` (or `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) sets the
+identifier the `plan` command generates the plan under. The identifier is the
+plan's server-side cache key: distinct values produce distinct plans, while
+reusing a value returns the previously cached plan for that identifier.
+
+Inside a Buildkite build you don't need to set this; the identifier defaults to
+`${BUILDKITE_BUILD_ID}/${BUILDKITE_STEP_ID}`. Supply `--plan-identifier`
+explicitly when generating a plan **off-agent** (for example, running it in your
+local development environment or on your own machine). Doing so also removes the
+need to set `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, which are otherwise
+required. Use a unique value per request (a UUIDv7 works well) so plans don't
+collide or silently return a stale cached plan.
+
+```sh
+./bktec plan --json --plan-identifier 01919f1e-0000-7000-8000-000000000000
+```
+
+`bktec run` accepts the same flag. It fetches the plan cached under the
+identifier, or, on a cache miss, creates and caches one under it. A reused
+identifier therefore returns the previously cached plan even if the inputs have
+changed, so keep the value unique per distinct plan.
+
 ### Preview: Test Selection
 You can pass test selection strategy configuration and additional change context to the test plan API request.
 This preview is enabled only when `BKTEC_PREVIEW_SELECTION` is truthy (`1`, `true`, `yes`, or `on`).

--- a/README.md
+++ b/README.md
@@ -104,17 +104,22 @@ Inside a Buildkite build you don't need to set this; the identifier defaults to
 explicitly when generating a plan **off-agent** (for example, running it in your
 local development environment or on your own machine). Doing so also removes the
 need to set `BUILDKITE_BUILD_ID` and `BUILDKITE_STEP_ID`, which are otherwise
-required. Use a unique value per request (a UUIDv7 works well) so plans don't
-collide or silently return a stale cached plan.
+required.
 
 > [!IMPORTANT]
 > The identifier must be unique per **step**, not just per build. It is the
 > cache key for the plan, so two steps sharing an identifier get the *same*
 > cached plan, and the second step runs the first step's test split instead of
 > its own. The default `${BUILDKITE_BUILD_ID}/${BUILDKITE_STEP_ID}` includes the
-> step id for exactly this reason.
+> step id for exactly this reason. When setting it yourself, use a unique value
+> per request; a UUIDv7 works well, but any unique string is fine.
+
 ```sh
-./bktec plan --json --plan-identifier 01919f1e-0000-7000-8000-000000000000
+# UUIDv7 via Python (3.14+); use uuid4() on older versions
+./bktec plan --json --plan-identifier "$(python3 -c 'import uuid; print(uuid.uuid7())')"
+
+# UUIDv4 via uuidgen (preinstalled on macOS and most Linux)
+./bktec plan --json --plan-identifier "$(uuidgen)"
 ```
 
 `bktec run` accepts the same flag. It fetches the plan cached under the

--- a/cli.go
+++ b/cli.go
@@ -426,11 +426,11 @@ var promiseFailureFlag = &cli.BoolFlag{
 	Destination: &cfg.PromiseFailure,
 }
 
-// `run` command flags
+// `run` and `plan` command flags
 var planIdentifierFlag = &cli.StringFlag{
 	Name:        "plan-identifier",
 	Value:       "",
-	Usage:       "run the tests from a plan previously generated matching the provided plan-identifier",
+	Usage:       "the identifier used as the plan's cache key. On 'run', consume a plan previously generated under this identifier. On 'plan', generate the plan under this identifier; distinct values produce distinct plans, a reused value returns the cached plan. Supplying it also lets 'plan' run off-agent without BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID set",
 	Destination: &cfg.Identifier,
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"),
 }
@@ -618,6 +618,7 @@ func planCommandFlags() []cli.Flag {
 	flags := []cli.Flag{
 		filesFlag,
 		tagFiltersFlag,
+		planIdentifierFlag,
 		// Dynamic Parallelism Flags
 		maxParallelismFlag,
 		targetTimeFlag,

--- a/cli_test.go
+++ b/cli_test.go
@@ -68,6 +68,12 @@ func TestPlanCommandIncludesParallelismFlag(t *testing.T) {
 	}
 }
 
+func TestPlanCommandIncludesPlanIdentifierFlag(t *testing.T) {
+	if !hasFlag(planCommandFlags(), "plan-identifier") {
+		t.Fatalf("planCommandFlags() missing --plan-identifier flag; an off-agent `bktec plan` cannot set the plan cache key or skip the BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID guards")
+	}
+}
+
 func TestApplyPlanRequestContext_ClearsCollectGitMetadataWhenPreviewDisabled(t *testing.T) {
 	t.Setenv(previewSelectionEnvVar, "")
 

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -89,6 +89,132 @@ called with testtemplate.yml
 	}
 }
 
+// An off-agent `bktec plan` supplies --plan-identifier instead of
+// BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID. The identifier must flow through to the
+// test_plan create request as the `identifier` param (the server cache key).
+func TestPlan_PlanIdentifierFlowsToRequestParam(t *testing.T) {
+	var requestBody []byte
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			enc.Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			requestBody, _ = io.ReadAll(r.Body)
+			enc.Encode(plan.TestPlan{
+				Identifier:  "01919f1e-0000-7000-8000-000000000000",
+				Parallelism: 42,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+	// An off-agent run has no build/step; identity comes from the identifier.
+	cfg.BuildID = ""
+	cfg.StepID = ""
+	cfg.Identifier = "01919f1e-0000-7000-8000-000000000000"
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Fatalf("ValidateForPlan() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	if err := Plan(ctx, cfg, "", PlanOutputJSON, ""); err != nil {
+		t.Fatalf("command.Plan(...) error = %v", err)
+	}
+
+	var params map[string]any
+	if err := json.Unmarshal(requestBody, &params); err != nil {
+		t.Fatalf("failed to unmarshal request body %q: %v", requestBody, err)
+	}
+
+	if got, want := params["identifier"], "01919f1e-0000-7000-8000-000000000000"; got != want {
+		t.Errorf("request identifier = %v, want %v", got, want)
+	}
+}
+
+// Supplying an identifier lets `ValidateForPlan` skip the BUILDKITE_BUILD_ID /
+// BUILDKITE_STEP_ID blank guards, so an off-agent run needn't fake build env vars.
+func TestValidateForPlan_PlanIdentifierSkipsBuildStepGuards(t *testing.T) {
+	cfg := getConfig()
+	cfg.BuildID = ""
+	cfg.StepID = ""
+	cfg.Identifier = "01919f1e-0000-7000-8000-000000000000"
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Fatalf("ValidateForPlan() with --plan-identifier and no BUILD_ID/STEP_ID error = %v", err)
+	}
+
+	if cfg.Identifier != "01919f1e-0000-7000-8000-000000000000" {
+		t.Errorf("cfg.Identifier = %q, want it preserved (not overwritten with BUILD_ID/STEP_ID)", cfg.Identifier)
+	}
+}
+
+// A supplied identifier takes precedence over BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID:
+// when both are set, the identifier is kept rather than overwritten with the
+// "<build>/<step>" composite.
+func TestValidateForPlan_PlanIdentifierTakesPrecedenceOverBuildStep(t *testing.T) {
+	cfg := getConfig()
+	cfg.BuildID = "123"
+	cfg.StepID = "789"
+	cfg.Identifier = "01919f1e-0000-7000-8000-000000000000"
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Fatalf("ValidateForPlan() error = %v", err)
+	}
+
+	if cfg.Identifier != "01919f1e-0000-7000-8000-000000000000" {
+		t.Errorf("cfg.Identifier = %q, want the supplied identifier to win over %q", cfg.Identifier, "123/789")
+	}
+}
+
+// Without an identifier but with BUILD_ID/STEP_ID, the identifier defaults to
+// the "<build>/<step>" composite.
+func TestValidateForPlan_IdentifierDefaultsToBuildStepWhenUnset(t *testing.T) {
+	cfg := getConfig()
+	cfg.BuildID = "123"
+	cfg.StepID = "789"
+	cfg.Identifier = ""
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Fatalf("ValidateForPlan() error = %v", err)
+	}
+
+	if cfg.Identifier != "123/789" {
+		t.Errorf("cfg.Identifier = %q, want %q", cfg.Identifier, "123/789")
+	}
+}
+
+// Without an identifier and without BUILD_ID/STEP_ID, validation must still fail.
+func TestValidateForPlan_RequiresBuildStepWhenNoPlanIdentifier(t *testing.T) {
+	cfg := getConfig()
+	cfg.BuildID = ""
+	cfg.StepID = ""
+	cfg.Identifier = ""
+
+	err := cfg.ValidateForPlan()
+	if err == nil {
+		t.Fatal("ValidateForPlan() error = nil, want errors for blank BUILDKITE_BUILD_ID/BUILDKITE_STEP_ID")
+	}
+	if !strings.Contains(err.Error(), "BUILDKITE_BUILD_ID") || !strings.Contains(err.Error(), "BUILDKITE_STEP_ID") {
+		t.Errorf("ValidateForPlan() error = %v, want it to mention BUILDKITE_BUILD_ID and BUILDKITE_STEP_ID", err)
+	}
+}
+
 func TestPlanJSON_BillingError(t *testing.T) {
 	// mock server to return 403 with a billing error
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Description

Add the `--plan-identifier` flag (env `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`, so a plan can be generated under a caller-supplied identifier rather than only consumed by `bktec run`. The identifier is the plan's server-side cache key; a non-blank value also skips the `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID` guards in `validate()`, which lets `plan` run off-agent (locally, outside a Buildkite build).

This **reverses a decision made in [#102](https://github.com/buildkite/test-engine-client/pull/102)** (`tat-209`), which removed the ability to override the identifier to tie plan identity to the build. Re-exposing it on `plan` is a deliberate, scoped reopening of that override for the off-agent use case, and needs the client owner's sign-off. The flag itself already existed on `run`; this PR only registers it on `plan` and broadens its usage text.

**Decision — identity over faking build vars:** chosen over making callers set a dummy `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`, which would leak a fake build identity downstream.

### Context

- Linear: [TE-6228](https://linear.app/buildkite/issue/TE-6228) (sub-issue of [TE-6168](https://linear.app/buildkite/issue/TE-6168))
- Reverses: [#102](https://github.com/buildkite/test-engine-client/pull/102)

### Changes

- `cli.go`: register `planIdentifierFlag` on `planCommandFlags()`; rewrite its usage to describe both `run` and `plan`.
- Tests: flag registration on `plan`; identifier flows to the `test_plan` create request param; the `validate()` identity branch (identifier precedence over build/step, off-agent validation, and the blank-identifier failure).
- Docs: README `Plan identifier` section and an unreleased changelog entry.

Best reviewed commit-by-commit.

### Testing

Backed by specs; AI assisted. `go build ./...`, `go vet ./...`, and `go test . ./internal/command/ ./internal/config/` all pass.
