### PR TITLE
[TE-6253] Simplify parallelism-1 split summary after server drops known_timings_ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+- At parallelism 1 the split summary now prints only the case count without a known/unknown timing breakdown. The server no longer emits `known_timings_ratio` at parallelism 1 (it skips the timing fetch), so the previous breakdown was derived from a value the server no longer sends.
 - Add `--plan-identifier` (env: `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`. The identifier sets the plan's server-side cache key, and supplying it lets `plan` run off-agent without `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`. Previously this flag was only available on `bktec run`.
 - `bktec plan` no longer requires `BUILDKITE_TEST_ENGINE_RESULT_PATH` (`--result-path`). The value is only used when running tests, so planning never needed it. `bktec run` still requires it for runners that read a result file.
 

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -8,12 +8,12 @@ import (
 
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
 // to w (typically os.Stderr). At parallelism > 1 it uses per-format
-// TimingMetadata to break down known vs unknown cases. At parallelism == 1
-// the server skips per-format timing data due to performance reasons, so it falls back to the
-// plan-level KnownTimingsRatio. Skipped for fallback plans, or when neither
-// signal is available.
+// TimingMetadata to break down known vs unknown cases. At parallelism == 1 the
+// server skips the per-format timing fetch and emits an empty TimingMetadata,
+// so only the header and case count are printed. Skipped for fallback plans and
+// plans without TimingMetadata at all (e.g. error or older cached plans).
 func PrintSplitSummary(w io.Writer, p TestPlan) {
-	if p.Fallback || (p.TimingMetadata == nil && p.KnownTimingsRatio == nil) {
+	if p.Fallback || p.TimingMetadata == nil {
 		return
 	}
 
@@ -34,16 +34,9 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	fmt.Fprintf(w, "%d %s across %d %s\n",
 		total, pluralize(total, noun), nodes, pluralize(nodes, "node"))
 
-	// At parallelism == 1 the server skips the per-format timing fetch, so
-	// per-case TimingSampleSize is always 0. Fall back to the plan-level
-	// known_timings_ratio for a meaningful breakdown.
-	if nodes <= 1 && p.KnownTimingsRatio != nil {
-		printRatioBreakdown(w, total, *p.KnownTimingsRatio, noun)
-		fmt.Fprintln(w)
-		return
-	}
-
-	if p.TimingMetadata == nil {
+	// At parallelism == 1 the server skips the per-format timing fetch and
+	// emits an empty TimingMetadata, so there is no breakdown to print.
+	if p.TimingMetadata.File == nil && p.TimingMetadata.Example == nil && p.TimingMetadata.Selector == nil {
 		fmt.Fprintln(w)
 		return
 	}
@@ -58,18 +51,6 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 		printFormatBreakdown(w, selectorTotal, selectorKnown, "selector", p.TimingMetadata.Selector, mixed)
 	}
 	fmt.Fprintln(w)
-}
-
-// printRatioBreakdown renders a single-node summary using the plan-level
-// known_timings_ratio. Per-format metadata is unavailable at parallelism == 1,
-// so it delegates to printFormatBreakdown with meta == nil; the breakdown text
-// is rendered without parenthesised duration values.
-func printRatioBreakdown(w io.Writer, total int, ratio float64, noun string) {
-	known := int(float64(total)*ratio + 0.5)
-	if known > total {
-		known = total
-	}
-	printFormatBreakdown(w, total, known, noun, nil, false)
 }
 
 // countByFormat returns (total, known) for cases of the given format. The

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -111,10 +111,9 @@ func TestPrintSplitSummary_SkipsWhenNoMetadata(t *testing.T) {
 	}
 }
 
-func TestPrintSplitSummary_ParallelismOneUsesKnownRatio(t *testing.T) {
-	// At parallelism=1 the server skips per-format timing metadata, so the
-	// summary derives counts from the plan-level known_timings_ratio.
-	ratio := 0.75
+func TestPrintSplitSummary_ParallelismOneNoBreakdown(t *testing.T) {
+	// At parallelism=1 the server skips the per-format timing fetch and emits an
+	// empty timing_metadata, so the summary prints only the header and count.
 	p := TestPlan{
 		Parallelism: 1,
 		Tasks: map[string]*Task{
@@ -122,43 +121,17 @@ func TestPrintSplitSummary_ParallelismOneUsesKnownRatio(t *testing.T) {
 				{Path: "a"}, {Path: "b"}, {Path: "c"}, {Path: "d"},
 			}},
 		},
-		TimingMetadata:    &TimingMetadata{},
-		KnownTimingsRatio: &ratio,
+		TimingMetadata: &TimingMetadata{},
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
 	got := buf.String()
 
-	for _, want := range []string{
-		"4 files across 1 node",
-		"3 files (75%) estimated from past historical durations",
-		"1 file (25%) had no history",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("output missing %q\nfull output:\n%s", want, got)
-		}
+	if !strings.Contains(got, "4 files across 1 node") {
+		t.Errorf("output missing count line\nfull output:\n%s", got)
 	}
-}
-
-func TestPrintSplitSummary_ParallelismOneZeroRatio(t *testing.T) {
-	ratio := 0.0
-	p := TestPlan{
-		Parallelism: 1,
-		Tasks: map[string]*Task{
-			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}, {Path: "b"}}},
-		},
-		TimingMetadata:    &TimingMetadata{},
-		KnownTimingsRatio: &ratio,
-	}
-	var buf bytes.Buffer
-	PrintSplitSummary(&buf, p)
-	got := buf.String()
-
-	if !strings.Contains(got, "2 files (100%) had no history") {
-		t.Errorf("expected all-no-history line, got:\n%s", got)
-	}
-	if strings.Contains(got, "estimated from past") {
-		t.Errorf("unexpected estimated line at ratio=0:\n%s", got)
+	if strings.Contains(got, "estimated from past") || strings.Contains(got, "had no history") {
+		t.Errorf("unexpected breakdown at parallelism 1:\n%s", got)
 	}
 }
 

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -77,7 +77,8 @@ type TestPlan struct {
 	// the server began emitting it).
 	TimingMetadata *TimingMetadata `json:"timing_metadata,omitempty"`
 	// KnownTimingsRatio is the fraction (0.0–1.0) of cases that had historical
-	// timing data when the plan was built. Used to summarise plans where
-	// per-format timing metadata is not emitted (e.g. parallelism == 1).
+	// timing data when the plan was built. The server only emits it at
+	// parallelism > 1, where the split summary instead uses per-format
+	// TimingMetadata. Currently unread; retained for wire compatibility.
 	KnownTimingsRatio *float64 `json:"known_timings_ratio,omitempty"`
 }


### PR DESCRIPTION
### Description

Simplify the parallelism-1 branch of the split-summary printer now that the server no longer emits `known_timings_ratio` at parallelism 1.

At parallelism 1 the server skips the per-format timing fetch and sends `timing_metadata: {}` with no `known_timings_ratio` (buildkite/buildkite#30725). `PrintSplitSummary` previously derived a known/unknown breakdown at parallelism 1 from that ratio, so the branch is now dead. The client already treated the field as optional (pointer + `omitempty`), so this is a cleanup rather than a fix for a break. At parallelism 1 the summary now prints the header and case count without a breakdown; parallelism > 1 is unchanged and still uses per-format `TimingMetadata`.

`KnownTimingsRatio` stays on the `TestPlan` struct for wire compatibility even though nothing reads it now; removing the field is a later cleanup.

### Context

- TE-6253: https://linear.app/buildkite/issue/TE-6253
- Server change: buildkite/buildkite#30725 (TE-6247)

### Changes

- Remove the parallelism-1 `known_timings_ratio` branch and the `printRatioBreakdown` helper in `internal/plan/summary.go`.
- Gate the summary on `TimingMetadata` presence; suppress the breakdown when all per-format metadata is absent (parallelism 1).
- Replace the two parallelism-1 ratio tests with one asserting header-only output.
- Changelog entry; note the retained-but-unread `KnownTimingsRatio` field.

### Testing

Backed by specs. `go test ./internal/plan/...` passes. `go vet` and `gofmt` clean. The pre-existing `internal/runner` Jest test SIGSEGV is unrelated (that package is untouched and fails identically on `main`).
