### PR TITLE
Support selector-based splitting for the custom runner

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -8,6 +8,9 @@ COPY --from=ruby / /
 COPY --from=cypress / /
 COPY --from=python / /
 
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core \
+  && /tmp/bats-core/install.sh /usr/local \
+  && rm -rf /tmp/bats-core
 RUN gem install rspec cucumber base64
 RUN gem install bigdecimal -v 3.2.0
 RUN yarn global add jest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,6 +84,24 @@
         "BUILDKITE_STEP_ID": "playwright",
         "BUILDKITE_BUILD_ID": "${input:build-id}"
       }
+    },
+    {
+      "name": "Debug custom run",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceRoot}",
+      "args": ["run"],
+      "cwd": "${workspaceFolder}/internal/runner/testdata/custom",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "BUILDKITE_TEST_ENGINE_TEST_RUNNER": "custom",
+        "BUILDKITE_TEST_ENGINE_TEST_CMD": "bats --report-formatter junit --output tmp/ . {{testExamples}}",
+        "BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN": "tests/*.bats",
+        "BUILDKITE_TEST_ENGINE_RESULT_PATH": "tmp/report.xml",
+        "BUILDKITE_STEP_ID": "custom",
+        "BUILDKITE_BUILD_ID": "${input:build-id}"
+      }
     }
   ],
   "inputs": [

--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,18 @@ if command -v asdf &>/dev/null && asdf current golang &>/dev/null; then
   asdf reshim golang
 fi
 
+# Install bats for the shell-based custom runner test cases
+if ! command -v bats &>/dev/null; then
+  echo "🦇 Installing bats..."
+  if command -v brew &>/dev/null; then
+    brew install bats-core
+  elif command -v apt-get &>/dev/null; then
+    sudo apt-get update && sudo apt-get install -y bats
+  else
+    echo "⚠️ Couldn't install bats automatically. Please install bats-core manually: https://github.com/bats-core/bats-core"
+  fi
+fi
+
 echo "🛠️ Installing dependencies for sample projects..."
 
 pushd ./internal/runner/testdata || exit 1

--- a/cli.go
+++ b/cli.go
@@ -283,11 +283,11 @@ var filesFlag = &cli.StringFlag{
 }
 
 var selectorsFlag = &cli.StringFlag{
-	Name:        "selectors",
+	Name:        "selector-file",
 	Category:    "TEST RUNNER",
 	Value:       "",
-	Usage:       "A file path containing a list of selectors to run (one per line). Must be used alongside `selector-splitting`",
-	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH"),
+	Usage:       "Path to a file containing a list of selectors to run (one per line). Must be used alongside `selector-splitting`",
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_FILE"),
 	Destination: &cfg.SelectorListPath,
 	Hidden:      true,
 }

--- a/cli.go
+++ b/cli.go
@@ -282,6 +282,16 @@ var filesFlag = &cli.StringFlag{
 	Sources:  cli.EnvVars("BUILDKITE_TEST_ENGINE_FILES"),
 }
 
+var selectorsFlag = &cli.StringFlag{
+	Name:        "selectors",
+	Category:    "TEST RUNNER",
+	Value:       "",
+	Usage:       "A file path containing a list of selectors to run (one per line). Must be used alongside `selector-splitting`",
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH"),
+	Destination: &cfg.SelectorListPath,
+	Hidden:      true,
+}
+
 var tagFiltersFlag = &cli.StringFlag{
 	Name:        "tag-filters",
 	Category:    "TEST RUNNER",
@@ -575,6 +585,7 @@ var runnerEnvironmentFlags = []cli.Flag{
 	resultPathFlag,
 	splitByExampleFlag,
 	selectorSplittingFlag,
+	selectorsFlag,
 	locationPrefixFlag,
 	// Runner Retry Flags
 	disableRetryMutedFlag,

--- a/cli_test.go
+++ b/cli_test.go
@@ -143,6 +143,7 @@ func TestRunCommandEnvVarsBindToConfig(t *testing.T) {
 	t.Setenv("BUILDKITE_TEST_ENGINE_RESULT_PATH", "/tmp/results.json")
 	t.Setenv("BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE", "true")
 	t.Setenv("BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING", "true")
+	t.Setenv("BUILDKITE_TEST_ENGINE_SELECTOR_FILE", "selectors.txt")
 	t.Setenv("BUILDKITE_TEST_ENGINE_FAIL_ON_NO_TESTS", "true")
 	t.Setenv("BUILDKITE_TEST_ENGINE_LOCATION_PREFIX", "app/")
 	t.Setenv("BUILDKITE_TEST_ENGINE_RETRY_COUNT", "3")
@@ -196,6 +197,7 @@ func TestRunCommandEnvVarsBindToConfig(t *testing.T) {
 		{"ResultPath", cfg.ResultPath, "/tmp/results.json"},
 		{"SplitByExample", cfg.SplitByExample, true},
 		{"SelectorSplitting", cfg.SelectorSplitting, true},
+		{"SelectorListPath", cfg.SelectorListPath, "selectors.txt"},
 		{"FailOnNoTests", cfg.FailOnNoTests, true},
 		{"LocationPrefix", cfg.LocationPrefix, "app/"},
 		{"MaxRetries", cfg.MaxRetries, 3},

--- a/docs/custom-test-runner.md
+++ b/docs/custom-test-runner.md
@@ -27,39 +27,6 @@ You can exclude specific files or directories that match a certain pattern using
 export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=tests/api
 ```
 
-## Splitting by selector
-
-> [!NOTE]
-> Selector-based splitting is experimental and may change.
-
-By default bktec discovers and splits work by test file. If your test suite is better divided by something other than a file path, for example a tag, scenario, or package, you can split by selector instead.
-
-A selector is an arbitrary string that your test command understands. You provide them in a file with one selector per line, and bktec distributes them across parallel nodes the same way it distributes test files. The selectors assigned to each node replace `{{testExamples}}` in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
-
-To enable it, set `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true` and point `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` at your selector file. When selector splitting is enabled, `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` is required and `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` is not used.
-
-```sh
-export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
-export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/test {{testExamples}}"
-export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
-export BUILDKITE_TEST_ENGINE_SELECTOR_FILE="path/to/selectors.txt"
-bktec run
-```
-
-Given a `selectors.txt` like this:
-
-```
-checkout
-search
-account
-```
-
-The actual command that bktec runs on each node will look like this:
-
-```sh
-bin/test checkout search
-```
-
 ## Muting test results
 If you have [Test state and quarantine](https://buildkite.com/docs/test-engine/test-suites/test-state-and-quarantine#lifecycle-states-mute-recommended) enabled in your Buildkite Test Suite, you can configure bktec to mute test results. When this is configured, failure from muted tests will not cause the build to fail.
 

--- a/docs/custom-test-runner.md
+++ b/docs/custom-test-runner.md
@@ -27,6 +27,39 @@ You can exclude specific files or directories that match a certain pattern using
 export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=tests/api
 ```
 
+## Splitting by selector
+
+> [!NOTE]
+> Selector-based splitting is experimental and may change.
+
+By default bktec discovers and splits work by test file. If your test suite is better divided by something other than a file path, for example a tag, scenario, or package, you can split by selector instead.
+
+A selector is an arbitrary string that your test command understands. You provide them in a file with one selector per line, and bktec distributes them across parallel nodes the same way it distributes test files. The selectors assigned to each node replace `{{testExamples}}` in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
+
+To enable it, set `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true` and point `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` at your selector file. When selector splitting is enabled, `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` is required and `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` is not used.
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
+export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/test {{testExamples}}"
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+export BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH="path/to/selectors.txt"
+bktec run
+```
+
+Given a `selectors.txt` like this:
+
+```
+checkout
+search
+account
+```
+
+The actual command that bktec runs on each node will look like this:
+
+```sh
+bin/test checkout search
+```
+
 ## Muting test results
 If you have [Test state and quarantine](https://buildkite.com/docs/test-engine/test-suites/test-state-and-quarantine#lifecycle-states-mute-recommended) enabled in your Buildkite Test Suite, you can configure bktec to mute test results. When this is configured, failure from muted tests will not cause the build to fail.
 

--- a/docs/custom-test-runner.md
+++ b/docs/custom-test-runner.md
@@ -36,13 +36,13 @@ By default bktec discovers and splits work by test file. If your test suite is b
 
 A selector is an arbitrary string that your test command understands. You provide them in a file with one selector per line, and bktec distributes them across parallel nodes the same way it distributes test files. The selectors assigned to each node replace `{{testExamples}}` in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
 
-To enable it, set `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true` and point `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` at your selector file. When selector splitting is enabled, `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` is required and `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` is not used.
+To enable it, set `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true` and point `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` at your selector file. When selector splitting is enabled, `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` is required and `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` is not used.
 
 ```sh
 export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
 export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/test {{testExamples}}"
 export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
-export BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH="path/to/selectors.txt"
+export BUILDKITE_TEST_ENGINE_SELECTOR_FILE="path/to/selectors.txt"
 bktec run
 ```
 

--- a/internal/command/files.go
+++ b/internal/command/files.go
@@ -11,16 +11,18 @@ import (
 
 func getTestFiles(fileList string, testRunner runner.TestRunner) ([]string, error) {
 	if fileList != "" {
-		return getTestFilesFromFile(fileList)
+		return getRowsFromFile(fileList)
 	} else {
 		return testRunner.GetFiles()
 	}
 }
 
-func getTestFilesFromFile(path string) ([]string, error) {
+// getRowsFromFile reads a text file and returns each non-empty, trimmed line as
+// a row. It's used for any newline-delimited list, such as test files or selectors.
+func getRowsFromFile(path string) ([]string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't read files from %s", path)
+		return nil, fmt.Errorf("couldn't read rows from %s", path)
 	}
 
 	contentType := http.DetectContentType(content)
@@ -29,17 +31,17 @@ func getTestFilesFromFile(path string) ([]string, error) {
 	}
 
 	lines := strings.Split(string(content), "\n")
-	fileNames := []string{}
+	rows := []string{}
 	for _, line := range lines {
 		trimmedLine := strings.TrimSpace(line)
 		if trimmedLine != "" {
-			fileNames = append(fileNames, trimmedLine)
+			rows = append(rows, trimmedLine)
 		}
 	}
 
-	if len(fileNames) == 0 {
-		return nil, fmt.Errorf("no test files found in %s", path)
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("no rows found in %s", path)
 	}
 
-	return fileNames, nil
+	return rows, nil
 }

--- a/internal/command/get_test_files_from_file_test.go
+++ b/internal/command/get_test_files_from_file_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGetTestFilesFromFile(t *testing.T) {
-	files, err := getTestFilesFromFile("testdata/test_file_discovery/list.txt")
+func TestGetRowsFromFile(t *testing.T) {
+	rows, err := getRowsFromFile("testdata/test_file_discovery/list.txt")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -19,21 +19,21 @@ func TestGetTestFilesFromFile(t *testing.T) {
 		"./c_spec.rb",
 		"./spec/my spec.rb",
 	}
-	if diff := cmp.Diff(files, expected); diff != "" {
-		t.Errorf("files diff (-got +want):\n%s", diff)
+	if diff := cmp.Diff(rows, expected); diff != "" {
+		t.Errorf("rows diff (-got +want):\n%s", diff)
 	}
 }
 
-func TestGetTestFilesFromFile_Dir(t *testing.T) {
-	_, err := getTestFilesFromFile("testdata")
+func TestGetRowsFromFile_Dir(t *testing.T) {
+	_, err := getRowsFromFile("testdata")
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
 }
 
-func TestGetTestFilesFromFile_BinaryFile(t *testing.T) {
+func TestGetRowsFromFile_BinaryFile(t *testing.T) {
 	path := "testdata/test_file_discovery/image.png"
-	_, err := getTestFilesFromFile(path)
+	_, err := getRowsFromFile(path)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -44,13 +44,13 @@ func TestGetTestFilesFromFile_BinaryFile(t *testing.T) {
 	}
 }
 
-func TestGetTestFilesFromFile_EmptyFile(t *testing.T) {
+func TestGetRowsFromFile_EmptyFile(t *testing.T) {
 	path := "testdata/test_file_discovery/empty_list.txt"
-	_, err := getTestFilesFromFile(path)
+	_, err := getRowsFromFile(path)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
-	expectedError := fmt.Sprintf("no test files found in %s", path)
+	expectedError := fmt.Sprintf("no rows found in %s", path)
 	if err.Error() != expectedError {
 		t.Fatalf("expected error: %q, got %v", expectedError, err)
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -134,14 +134,14 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 	return cmd
 }
 
-func createTestPlan(ctx context.Context, cfg *config.Config, files []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
+func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
 	fallbackPlan := plan.TestPlan{
 		Identifier:  cfg.Identifier,
 		Parallelism: cfg.MaxParallelism,
 		Fallback:    true,
 	}
 
-	params, err := createRequestParam(ctx, cfg, files, *apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
 		return fallbackPlan, err
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -416,7 +416,7 @@ func logSignalAndExit(name string, signal syscall.Signal) {
 
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, files []string, testRunner runner.TestRunner) (plan.TestPlan, error) {
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, testTargets []string, testRunner runner.TestRunner) (plan.TestPlan, error) {
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.
@@ -426,7 +426,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 		if handledErr := handleError(err); handledErr != nil {
 			return plan.TestPlan{}, handledErr
 		}
-		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
 	}
 
 	if cachedPlan != nil {
@@ -434,7 +434,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
 			warnErrorPlan()
-			return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
+			return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
 		}
 
 		debug.Printf("Test plan found. Identifier: %q", cfg.Identifier)
@@ -443,12 +443,12 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 
 	debug.Println("No test plan found, creating a new plan")
 	// If the cache is empty, create a new plan.
-	params, err := createRequestParam(ctx, cfg, files, *apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
 			return plan.TestPlan{}, handledErr
 		}
-		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
 	}
 
 	debug.Println("Creating test plan")
@@ -458,14 +458,14 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 		if handledErr := handleError(err); handledErr != nil {
 			return plan.TestPlan{}, handledErr
 		}
-		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
-		return plan.CreateFallbackPlan(files, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
 	}
 
 	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)

--- a/internal/command/test_target.go
+++ b/internal/command/test_target.go
@@ -7,7 +7,11 @@ import (
 
 func getTestTargets(cfg *config.Config, runner runner.TestRunner, testFileList string) ([]string, error) {
 	if shouldUseSelectorSplitting(cfg, runner) {
-		return runner.GetSelectors()
+		if cfg.SelectorListPath != "" {
+			return getRowsFromFile(cfg.SelectorListPath)
+		} else {
+			return runner.GetSelectors()
+		}
 	}
 
 	return getTestFiles(testFileList, runner)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,8 @@ type Config struct {
 	UploadToken string `json:"-"`
 	// SelectorSplitting enables selector-based splitting for supported runners.
 	SelectorSplitting bool `json:"-"`
+	// File path containing the list of selectors to run. If not set, `bktec` will rely on each runner implementation of `GetSelectors`
+	SelectorListPath string `json:"-"`
 	// SplitByExample is the flag to enable split the test by example.
 	SplitByExample bool   `json:"-"`
 	StepID         string `json:"-"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// splitBySelectorList reports whether the run is splitting work using a
+// user-provided selector list instead of discovered test files. In this mode
+// test file discovery is skipped, so TestFilePattern isn't required.
+func (c *Config) splitBySelectorList() bool {
+	return c.SelectorSplitting && c.SelectorListPath != ""
+}
+
 // Checks common to all commands
 func (c *Config) validate() error {
 	if c.MaxRetries < 0 {
@@ -80,7 +87,7 @@ func (c *Config) validate() error {
 		}
 		// A selector list replaces test file discovery, so the file pattern
 		// isn't required when splitting by a provided selector list.
-		if c.TestFilePattern == "" && !(c.SelectorSplitting && c.SelectorListPath != "") {
+		if c.TestFilePattern == "" && !c.splitBySelectorList() {
 			c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN", "must not be blank when using the custom test runner")
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -78,7 +78,9 @@ func (c *Config) validate() error {
 		if c.TestCommand == "" {
 			c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_TEST_CMD", "must not be blank when using the custom test runner")
 		}
-		if c.TestFilePattern == "" {
+		// A selector list replaces test file discovery, so the file pattern
+		// isn't required when splitting by a provided selector list.
+		if c.TestFilePattern == "" && !(c.SelectorSplitting && c.SelectorListPath != "") {
 			c.errs.appendFieldError("BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN", "must not be blank when using the custom test runner")
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -94,6 +94,10 @@ func (c *Config) validate() error {
 		c.errs.appendFieldError("selection-param", "selection strategy must be set when selection params are provided")
 	}
 
+	if c.SelectorListPath != "" && !c.SelectorSplitting {
+		c.errs.appendFieldError("selectors", "selector splitting must be enabled when a selector list is provided")
+	}
+
 	if len(c.errs) > 0 {
 		return c.errs
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -50,6 +50,38 @@ func TestConfigValidate_SelectorSplittingIsPermissive(t *testing.T) {
 	})
 }
 
+func TestConfigValidate_SelectorListRequiresSelectorSplitting(t *testing.T) {
+	t.Run("rejects a selector list without selector splitting", func(t *testing.T) {
+		c := createConfig()
+		c.SelectorListPath = "selectors.txt"
+
+		err := c.validate()
+		if err == nil {
+			t.Fatalf("config.validate() error = nil, want InvalidConfigError")
+		}
+
+		var invConfigError InvalidConfigError
+		if !errors.As(err, &invConfigError) {
+			t.Fatalf("config.validate() error = %v, want InvalidConfigError", err)
+		}
+
+		want := "selector splitting must be enabled when a selector list is provided"
+		if got := invConfigError["selectors"][0].Error(); got != want {
+			t.Errorf("config.validate() error for selectors = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("accepts a selector list when selector splitting is enabled", func(t *testing.T) {
+		c := createConfig()
+		c.SelectorListPath = "selectors.txt"
+		c.SelectorSplitting = true
+
+		if err := c.validate(); err != nil {
+			t.Errorf("config.validate() error = %v, want nil", err)
+		}
+	})
+}
+
 func TestConfigValidate_Empty(t *testing.T) {
 	c := Config{errs: InvalidConfigError{}}
 	err := c.validate()

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -82,6 +82,37 @@ func TestConfigValidate_SelectorListRequiresSelectorSplitting(t *testing.T) {
 	})
 }
 
+func TestConfigValidate_CustomRunnerFilePatternWithSelectorList(t *testing.T) {
+	t.Run("requires a file pattern for the custom runner by default", func(t *testing.T) {
+		c := createConfig()
+		c.TestRunner = "custom"
+		c.TestCommand = "bin/test"
+		c.TestFilePattern = ""
+
+		err := c.validate()
+		var invConfigError InvalidConfigError
+		if !errors.As(err, &invConfigError) {
+			t.Fatalf("config.validate() error = %v, want InvalidConfigError", err)
+		}
+		if _, ok := invConfigError["BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN"]; !ok {
+			t.Errorf("config.validate() = %v, want a TEST_FILE_PATTERN error", invConfigError)
+		}
+	})
+
+	t.Run("does not require a file pattern when splitting by a selector list", func(t *testing.T) {
+		c := createConfig()
+		c.TestRunner = "custom"
+		c.TestCommand = "bin/test"
+		c.TestFilePattern = ""
+		c.SelectorSplitting = true
+		c.SelectorListPath = "selectors.txt"
+
+		if err := c.validate(); err != nil {
+			t.Errorf("config.validate() error = %v, want nil", err)
+		}
+	})
+}
+
 func TestConfigValidate_Empty(t *testing.T) {
 	c := Config{errs: InvalidConfigError{}}
 	err := c.validate()

--- a/internal/plan/fallback.go
+++ b/internal/plan/fallback.go
@@ -8,9 +8,9 @@ import (
 
 // CreateFallbackPlan creates a fallback test plan for the given tests and parallelism.
 // It distributes test cases evenly across the tasks using deterministic algorithm.
-func CreateFallbackPlan(files []string, parallelism int) TestPlan {
+func CreateFallbackPlan(testTargets []string, parallelism int) TestPlan {
 	// sort all test cases
-	slices.SortFunc(files, func(a, b string) int {
+	slices.SortFunc(testTargets, func(a, b string) int {
 		return cmp.Compare(a, b)
 	})
 
@@ -22,12 +22,12 @@ func CreateFallbackPlan(files []string, parallelism int) TestPlan {
 		}
 	}
 
-	// distribute files to tasks
-	for i, file := range files {
+	// distribute test targets to tasks
+	for i, target := range testTargets {
 		nodeNumber := i % parallelism
 		task := tasks[strconv.Itoa(nodeNumber)]
 		task.Tests = append(task.Tests, TestCase{
-			Path: file,
+			Path: target,
 		})
 	}
 

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -41,6 +41,7 @@ func (c Custom) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       false,
 		Mute:            true,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -73,6 +74,10 @@ func (r Custom) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (r Custom) GetSelectors() ([]string, error) {
+	return nil, fmt.Errorf("use `--selectors` or `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` to provide the list of selectors")
 }
 
 func (r Custom) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -77,7 +77,7 @@ func (r Custom) GetFiles() ([]string, error) {
 }
 
 func (r Custom) GetSelectors() ([]string, error) {
-	return nil, fmt.Errorf("use `--selectors` or `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` to provide the list of selectors")
+	return nil, fmt.Errorf("use `--selector-file` or `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` to provide the list of selectors")
 }
 
 func (r Custom) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -19,7 +19,7 @@ func NewCustom(r RunnerConfig) (Custom, error) {
 		return Custom{}, errors.New("test command must be provided for custom runner")
 	}
 
-	if r.TestFilePattern == "" {
+	if r.TestFilePattern == "" && !r.splitBySelectorList() {
 		return Custom{}, errors.New("test file pattern must be provided for custom runner")
 	}
 

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -56,8 +56,8 @@ func TestCustom_GetExamples(t *testing.T) {
 func TestCustom_GetFiles(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "./test {{testExamples}}",
-		TestFilePattern: "tests/**/test_*.sh",
+		TestCommand:     "bats {{testExamples}}",
+		TestFilePattern: "tests/*.bats",
 	})
 
 	if err != nil {
@@ -70,8 +70,9 @@ func TestCustom_GetFiles(t *testing.T) {
 	}
 
 	want := []string{
-		"tests/test_a.sh",
-		"tests/test_b.sh",
+		"tests/failed_test.bats",
+		"tests/flaky_test.bats",
+		"tests/happy_test.bats",
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
@@ -128,8 +129,8 @@ func TestCustom_CommandNameAndArgs(t *testing.T) {
 func TestCustom_Run(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "./test {{testExamples}}",
-		TestFilePattern: "tests/**/test_*.sh",
+		TestCommand:     "bats {{testExamples}}",
+		TestFilePattern: "tests/**/*.bats",
 	})
 
 	if err != nil {
@@ -137,8 +138,7 @@ func TestCustom_Run(t *testing.T) {
 	}
 
 	testCases := []plan.TestCase{
-		{Path: "./tests/test_a.sh"},
-		{Path: "./tests/test_b.sh"},
+		{Path: "./tests/happy_test.bats"},
 	}
 
 	result := NewRunResult([]plan.TestCase{})
@@ -155,8 +155,8 @@ func TestCustom_Run(t *testing.T) {
 func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "./test {{testExamples}}",
-		TestFilePattern: "./tests/**/test_*.sh",
+		TestCommand:     "bats {{testExamples}}",
+		TestFilePattern: "tests/**/*.bats",
 	})
 
 	if err != nil {
@@ -164,7 +164,7 @@ func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
 	}
 
 	testCases := []plan.TestCase{
-		{Path: "./tests/fail_test.sh"},
+		{Path: "./tests/failed_test.bats"},
 	}
 	result := NewRunResult([]plan.TestCase{})
 	err = custom.Run(result, testCases, false)
@@ -180,9 +180,9 @@ func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
 func TestCustom_Run_TestFailedWithXMLResult(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "./test {{testExamples}}",
-		TestFilePattern: "./tests/**/test_*.sh",
-		ResultPath:      "./test-result.xml",
+		TestCommand:     "bats --report-formatter junit --output tmp/ {{testExamples}}",
+		TestFilePattern: "tests/**/*.bats",
+		ResultPath:      "tmp/report.xml",
 	})
 
 	if err != nil {
@@ -190,8 +190,7 @@ func TestCustom_Run_TestFailedWithXMLResult(t *testing.T) {
 	}
 
 	testCases := []plan.TestCase{
-		{Path: "./tests/test_a.sh"},
-		{Path: "./tests/fail_test.sh"},
+		{Path: "./tests/failed_test.bats"},
 	}
 	result := NewRunResult([]plan.TestCase{})
 	err = custom.Run(result, testCases, false)
@@ -203,16 +202,16 @@ func TestCustom_Run_TestFailedWithXMLResult(t *testing.T) {
 		t.Errorf("Custom.Run() RunResult.Status = %v, want %v", result.Status(), RunStatusFailed)
 	}
 
-	if len(result.tests) != 2 {
-		t.Errorf("Custom.Run() len(RunResult.tests) = %d, want %d", len(result.tests), 2)
+	if len(result.tests) != 1 {
+		t.Errorf("Custom.Run() len(RunResult.tests) = %d, want %d", len(result.tests), 1)
 	}
 }
 
 func TestCustom_Run_TestFailedWithJSONResult(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "./test {{testExamples}}",
-		TestFilePattern: "./tests/**/test_*.sh",
+		TestCommand:     "bats {{testExamples}}",
+		TestFilePattern: "tests/**/*.bats",
 		ResultPath:      "./test-result.json",
 	})
 
@@ -221,8 +220,8 @@ func TestCustom_Run_TestFailedWithJSONResult(t *testing.T) {
 	}
 
 	testCases := []plan.TestCase{
-		{Path: "./tests/test_a.sh"},
-		{Path: "./tests/fail_test.sh"},
+		{Path: "./tests/happy_test.bats"},
+		{Path: "./tests/failed_test.bats"},
 	}
 	result := NewRunResult([]plan.TestCase{})
 	err = custom.Run(result, testCases, false)

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -1,7 +1,9 @@
 package runner
 
 import (
+	"fmt"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
@@ -179,10 +181,12 @@ func TestCustom_Run_TestFailedWithoutResult(t *testing.T) {
 
 func TestCustom_Run_TestFailedWithXMLResult(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
+	tmpDir := t.TempDir()
+
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "bats --report-formatter junit --output tmp/ {{testExamples}}",
+		TestCommand:     fmt.Sprintf("bats --report-formatter junit --output %s {{testExamples}}", tmpDir),
 		TestFilePattern: "tests/**/*.bats",
-		ResultPath:      "tmp/report.xml",
+		ResultPath:      filepath.Join(tmpDir, "report.xml"),
 	})
 
 	if err != nil {

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -39,6 +39,21 @@ func TestCustom_NewCustom_MissingTestFilePattern(t *testing.T) {
 	}
 }
 
+func TestCustom_NewCustom_SelectorListWithoutTestFilePattern(t *testing.T) {
+	// When splitting by a provided selector list, test file discovery is
+	// skipped, so an empty TestFilePattern should be allowed.
+	_, err := NewCustom(RunnerConfig{
+		TestCommand:       "bin/test",
+		TestFilePattern:   "",
+		SelectorSplitting: true,
+		SelectorListPath:  "selectors.txt",
+	})
+
+	if err != nil {
+		t.Errorf("NewCustom() error = %v, want nil", err)
+	}
+}
+
 func TestCustom_GetExamples(t *testing.T) {
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "bin/test",

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -18,6 +18,8 @@ func DetectRunner(cfg *config.Config) (TestRunner, error) {
 		TestFileExcludePattern: cfg.TestFileExcludePattern,
 		TestFilePattern:        cfg.TestFilePattern,
 		uploadToken:            cfg.UploadToken,
+		SelectorSplitting:      cfg.SelectorSplitting,
+		SelectorListPath:       cfg.SelectorListPath,
 	}
 
 	switch testRunner := cfg.TestRunner; testRunner {

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -16,6 +16,18 @@ type RunnerConfig struct {
 	TestFileExcludePattern string
 	TestFilePattern        string
 	uploadToken            string
+
+	// SelectorSplitting enables selector-based splitting for this runner.
+	SelectorSplitting bool
+	// SelectorListPath points at a file containing the selectors to run.
+	SelectorListPath string
+}
+
+// splitBySelectorList reports whether the runner is splitting work using a
+// user-provided selector list instead of discovered test files. In this mode
+// test file discovery is skipped, so TestFilePattern isn't required.
+func (rc RunnerConfig) splitBySelectorList() bool {
+	return rc.SelectorSplitting && rc.SelectorListPath != ""
 }
 
 func (rc RunnerConfig) LocationPrefix() string {

--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -1,8 +1,11 @@
 package runner
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
-func TestSupportedFeatures_SplitBySelectorOnlyGotest(t *testing.T) {
+func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 	runnerConfig := RunnerConfig{
 		ResultPath:       "results.json",
 		TestCommand:      "test-command",
@@ -15,22 +18,34 @@ func TestSupportedFeatures_SplitBySelectorOnlyGotest(t *testing.T) {
 		t.Fatalf("NewCustom() error = %v", err)
 	}
 
+	rspec := NewRspec(runnerConfig)
+	jest := NewJest(runnerConfig)
+	playwright := NewPlaywright(runnerConfig)
+	cypress := NewCypress(runnerConfig)
+	pytest := NewPytest(runnerConfig)
+	pytestPants := NewPytestPants(runnerConfig)
+	gotest := NewGoTest(runnerConfig)
+	cucumber := NewCucumber(runnerConfig)
+	nunit := NewNUnit(runnerConfig)
+
 	runners := []TestRunner{
-		NewRspec(runnerConfig),
-		NewJest(runnerConfig),
-		NewPlaywright(runnerConfig),
-		NewCypress(runnerConfig),
-		NewPytest(runnerConfig),
-		NewPytestPants(runnerConfig),
-		NewGoTest(runnerConfig),
-		NewCucumber(runnerConfig),
-		NewNUnit(runnerConfig),
 		custom,
+		rspec,
+		jest,
+		playwright,
+		cypress,
+		pytest,
+		pytestPants,
+		gotest,
+		cucumber,
+		nunit,
 	}
+
+	supportedRunners := []string{gotest.Name(), custom.Name()}
 
 	for _, runner := range runners {
 		got := runner.SupportedFeatures().SplitBySelector
-		want := runner.Name() == "gotest"
+		want := slices.Contains(supportedRunners, runner.Name())
 		if got != want {
 			t.Errorf("%s SplitBySelector = %v, want %v", runner.Name(), got, want)
 		}

--- a/internal/runner/testdata/custom/selectors.txt
+++ b/internal/runner/testdata/custom/selectors.txt
@@ -1,0 +1,3 @@
+tests/failed_test.bats
+tests/flaky_test.bats
+tests/happy_test.bats

--- a/internal/runner/testdata/custom/test
+++ b/internal/runner/testdata/custom/test
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-for arg in "$@"; do
-  bash "$arg"
-done

--- a/internal/runner/testdata/custom/test-result.json
+++ b/internal/runner/testdata/custom/test-result.json
@@ -1,10 +1,8 @@
 [
   {
-    "id": "db2c4ffa-efee-4b6a-b293-a4c4168aa353",
-    "scope": "My test",
-    "name": "test a",
-    "location": "./tests/test_a.sh:1",
-    "file_name": "./tests/test_a.sh",
+    "scope": "tests/happy_test.bats",
+    "name": "happy",
+    "file_name": "tests/happy_test.bats",
     "result": "passed",
     "failure_reason": "",
     "failure_expanded": [],
@@ -16,13 +14,11 @@
     }
   },
   {
-    "id": "95f7e024-9e0a-450f-bc64-9edb62d43fa9",
-    "scope": "My test",
-    "name": "failed test",
-    "location": "./tests/fail_test.sh:1",
-    "file_name": "./tests/fail_test.sh",
+    "scope": "tests/failed_test.bats",
+    "name": "failed",
+    "file_name": "tests/failed_test.bats",
     "result": "failed",
-    "failure_reason": "Failure/Error: expect(true).to eq false",
+    "failure_reason": "`[ \"$status\" -eq 0 ]' failed",
     "failure_expanded": [],
     "history": {
       "start_at": 347611.724809,

--- a/internal/runner/testdata/custom/test-result.xml
+++ b/internal/runner/testdata/custom/test-result.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<testsuites>
-  <testsuite name="My test" tests="2" errors="0" failures="1" skipped="0">
-    <testcase classname="My test" name="test a" time="0.726" />
-    <testcase classname="My test" name="failed test" time="0.726">
-      <failure message="Failure/Error: expect(true).to eq false">AssertionError: expected true to equal false</failure>
-    </testcase>
-  </testsuite>
-</testsuites>

--- a/internal/runner/testdata/custom/tests/fail_test.sh
+++ b/internal/runner/testdata/custom/tests/fail_test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running fail_test.sh"
-echo "  Failed"
-exit 1

--- a/internal/runner/testdata/custom/tests/failed_test.bats
+++ b/internal/runner/testdata/custom/tests/failed_test.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "failed" {
+  run bash -c 'echo "something went wrong" >&2; exit 1'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"something went wrong"* ]]
+}

--- a/internal/runner/testdata/custom/tests/flaky_test.bats
+++ b/internal/runner/testdata/custom/tests/flaky_test.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+@test "flaky" {
+  run bash -c '
+    if [ $((RANDOM % 2)) -eq 0 ]; then
+      echo "fail"
+      exit 1
+    fi
+    echo "pass"
+    exit 0
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "pass" ]]
+}

--- a/internal/runner/testdata/custom/tests/happy_test.bats
+++ b/internal/runner/testdata/custom/tests/happy_test.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "happy" {
+  run bash -c 'echo "ok"; exit 0'
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}

--- a/internal/runner/testdata/custom/tests/test_a.sh
+++ b/internal/runner/testdata/custom/tests/test_a.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running test_a.sh"

--- a/internal/runner/testdata/custom/tests/test_b.sh
+++ b/internal/runner/testdata/custom/tests/test_b.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running test_b.sh"

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -13,7 +13,11 @@ func testCasesFromPaths(paths []string) []plan.TestCase {
 func pathsFromTestCases(testCases []plan.TestCase) []string {
 	paths := make([]string, len(testCases))
 	for i, tc := range testCases {
-		paths[i] = tc.Path
+		if tc.Format == plan.TestCaseFormatSelector {
+			paths[i] = tc.Value
+		} else {
+			paths[i] = tc.Path
+		}
 	}
 	return paths
 }


### PR DESCRIPTION
### Description

Selector-based splitting is currently only supported by the Go runner. We want to bring it to the other runners too, and this PR is the first step, starting with the custom runner. This is still experimental and may change.

Splitting by selector lets you divide a suite by something other than a test file, like a tag or package. The custom runner can't auto-discover selectors the way the Go runner does with `go list`, so instead you point bktec at a file with one selector per line. bktec distributes those selectors across parallel nodes the same way it distributes test files, and the selectors assigned to each node replace `{{testExamples}}` in `BUILDKITE_TEST_ENGINE_TEST_CMD`.

To use it:

```sh
export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/test {{testExamples}}"
export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
export BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH="path/to/selectors.txt"
bktec run
```

Since it's still experimental, the new `--selectors` flag (`BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH`) is hidden for now.

### Context

- Linear: [TE-6225](https://linear.app/buildkite/issue/TE-6225/support-selector-based-splitting-for-custom-runner)
- Parent: TE-6222 (added `GetSelectors` and selector splitting for the Go runner)

### Changes

- Added the `--selectors` flag / `BUILDKITE_TEST_ENGINE_SELECTOR_LIST_PATH` env var for providing a selector list file. When a selector file is given it takes precedence over a runner's own `GetSelectors`, so this also lets the Go runner read selectors from a file instead of auto-discovering them
- Taught the custom runner to support selector splitting, sourcing selectors from the file
- Required `--selector-splitting` to be enabled when a selector list is provided, with validation
- Documented selector splitting in the custom runner docs

Also, while working on this I moved the custom runner test fixtures over to bats and made sure bats gets installed in the pipeline Dockerfile and `bin/setup`.

### Testing

Covered by unit tests for the new validation and the supported-features changes, plus the bats-based custom runner test fixtures.
