### PR TITLE
[TE-6236] Stop requiring result-path for the plan command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 - Add `--plan-identifier` (env: `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`. The identifier sets the plan's server-side cache key, and supplying it lets `plan` run off-agent without `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`. Previously this flag was only available on `bktec run`.
+- `bktec plan` no longer requires `BUILDKITE_TEST_ENGINE_RESULT_PATH` (`--result-path`). The value is only used when running tests, so planning never needed it. `bktec run` still requires it for runners that read a result file.
 
 ## 2.8.2 - 2026-06-19
 - Treat pytest collection errors reported by `buildkite-test-collector` as terminal, and preserve their file-only node IDs when recording JSON results. Previously bktec could construct invalid retry selectors like `::tests/test_broken.py` for collection failures with empty scopes, then waste a retry on a failure that cannot be fixed by rerunning individual tests.

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -502,7 +502,6 @@ func getConfig() *config.Config {
 	cfg.AccessToken = "asdf1234"
 	cfg.SuiteSlug = "rspec"
 	cfg.TestRunner = "rspec"
-	cfg.ResultPath = "out.json"
 	cfg.DebugEnabled = true
 	cfg.TestFilePattern = "testdata/rspec/spec/**/*_spec.rb"
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -60,16 +60,6 @@ func (c *Config) validate() error {
 		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_SUITE_SLUG", "must not be blank")
 	}
 
-	runnersWithoutResultPath := map[string]bool{
-		"cypress":      true,
-		"pytest":       true,
-		"pytest-pants": true,
-		"custom":       true,
-	}
-	if c.ResultPath == "" && !runnersWithoutResultPath[c.TestRunner] {
-		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_RESULT_PATH", "must not be blank")
-	}
-
 	if c.TestRunner == "" {
 		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_TEST_RUNNER", "must not be blank")
 	}
@@ -104,6 +94,18 @@ func (c *Config) validate() error {
 // Validation for the `bktec run` command
 func (c *Config) ValidateForRun() error {
 	_ = c.validate()
+
+	// result-path is only consumed when running tests (command construction and
+	// report parsing), so it is required here but not for `plan`.
+	runnersWithoutResultPath := map[string]bool{
+		"cypress":      true,
+		"pytest":       true,
+		"pytest-pants": true,
+		"custom":       true,
+	}
+	if c.ResultPath == "" && !runnersWithoutResultPath[c.TestRunner] {
+		c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_RESULT_PATH", "must not be blank")
+	}
 
 	// Upload token could come from the env BUILDKITE_ANALYTICS_TOKEN, but may be blank ...
 	if c.UploadToken == "" {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -198,25 +198,46 @@ func TestConfigValidate_IdentifierPresentBuildIdStepIdMissing(t *testing.T) {
 	}
 }
 
-func TestConfigValidate_ResultPathOptionalWithCypress(t *testing.T) {
+func TestConfigValidateForRun_ResultPathOptionalWithCypress(t *testing.T) {
 	c := createConfig()
 	c.ResultPath = ""
 	c.TestRunner = "cypress"
 
-	err := c.validate()
-	if err != nil {
-		t.Errorf("config.validate() error = %v", err)
+	if err := c.ValidateForRun(); err != nil {
+		t.Errorf("ValidateForRun() error = %v, want nil", err)
 	}
 }
 
-func TestConfigValidate_ResultPathOptionalWithPytest(t *testing.T) {
+func TestConfigValidateForRun_ResultPathOptionalWithPytest(t *testing.T) {
 	c := createConfig()
 	c.ResultPath = ""
 	c.TestRunner = "pytest"
 
-	err := c.validate()
-	if err != nil {
-		t.Errorf("config.validate() error = %v", err)
+	if err := c.ValidateForRun(); err != nil {
+		t.Errorf("ValidateForRun() error = %v, want nil", err)
+	}
+}
+
+func TestConfigValidateForRun_ResultPathRequiredWithRspec(t *testing.T) {
+	c := createConfig()
+	c.ResultPath = ""
+	c.TestRunner = "rspec"
+
+	err := c.ValidateForRun()
+
+	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Errorf("ValidateForRun() error = %v, want InvalidConfigError", err)
+	}
+}
+
+func TestConfigValidateForPlan_ResultPathNotRequired(t *testing.T) {
+	c := createConfig()
+	c.ResultPath = ""
+	c.TestRunner = "rspec"
+
+	if err := c.ValidateForPlan(); err != nil {
+		t.Errorf("ValidateForPlan() error = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
### Description

`bktec plan` no longer requires `BUILDKITE_TEST_ENGINE_RESULT_PATH` (`--result-path`). The result path is only consumed when running tests (command construction and report parsing), so the plan path never read it, yet `ValidateForPlan()` rejected most runners without it. The check moves from the shared `validate()` into `ValidateForRun()`, where it stays required for runners that read a result file.

`--test-runner` remains required for `plan`, since it drives `DetectRunner` and file discovery.

This is stacked on #566 and best reviewed commit-by-commit.

### Context

- TE-6236: https://linear.app/buildkite/issue/TE-6236/bktec-plan-drop-unnecessary-result-path-requirement
- Parent TE-6228 (stacked on #566).

### Changes

- Move the `BUILDKITE_TEST_ENGINE_RESULT_PATH` check out of `validate()` into `ValidateForRun()`; add tests asserting `run` still requires it for `rspec` and `plan` does not.
- Add an unreleased changelog entry.

### Testing

Backed by specs. `go test ./internal/config/... ./internal/command/...` passes. AI assisted.
