### PR TITLE
[TE-6254] Add --plan-out output mode to bktec plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+- Add `--full-json` to `bktec plan`. It prints the full test plan (tasks, per-node test breakdown, muted and skipped tests, and timing metadata) to stdout as JSON without running the tests, so you can pull down a copy of the plan. `--json`, `--full-json` and `--pipeline-upload` are mutually exclusive.
 - At parallelism 1 the split summary now prints only the case count without a known/unknown timing breakdown. The server no longer emits `known_timings_ratio` at parallelism 1 (it skips the timing fetch), so the previous breakdown was derived from a value the server no longer sends.
 - Add `--plan-identifier` (env: `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`. The identifier sets the plan's server-side cache key, and supplying it lets `plan` run off-agent without `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`. Previously this flag was only available on `bktec run`.
 - `bktec plan` no longer requires `BUILDKITE_TEST_ENGINE_RESULT_PATH` (`--result-path`). The value is only used when running tests, so planning never needed it. `bktec run` still requires it for runners that read a result file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## Unreleased
-- Add `--full-json` to `bktec plan`. It prints the full test plan (tasks, per-node test breakdown, muted and skipped tests, and timing metadata) to stdout as JSON without running the tests, so you can pull down a copy of the plan. `--json`, `--full-json` and `--pipeline-upload` are mutually exclusive.
+- Add `--plan-out` to `bktec plan`. It writes the full test plan (tasks, per-node test breakdown, muted and skipped tests, and timing metadata) as the server's response, unmodified, without running the tests, so you can pull down a copy of the plan. Takes a destination: `-` for stdout, or a file path. `--json`, `--plan-out` and `--pipeline-upload` are mutually exclusive.
 - At parallelism 1 the split summary now prints only the case count without a known/unknown timing breakdown. The server no longer emits `known_timings_ratio` at parallelism 1 (it skips the timing fetch), so the previous breakdown was derived from a value the server no longer sends.
 - Add `--plan-identifier` (env: `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) to `bktec plan`. The identifier sets the plan's server-side cache key, and supplying it lets `plan` run off-agent without `BUILDKITE_BUILD_ID`/`BUILDKITE_STEP_ID`. Previously this flag was only available on `bktec run`.
 - `bktec plan` no longer requires `BUILDKITE_TEST_ENGINE_RESULT_PATH` (`--result-path`). The value is only used when running tests, so planning never needed it. `bktec run` still requires it for runners that read a result file.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ the muted and skipped tests, and the timing metadata. It takes a destination:
 `-` for stdout, or a file path.
 
 ```sh
-./bktec plan --plan-out - > plan.json    # stdout
-./bktec plan --plan-out plan.json        # a file
+./bktec plan --plan-out -            # stdout
+./bktec plan --plan-out plan.json    # a file
 ```
 
 The human-readable split summary and any warnings are written to stderr, so

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ tests, the muted and skipped tests, and the timing metadata. Redirect stdout to
 keep a copy:
 
 ```sh
-./bktec plan --full-json --plan-identifier "$(uuidgen)" > plan.json
+./bktec plan --full-json ... > plan.json
 ```
 
 The human-readable split summary and any warnings are written to stderr, so

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ The human-readable split summary and any warnings are written to stderr, so
 stdout carries only the JSON. `--json`, `--full-json` and `--pipeline-upload`
 are mutually exclusive; choose one.
 
+`--full-json` prints what the server returns. If the server cannot generate a
+plan it returns an empty plan, which is emitted as-is (a warning is printed to
+stderr). Only when the server cannot be reached at all does `bktec` fall back to
+a locally-computed plan, again noting this on stderr.
+
 ### Preview: Test Selection
 You can pass test selection strategy configuration and additional change context to the test plan API request.
 This preview is enabled only when `BKTEC_PREVIEW_SELECTION` is truthy (`1`, `true`, `yes`, or `on`).

--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ identifier, or, on a cache miss, creates and caches one under it. A reused
 identifier therefore returns the previously cached plan even if the inputs have
 changed, so keep the value unique per distinct plan.
 
+### Inspecting the full plan
+
+`--full-json` makes `bktec plan` print the full test plan to stdout as JSON,
+without running any tests. Unlike `--json`, which emits only the plan identifier
+and parallelism, `--full-json` includes the tasks, the per-node breakdown of
+tests, the muted and skipped tests, and the timing metadata. Redirect stdout to
+keep a copy:
+
+```sh
+./bktec plan --full-json --plan-identifier "$(uuidgen)" > plan.json
+```
+
+The human-readable split summary and any warnings are written to stderr, so
+stdout carries only the JSON. `--json`, `--full-json` and `--pipeline-upload`
+are mutually exclusive; choose one.
+
 ### Preview: Test Selection
 You can pass test selection strategy configuration and additional change context to the test plan API request.
 This preview is enabled only when `BKTEC_PREVIEW_SELECTION` is truthy (`1`, `true`, `yes`, or `on`).

--- a/README.md
+++ b/README.md
@@ -129,24 +129,25 @@ changed, so keep the value unique per distinct plan.
 
 ### Inspecting the full plan
 
-`--full-json` makes `bktec plan` print the full test plan to stdout as JSON,
-without running any tests. Unlike `--json`, which emits only the plan identifier
-and parallelism, `--full-json` includes the tasks, the per-node breakdown of
-tests, the muted and skipped tests, and the timing metadata. Redirect stdout to
-keep a copy:
+`--plan-out` makes `bktec plan` write the full test plan without running any
+tests. Unlike `--json`, which emits only the plan identifier and parallelism,
+`--plan-out` writes the whole plan: the tasks, the per-node breakdown of tests,
+the muted and skipped tests, and the timing metadata. It takes a destination:
+`-` for stdout, or a file path.
 
 ```sh
-./bktec plan --full-json ... > plan.json
+./bktec plan --plan-out - > plan.json    # stdout
+./bktec plan --plan-out plan.json        # a file
 ```
 
 The human-readable split summary and any warnings are written to stderr, so
-stdout carries only the JSON. `--json`, `--full-json` and `--pipeline-upload`
+stdout carries only the plan. `--json`, `--plan-out` and `--pipeline-upload`
 are mutually exclusive; choose one.
 
-`--full-json` prints what the server returns. If the server cannot generate a
-plan it returns an empty plan, which is emitted as-is (a warning is printed to
-stderr). Only when the server cannot be reached at all does `bktec` fall back to
-a locally-computed plan, again noting this on stderr.
+`--plan-out` writes what the server returns, unmodified. If the server cannot
+generate a plan it returns an empty plan, which is emitted as-is (a warning is
+printed to stderr). Only when the server cannot be reached at all does `bktec`
+fall back to a locally-computed plan, again noting this on stderr.
 
 ### Preview: Test Selection
 You can pass test selection strategy configuration and additional change context to the test plan API request.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ are mutually exclusive; choose one.
 `--plan-out` writes what the server returns, unmodified. If the server cannot
 generate a plan it returns an empty plan, which is emitted as-is (a warning is
 printed to stderr). Only when the server cannot be reached at all does `bktec`
-fall back to a locally-computed plan, again noting this on stderr.
+fall back to a minimal locally-generated plan; this carries the identifier and
+parallelism but no tasks (it is not a computed split), and is noted on stderr.
 
 ### Preview: Test Selection
 You can pass test selection strategy configuration and additional change context to the test plan API request.

--- a/cli.go
+++ b/cli.go
@@ -467,6 +467,11 @@ var jsonFlag = &cli.BoolFlag{
 	Usage: "JSON format output",
 }
 
+var fullJSONFlag = &cli.BoolFlag{
+	Name:  "full-json",
+	Usage: "print the full test plan (tasks, per-node test breakdown, muted/skipped tests and timing metadata) as JSON to stdout, without running the tests",
+}
+
 var pipelineUploadFlag = &cli.StringFlag{
 	Name:  "pipeline-upload",
 	Usage: "buildkite-agent pipeline upload will be executed with the provided `template.yml`. The additional enviroment variables BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER and BUILDKITE_TEST_ENGINE_PARALLELISM from the generated plan will be available to the template.",
@@ -666,6 +671,7 @@ var cliCommand = &cli.Command{
 					Category: "PLAN OUTPUT",
 					Flags: [][]cli.Flag{
 						{jsonFlag},
+						{fullJSONFlag},
 						{pipelineUploadFlag},
 					},
 				},

--- a/cli.go
+++ b/cli.go
@@ -467,9 +467,10 @@ var jsonFlag = &cli.BoolFlag{
 	Usage: "JSON format output",
 }
 
-var fullJSONFlag = &cli.BoolFlag{
-	Name:  "full-json",
-	Usage: "print the full test plan (tasks, per-node test breakdown, muted/skipped tests and timing metadata) as JSON to stdout, without running the tests",
+var planOutFlag = &cli.StringFlag{
+	Name:        "plan-out",
+	Usage:       "write the full test plan (the server's test plan response, unmodified) to `PATH`, or `-` for stdout, without running the tests",
+	Destination: &cfg.PlanOut,
 }
 
 var pipelineUploadFlag = &cli.StringFlag{
@@ -671,7 +672,7 @@ var cliCommand = &cli.Command{
 					Category: "PLAN OUTPUT",
 					Flags: [][]cli.Flag{
 						{jsonFlag},
-						{fullJSONFlag},
+						{planOutFlag},
 						{pipelineUploadFlag},
 					},
 				},

--- a/cli_test.go
+++ b/cli_test.go
@@ -74,6 +74,52 @@ func TestPlanCommandIncludesPlanIdentifierFlag(t *testing.T) {
 	}
 }
 
+func TestPlanCommandIncludesFullJSONOutputFlag(t *testing.T) {
+	planCmd := findCommand(cliCommand, "plan")
+	if planCmd == nil {
+		t.Fatal("cliCommand missing the plan subcommand")
+	}
+
+	if !mutuallyExclusiveGroupHasFlag(planCmd, "PLAN OUTPUT", "full-json") {
+		t.Fatalf("plan command's PLAN OUTPUT group missing --full-json; `bktec plan --full-json` cannot emit the full plan")
+	}
+}
+
+// --full-json belongs to the required, mutually-exclusive PLAN OUTPUT group, so
+// it cannot be combined with --json and one output flag must be supplied.
+func TestPlanFullJSONIsMutuallyExclusiveWithJSON(t *testing.T) {
+	cfg = config.New()
+	t.Cleanup(func() { cfg = config.New() })
+
+	err := cliCommand.Run(context.Background(), []string{"bktec", "plan", "--json", "--full-json"})
+	if err == nil {
+		t.Fatal("expected an error when --json and --full-json are combined, got nil")
+	}
+}
+
+func findCommand(root *cli.Command, name string) *cli.Command {
+	for _, c := range root.Commands {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func mutuallyExclusiveGroupHasFlag(cmd *cli.Command, category, name string) bool {
+	for _, group := range cmd.MutuallyExclusiveFlags {
+		if group.Category != category {
+			continue
+		}
+		for _, flags := range group.Flags {
+			if hasFlag(flags, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestApplyPlanRequestContext_ClearsCollectGitMetadataWhenPreviewDisabled(t *testing.T) {
 	t.Setenv(previewSelectionEnvVar, "")
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -74,70 +74,35 @@ func TestPlanCommandIncludesPlanIdentifierFlag(t *testing.T) {
 	}
 }
 
+// --full-json is registered in the plan command's mutually-exclusive PLAN
+// OUTPUT group, so it is a valid output mode and cannot be combined with --json
+// or --pipeline-upload.
 func TestPlanCommandIncludesFullJSONOutputFlag(t *testing.T) {
-	planCmd := findCommand(cliCommand, "plan")
+	var planCmd *cli.Command
+	for _, c := range cliCommand.Commands {
+		if c.Name == "plan" {
+			planCmd = c
+		}
+	}
 	if planCmd == nil {
 		t.Fatal("cliCommand missing the plan subcommand")
 	}
 
-	if !mutuallyExclusiveGroupHasFlag(planCmd, "PLAN OUTPUT", "full-json") {
-		t.Fatalf("plan command's PLAN OUTPUT group missing --full-json; `bktec plan --full-json` cannot emit the full plan")
-	}
-}
-
-// --full-json belongs to the required, mutually-exclusive PLAN OUTPUT group, so
-// it cannot be combined with --json. Exercised on a fresh command with fresh
-// flag instances, so it doesn't mutate the package-global cliCommand/flag state
-// that other tests reuse.
-func TestPlanFullJSONIsMutuallyExclusiveWithJSON(t *testing.T) {
-	cmd := &cli.Command{
-		Name: "bktec",
-		Commands: []*cli.Command{
-			{
-				Name:   "plan",
-				Action: func(ctx context.Context, cmd *cli.Command) error { return nil },
-				MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{
-					{
-						Required: true,
-						Category: "PLAN OUTPUT",
-						Flags: [][]cli.Flag{
-							{&cli.BoolFlag{Name: "json"}},
-							{&cli.BoolFlag{Name: "full-json"}},
-							{&cli.StringFlag{Name: "pipeline-upload"}},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err := cmd.Run(context.Background(), []string{"bktec", "plan", "--json", "--full-json"})
-	if err == nil {
-		t.Fatal("expected an error when --json and --full-json are combined, got nil")
-	}
-}
-
-func findCommand(root *cli.Command, name string) *cli.Command {
-	for _, c := range root.Commands {
-		if c.Name == name {
-			return c
-		}
-	}
-	return nil
-}
-
-func mutuallyExclusiveGroupHasFlag(cmd *cli.Command, category, name string) bool {
-	for _, group := range cmd.MutuallyExclusiveFlags {
-		if group.Category != category {
+	found := false
+	for _, group := range planCmd.MutuallyExclusiveFlags {
+		if group.Category != "PLAN OUTPUT" {
 			continue
 		}
 		for _, flags := range group.Flags {
-			if hasFlag(flags, name) {
-				return true
+			if hasFlag(flags, "full-json") {
+				found = true
 			}
 		}
 	}
-	return false
+
+	if !found {
+		t.Fatal("plan command's PLAN OUTPUT group missing --full-json")
+	}
 }
 
 func TestApplyPlanRequestContext_ClearsCollectGitMetadataWhenPreviewDisabled(t *testing.T) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -74,10 +74,10 @@ func TestPlanCommandIncludesPlanIdentifierFlag(t *testing.T) {
 	}
 }
 
-// --full-json is registered in the plan command's mutually-exclusive PLAN
+// --plan-out is registered in the plan command's mutually-exclusive PLAN
 // OUTPUT group, so it is a valid output mode and cannot be combined with --json
 // or --pipeline-upload.
-func TestPlanCommandIncludesFullJSONOutputFlag(t *testing.T) {
+func TestPlanCommandIncludesPlanOutOutputFlag(t *testing.T) {
 	var planCmd *cli.Command
 	for _, c := range cliCommand.Commands {
 		if c.Name == "plan" {
@@ -94,14 +94,14 @@ func TestPlanCommandIncludesFullJSONOutputFlag(t *testing.T) {
 			continue
 		}
 		for _, flags := range group.Flags {
-			if hasFlag(flags, "full-json") {
+			if hasFlag(flags, "plan-out") {
 				found = true
 			}
 		}
 	}
 
 	if !found {
-		t.Fatal("plan command's PLAN OUTPUT group missing --full-json")
+		t.Fatal("plan command's PLAN OUTPUT group missing --plan-out")
 	}
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -86,12 +86,32 @@ func TestPlanCommandIncludesFullJSONOutputFlag(t *testing.T) {
 }
 
 // --full-json belongs to the required, mutually-exclusive PLAN OUTPUT group, so
-// it cannot be combined with --json and one output flag must be supplied.
+// it cannot be combined with --json. Exercised on a fresh command with fresh
+// flag instances, so it doesn't mutate the package-global cliCommand/flag state
+// that other tests reuse.
 func TestPlanFullJSONIsMutuallyExclusiveWithJSON(t *testing.T) {
-	cfg = config.New()
-	t.Cleanup(func() { cfg = config.New() })
+	cmd := &cli.Command{
+		Name: "bktec",
+		Commands: []*cli.Command{
+			{
+				Name:   "plan",
+				Action: func(ctx context.Context, cmd *cli.Command) error { return nil },
+				MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{
+					{
+						Required: true,
+						Category: "PLAN OUTPUT",
+						Flags: [][]cli.Flag{
+							{&cli.BoolFlag{Name: "json"}},
+							{&cli.BoolFlag{Name: "full-json"}},
+							{&cli.StringFlag{Name: "pipeline-upload"}},
+						},
+					},
+				},
+			},
+		},
+	}
 
-	err := cliCommand.Run(context.Background(), []string{"bktec", "plan", "--json", "--full-json"})
+	err := cmd.Run(context.Background(), []string{"bktec", "plan", "--json", "--full-json"})
 	if err == nil {
 		t.Fatal("expected an error when --json and --full-json are combined, got nil")
 	}

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -52,4 +53,30 @@ func (c Client) CreateTestPlan(ctx context.Context, suiteSlug string, params Tes
 	}
 
 	return testPlan, nil
+}
+
+// CreateTestPlanRaw is like CreateTestPlan but also returns the raw JSON
+// response body from the server, unmodified. Callers that want to surface the
+// server's exact response (rather than a re-marshalled struct) use the raw
+// bytes, and use the decoded plan for control-flow decisions.
+// ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
+func (c Client) CreateTestPlanRaw(ctx context.Context, suiteSlug string, params TestPlanParams) (plan.TestPlan, json.RawMessage, error) {
+	postURL := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan", c.ServerBaseURL, c.OrganizationSlug, suiteSlug)
+
+	var raw json.RawMessage
+	_, err := c.doJSONWithRetry(ctx, httpRequest{
+		Method: http.MethodPost,
+		URL:    postURL,
+		Body:   params,
+	}, &raw)
+	if err != nil {
+		return plan.TestPlan{}, nil, err
+	}
+
+	var testPlan plan.TestPlan
+	if err := json.Unmarshal(raw, &testPlan); err != nil {
+		return plan.TestPlan{}, nil, fmt.Errorf("parsing test plan: %w", err)
+	}
+
+	return testPlan, raw, nil
 }

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -104,6 +104,49 @@ func TestCreateTestPlan(t *testing.T) {
 	}
 }
 
+func TestCreateTestPlanRaw(t *testing.T) {
+	// Include a field the client struct does not model to confirm the raw bytes
+	// are returned verbatim.
+	serverBody := `{"identifier":"facecafe","parallelism":2,"tasks":{"0":{"node_number":0,"tests":[{"path":"sky_spec.rb"}]}},"server_only":"kept"}`
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = io.WriteString(w, serverBody)
+	}))
+	defer svr.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	apiClient := NewClient(ClientConfig{
+		AccessToken:      "asdf1234",
+		OrganizationSlug: "buildkite",
+		ServerBaseURL:    svr.URL,
+	})
+
+	gotPlan, gotRaw, err := apiClient.CreateTestPlanRaw(ctx, "rspec", TestPlanParams{Identifier: "facecafe"})
+	if err != nil {
+		t.Fatalf("CreateTestPlanRaw() error = %v", err)
+	}
+
+	// Raw bytes are returned unmodified.
+	if string(gotRaw) != serverBody {
+		t.Errorf("CreateTestPlanRaw() raw = %s, want %s", gotRaw, serverBody)
+	}
+
+	// The decoded plan is also returned for control-flow decisions.
+	wantPlan := plan.TestPlan{
+		Identifier:  "facecafe",
+		Parallelism: 2,
+		Tasks: map[string]*plan.Task{
+			"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "sky_spec.rb"}}},
+		},
+	}
+	if diff := cmp.Diff(gotPlan, wantPlan); diff != "" {
+		t.Errorf("CreateTestPlanRaw() plan diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCreateTestPlan_SplitByExample(t *testing.T) {
 	params := TestPlanParams{
 		Identifier:  "abc123",

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -133,10 +134,12 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	return nil
 }
 
-// fullPlanOutput mirrors the server's test_plan endpoint response, so
-// --full-json emits the same shape a fetch of that endpoint would. It
-// deliberately omits plan.TestPlan.Fallback, which is client-internal and
-// untagged (it would otherwise leak as "Fallback": <bool>).
+// fullPlanOutput mirrors the server's test_plan endpoint response. It is used
+// only for the locally-computed fallback plan (when the server is unreachable),
+// so that fallback output matches the server's shape. It deliberately omits
+// plan.TestPlan.Fallback, which is client-internal and untagged (it would
+// otherwise leak as "Fallback": <bool>). Plans that come from the server are
+// passed through as their raw JSON, not via this struct.
 type fullPlanOutput struct {
 	Identifier        string                `json:"identifier"`
 	Parallelism       int                   `json:"parallelism"`
@@ -168,7 +171,15 @@ func newFullPlanOutput(p plan.TestPlan) fullPlanOutput {
 // reflects what the server has. A locally-computed fallback is used only when
 // the server cannot be reached at all, since there is nothing to pass through.
 func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) error {
-	testPlan, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
+	if err != nil {
+		if handledErr := handleError(err); handledErr != nil {
+			return handledErr
+		}
+		return emitLocalFallback(cfg, testTargets)
+	}
+
+	testPlan, raw, err := apiClient.CreateTestPlanRaw(ctx, cfg.SuiteSlug, params)
 	if err != nil {
 		// Fatal errors (auth, forbidden, bad request) are returned; soft
 		// errors (timeout, billing, disabled, not found) fall through to a
@@ -176,36 +187,53 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 		if handledErr := handleError(err); handledErr != nil {
 			return handledErr
 		}
-		fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
-		testPlan = makeFallbackPlan(cfg, testTargets)
-	} else if len(testPlan.Tasks) == 0 {
-		// The server returned an error plan (`{"tasks": {}}`). Pass it through
-		// verbatim rather than substituting a fallback, so --full-json reflects
-		// the server's actual response.
+		return emitLocalFallback(cfg, testTargets)
+	}
+
+	// The server responded. Emit its exact JSON, unmodified. An error plan
+	// (`{"tasks": {}}`) is passed through verbatim so --full-json reflects the
+	// server's actual response; we only warn about it on stderr.
+	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
 	}
 
-	if testPlan.Fallback {
-		debug.Printf("Using fallback plan. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
-	} else {
-		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
-	}
-
+	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	plan.PrintSplitSummary(os.Stderr, testPlan)
-
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}
 
-	encoded, err := json.MarshalIndent(newFullPlanOutput(testPlan), "", "  ")
+	return writeIndentedJSON(raw)
+}
+
+// emitLocalFallback writes a locally-computed fallback plan, used by --full-json
+// when the server cannot be reached and there is nothing to pass through.
+func emitLocalFallback(cfg *config.Config, testTargets []string) error {
+	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
+
+	testPlan := makeFallbackPlan(cfg, testTargets)
+	plan.PrintSplitSummary(os.Stderr, testPlan)
+	if testPlan.Parallelism == 0 {
+		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
+	}
+
+	encoded, err := json.Marshal(newFullPlanOutput(testPlan))
 	if err != nil {
 		return err
 	}
+	return writeIndentedJSON(encoded)
+}
 
-	if _, err := fmt.Fprintln(planWriter, string(encoded)); err != nil {
+// writeIndentedJSON re-indents raw JSON and writes it to planWriter, leaving the
+// content (keys, values, order) untouched.
+func writeIndentedJSON(raw []byte) error {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
 		return err
 	}
-
+	if _, err := fmt.Fprintln(planWriter, buf.String()); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -176,7 +176,7 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 		if handledErr := handleError(err); handledErr != nil {
 			return handledErr
 		}
-		return emitLocalFallback(cfg, testTargets)
+		return emitLocalFallback(cfg)
 	}
 
 	testPlan, raw, err := apiClient.CreateTestPlanRaw(ctx, cfg.SuiteSlug, params)
@@ -187,7 +187,7 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 		if handledErr := handleError(err); handledErr != nil {
 			return handledErr
 		}
-		return emitLocalFallback(cfg, testTargets)
+		return emitLocalFallback(cfg)
 	}
 
 	// The server responded. Emit its exact JSON, unmodified. An error plan
@@ -206,13 +206,13 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 	return writeIndentedJSON(raw)
 }
 
-// emitLocalFallback writes a locally-computed fallback plan, used by --full-json
-// when the server cannot be reached and there is nothing to pass through.
-func emitLocalFallback(cfg *config.Config, testTargets []string) error {
+// emitLocalFallback writes a locally-computed fallback plan as JSON, used by
+// --full-json when the server cannot be reached and there is nothing to pass
+// through.
+func emitLocalFallback(cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
 
-	testPlan := makeFallbackPlan(cfg, testTargets)
-	plan.PrintSplitSummary(os.Stderr, testPlan)
+	testPlan := makeFallbackPlan(cfg)
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}
@@ -245,59 +245,38 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 	return cmd
 }
 
-// requestTestPlan requests a plan from the server and returns it verbatim,
-// without substituting a local fallback. The returned plan may be an "error
-// plan" with an empty task list (i.e. `{"tasks": {}}`) when the server could
-// not generate one; callers that need a runnable plan should fall back
-// themselves.
-func requestTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
-	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
-	if err != nil {
-		return plan.TestPlan{}, err
+// makeFallbackPlan returns the locally-computed fallback plan used when the
+// server cannot generate or return one.
+func makeFallbackPlan(cfg *config.Config) plan.TestPlan {
+	return plan.TestPlan{
+		Identifier:  cfg.Identifier,
+		Parallelism: cfg.MaxParallelism,
+		Fallback:    true,
 	}
-
-	return apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
 }
 
 // createTestPlan requests a plan and substitutes a locally-computed fallback
 // when the server errors or returns an error plan, so the caller always gets a
-// runnable plan. Used by the --json and --pipeline-upload output modes.
+// plan. Used by the --json and --pipeline-upload output modes.
 func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
-	testPlan, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
+	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
-		return makeFallbackPlan(cfg, testTargets), err
+		return makeFallbackPlan(cfg), err
+	}
+
+	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
+	if err != nil {
+		return makeFallbackPlan(cfg), err
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
-		return makeFallbackPlan(cfg, testTargets), nil
+		return makeFallbackPlan(cfg), nil
 	}
 
 	return testPlan, nil
-}
-
-func makeFallbackPlan(cfg *config.Config, testTargets []string) plan.TestPlan {
-	parallelism := fallbackParallelism(cfg)
-	fallbackPlan := plan.CreateFallbackPlan(testTargets, parallelism)
-	fallbackPlan.Identifier = cfg.Identifier
-	fallbackPlan.Parallelism = parallelism
-	return fallbackPlan
-}
-
-// fallbackParallelism resolves the parallelism for a locally-computed fallback
-// plan. It prefers the dynamic --max-parallelism, then BUILDKITE_PARALLEL_JOB_COUNT,
-// and finally 1, so the fallback always has at least one node to distribute
-// files across (plan.CreateFallbackPlan divides by parallelism).
-func fallbackParallelism(cfg *config.Config) int {
-	if cfg.MaxParallelism > 0 {
-		return cfg.MaxParallelism
-	}
-	if cfg.Parallelism > 0 {
-		return cfg.Parallelism
-	}
-	return 1
 }
 
 // autoCollectGitMetadata collects git commit metadata and merges it into

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -24,7 +24,7 @@ type PlanOutput int
 const (
 	PlanOutputJSON PlanOutput = iota
 	PlanOutputPipelineUpload
-	PlanOutputFullJSON
+	PlanOutputPlanOut
 )
 
 var planWriter io.Writer = os.Stdout
@@ -61,10 +61,10 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 
 	debug.Println("Creating test plan via API")
 
-	// --full-json emits what the server returns, so it takes a distinct path
+	// --plan-out emits what the server returns, so it takes a distinct path
 	// that does not substitute a local fallback for a server error plan.
-	if outputFormat == PlanOutputFullJSON {
-		return fullJSONPlan(ctx, cfg, testTargets, apiClient, testRunner)
+	if outputFormat == PlanOutputPlanOut {
+		return planOut(ctx, cfg, testTargets, apiClient, testRunner)
 	}
 
 	testPlan, err := createTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
@@ -134,13 +134,20 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	return nil
 }
 
-// fullJSONPlan emits the plan as the server's test_plan endpoint would return
-// it. Unlike the --json and --pipeline-upload modes it does not substitute a
-// local fallback for a server error plan: the server's response (including an
-// empty error plan) is passed through verbatim, so the output faithfully
-// reflects what the server has. A locally-computed fallback is used only when
-// the server cannot be reached at all, since there is nothing to pass through.
-func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) error {
+// planOut writes the plan as the server's test_plan endpoint would return it to
+// the destination given by cfg.PlanOut ("-" for stdout, otherwise a file).
+// Unlike the --json and --pipeline-upload modes it does not substitute a local
+// fallback for a server error plan: the server's response (including an empty
+// error plan) is passed through verbatim, so the output faithfully reflects
+// what the server has. A locally-computed fallback is used only when the server
+// cannot be reached at all, since there is nothing to pass through.
+func planOut(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) error {
+	out, closeOut, err := planOutWriter(cfg.PlanOut)
+	if err != nil {
+		return err
+	}
+	defer closeOut()
+
 	testPlan, raw, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
 	if err != nil {
 		// Fatal errors (auth, forbidden, bad request) are returned; soft
@@ -149,11 +156,11 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 		if handledErr := handleError(err); handledErr != nil {
 			return handledErr
 		}
-		return emitLocalFallback(cfg)
+		return emitLocalFallback(out, cfg)
 	}
 
 	// The server responded. Emit its exact JSON, unmodified. An error plan
-	// (`{"tasks": {}}`) is passed through verbatim so --full-json reflects the
+	// (`{"tasks": {}}`) is passed through verbatim so --plan-out reflects the
 	// server's actual response. We warn on stderr, but not via warnErrorPlan:
 	// that appends a "falling back to non-intelligent splitting" notice, which
 	// is untrue here since we emit the server's plan rather than a fallback.
@@ -167,14 +174,29 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}
 
-	return writeIndentedJSON(raw)
+	return writeIndentedJSON(out, raw)
+}
+
+// planOutWriter resolves the --plan-out destination: "-" writes to planWriter
+// (stdout), any other value creates (or truncates) that file. The returned
+// close function closes a file destination, and is a no-op for stdout.
+func planOutWriter(dest string) (io.Writer, func(), error) {
+	if dest == "-" {
+		return planWriter, func() {}, nil
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening --plan-out file: %w", err)
+	}
+	return f, func() { f.Close() }, nil
 }
 
 // emitLocalFallback writes a locally-computed fallback plan as JSON, used by
-// --full-json when the server cannot be reached and there is nothing to pass
+// --plan-out when the server cannot be reached and there is nothing to pass
 // through. The fallback carries no tasks, so only the identifier and
 // parallelism are emitted.
-func emitLocalFallback(cfg *config.Config) error {
+func emitLocalFallback(out io.Writer, cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
 
 	// A fixed-shape struct of plain fields, so marshalling cannot fail.
@@ -188,18 +210,18 @@ func emitLocalFallback(cfg *config.Config) error {
 		Tasks:       map[string]*plan.Task{},
 	}, "", "  ")
 
-	_, err := fmt.Fprintln(planWriter, string(encoded))
+	_, err := fmt.Fprintln(out, string(encoded))
 	return err
 }
 
-// writeIndentedJSON re-indents raw JSON and writes it to planWriter, leaving the
+// writeIndentedJSON re-indents raw JSON and writes it to out, leaving the
 // content (keys, values, order) untouched.
-func writeIndentedJSON(raw []byte) error {
+func writeIndentedJSON(out io.Writer, raw []byte) error {
 	var buf bytes.Buffer
 	if err := json.Indent(&buf, raw, "", "  "); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(planWriter, buf.String()); err != nil {
+	if _, err := fmt.Fprintln(out, buf.String()); err != nil {
 		return err
 	}
 	return nil

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -212,10 +212,9 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 func emitLocalFallback(cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
 
-	encoded, err := json.Marshal(newFullPlanOutput(makeFallbackPlan(cfg)))
-	if err != nil {
-		return err
-	}
+	// The fallback is a fixed-shape struct of plain fields, so marshalling
+	// cannot fail.
+	encoded, _ := json.Marshal(newFullPlanOutput(makeFallbackPlan(cfg)))
 	return writeIndentedJSON(encoded)
 }
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -182,30 +182,46 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 }
 
 func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
-	fallbackPlan := plan.TestPlan{
-		Identifier:  cfg.Identifier,
-		Parallelism: cfg.MaxParallelism,
-		Fallback:    true,
+	makeFallbackPlan := func() plan.TestPlan {
+		parallelism := fallbackParallelism(cfg)
+		fallbackPlan := plan.CreateFallbackPlan(testTargets, parallelism)
+		fallbackPlan.Identifier = cfg.Identifier
+		fallbackPlan.Parallelism = parallelism
+		return fallbackPlan
 	}
 
 	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
-		return fallbackPlan, err
+		return makeFallbackPlan(), err
 	}
 
 	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
 	if err != nil {
-		return fallbackPlan, err
+		return makeFallbackPlan(), err
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
-		return fallbackPlan, nil
+		return makeFallbackPlan(), nil
 	}
 
 	return testPlan, nil
+}
+
+// fallbackParallelism resolves the parallelism for a locally-computed fallback
+// plan. It prefers the dynamic --max-parallelism, then BUILDKITE_PARALLEL_JOB_COUNT,
+// and finally 1, so the fallback always has at least one node to distribute
+// files across (plan.CreateFallbackPlan divides by parallelism).
+func fallbackParallelism(cfg *config.Config) int {
+	if cfg.MaxParallelism > 0 {
+		return cfg.MaxParallelism
+	}
+	if cfg.Parallelism > 0 {
+		return cfg.Parallelism
+	}
+	return 1
 }
 
 // autoCollectGitMetadata collects git commit metadata and merges it into

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -134,36 +134,6 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	return nil
 }
 
-// fullPlanOutput mirrors the server's test_plan endpoint response. It is used
-// only for the locally-computed fallback plan (when the server is unreachable),
-// so that fallback output matches the server's shape. It deliberately omits
-// plan.TestPlan.Fallback, which is client-internal and untagged (it would
-// otherwise leak as "Fallback": <bool>). Plans that come from the server are
-// passed through as their raw JSON, not via this struct.
-type fullPlanOutput struct {
-	Identifier        string                `json:"identifier"`
-	Parallelism       int                   `json:"parallelism"`
-	Experiment        string                `json:"experiment"`
-	Tasks             map[string]*plan.Task `json:"tasks"`
-	MutedTests        []plan.TestCase       `json:"muted_tests,omitempty"`
-	SkippedTests      []plan.TestCase       `json:"skipped_tests,omitempty"`
-	TimingMetadata    *plan.TimingMetadata  `json:"timing_metadata,omitempty"`
-	KnownTimingsRatio *float64              `json:"known_timings_ratio,omitempty"`
-}
-
-func newFullPlanOutput(p plan.TestPlan) fullPlanOutput {
-	return fullPlanOutput{
-		Identifier:        p.Identifier,
-		Parallelism:       p.Parallelism,
-		Experiment:        p.Experiment,
-		Tasks:             p.Tasks,
-		MutedTests:        p.MutedTests,
-		SkippedTests:      p.SkippedTests,
-		TimingMetadata:    p.TimingMetadata,
-		KnownTimingsRatio: p.KnownTimingsRatio,
-	}
-}
-
 // fullJSONPlan emits the plan as the server's test_plan endpoint would return
 // it. Unlike the --json and --pipeline-upload modes it does not substitute a
 // local fallback for a server error plan: the server's response (including an
@@ -208,14 +178,24 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 
 // emitLocalFallback writes a locally-computed fallback plan as JSON, used by
 // --full-json when the server cannot be reached and there is nothing to pass
-// through.
+// through. The fallback carries no tasks, so only the identifier and
+// parallelism are emitted.
 func emitLocalFallback(cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
 
-	// The fallback is a fixed-shape struct of plain fields, so marshalling
-	// cannot fail.
-	encoded, _ := json.Marshal(newFullPlanOutput(makeFallbackPlan(cfg)))
-	return writeIndentedJSON(encoded)
+	// A fixed-shape struct of plain fields, so marshalling cannot fail.
+	encoded, _ := json.MarshalIndent(struct {
+		Identifier  string                `json:"identifier"`
+		Parallelism int                   `json:"parallelism"`
+		Tasks       map[string]*plan.Task `json:"tasks"`
+	}{
+		Identifier:  cfg.Identifier,
+		Parallelism: cfg.MaxParallelism,
+		Tasks:       map[string]*plan.Task{},
+	}, "", "  ")
+
+	fmt.Fprintln(planWriter, string(encoded))
+	return nil
 }
 
 // writeIndentedJSON re-indents raw JSON and writes it to planWriter, leaving the

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -23,6 +23,7 @@ type PlanOutput int
 const (
 	PlanOutputJSON PlanOutput = iota
 	PlanOutputPipelineUpload
+	PlanOutputFullJSON
 )
 
 var planWriter io.Writer = os.Stdout
@@ -99,6 +100,24 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 			return err
 		}
 
+	case PlanOutputFullJSON:
+		if testPlan.Parallelism == 0 {
+			fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
+		}
+
+		if testPlan.Fallback {
+			fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
+		}
+
+		encoded, err := json.MarshalIndent(newFullPlanOutput(testPlan), "", "  ")
+		if err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintln(planWriter, string(encoded)); err != nil {
+			return err
+		}
+
 	case PlanOutputPipelineUpload:
 		if testPlan.Parallelism == 0 {
 			fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
@@ -124,6 +143,34 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 	}
 
 	return nil
+}
+
+// fullPlanOutput mirrors the server's test_plan endpoint response, so
+// --full-json emits the same shape a fetch of that endpoint would. It
+// deliberately omits plan.TestPlan.Fallback, which is client-internal and
+// untagged (it would otherwise leak as "Fallback": <bool>).
+type fullPlanOutput struct {
+	Identifier        string                `json:"identifier"`
+	Parallelism       int                   `json:"parallelism"`
+	Experiment        string                `json:"experiment"`
+	Tasks             map[string]*plan.Task `json:"tasks"`
+	MutedTests        []plan.TestCase       `json:"muted_tests,omitempty"`
+	SkippedTests      []plan.TestCase       `json:"skipped_tests,omitempty"`
+	TimingMetadata    *plan.TimingMetadata  `json:"timing_metadata,omitempty"`
+	KnownTimingsRatio *float64              `json:"known_timings_ratio,omitempty"`
+}
+
+func newFullPlanOutput(p plan.TestPlan) fullPlanOutput {
+	return fullPlanOutput{
+		Identifier:        p.Identifier,
+		Parallelism:       p.Parallelism,
+		Experiment:        p.Experiment,
+		Tasks:             p.Tasks,
+		MutedTests:        p.MutedTests,
+		SkippedTests:      p.SkippedTests,
+		TimingMetadata:    p.TimingMetadata,
+		KnownTimingsRatio: p.KnownTimingsRatio,
+	}
 }
 
 func makePipelineUploadCommand(template string) *exec.Cmd {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -154,9 +154,11 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 
 	// The server responded. Emit its exact JSON, unmodified. An error plan
 	// (`{"tasks": {}}`) is passed through verbatim so --full-json reflects the
-	// server's actual response; we only warn about it on stderr.
+	// server's actual response. We warn on stderr, but not via warnErrorPlan:
+	// that appends a "falling back to non-intelligent splitting" notice, which
+	// is untrue here since we emit the server's plan rather than a fallback.
 	if len(testPlan.Tasks) == 0 {
-		warnErrorPlan()
+		fmt.Fprintln(os.Stderr, "⚠️ The Test Engine API returned an empty plan.")
 	}
 
 	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -60,6 +60,12 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 
 	debug.Println("Creating test plan via API")
 
+	// --full-json emits what the server returns, so it takes a distinct path
+	// that does not substitute a local fallback for a server error plan.
+	if outputFormat == PlanOutputFullJSON {
+		return fullJSONPlan(ctx, cfg, testTargets, apiClient, testRunner)
+	}
+
 	testPlan, err := createTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
@@ -97,24 +103,6 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 
 		enc := json.NewEncoder(planWriter)
 		if err = enc.Encode(summary); err != nil {
-			return err
-		}
-
-	case PlanOutputFullJSON:
-		if testPlan.Parallelism == 0 {
-			fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
-		}
-
-		if testPlan.Fallback {
-			fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
-		}
-
-		encoded, err := json.MarshalIndent(newFullPlanOutput(testPlan), "", "  ")
-		if err != nil {
-			return err
-		}
-
-		if _, err := fmt.Fprintln(planWriter, string(encoded)); err != nil {
 			return err
 		}
 
@@ -173,6 +161,54 @@ func newFullPlanOutput(p plan.TestPlan) fullPlanOutput {
 	}
 }
 
+// fullJSONPlan emits the plan as the server's test_plan endpoint would return
+// it. Unlike the --json and --pipeline-upload modes it does not substitute a
+// local fallback for a server error plan: the server's response (including an
+// empty error plan) is passed through verbatim, so the output faithfully
+// reflects what the server has. A locally-computed fallback is used only when
+// the server cannot be reached at all, since there is nothing to pass through.
+func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) error {
+	testPlan, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
+	if err != nil {
+		// Fatal errors (auth, forbidden, bad request) are returned; soft
+		// errors (timeout, billing, disabled, not found) fall through to a
+		// locally-computed fallback since the server returned nothing.
+		if handledErr := handleError(err); handledErr != nil {
+			return handledErr
+		}
+		fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
+		testPlan = makeFallbackPlan(cfg, testTargets)
+	} else if len(testPlan.Tasks) == 0 {
+		// The server returned an error plan (`{"tasks": {}}`). Pass it through
+		// verbatim rather than substituting a fallback, so --full-json reflects
+		// the server's actual response.
+		warnErrorPlan()
+	}
+
+	if testPlan.Fallback {
+		debug.Printf("Using fallback plan. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
+	} else {
+		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
+	}
+
+	plan.PrintSplitSummary(os.Stderr, testPlan)
+
+	if testPlan.Parallelism == 0 {
+		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
+	}
+
+	encoded, err := json.MarshalIndent(newFullPlanOutput(testPlan), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(planWriter, string(encoded)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func makePipelineUploadCommand(template string) *exec.Cmd {
 	args := append(pipelineUploadArgs, template)
 	cmd := exec.Command(pipelineUploadCommand, args...)
@@ -181,33 +217,45 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 	return cmd
 }
 
-func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
-	makeFallbackPlan := func() plan.TestPlan {
-		parallelism := fallbackParallelism(cfg)
-		fallbackPlan := plan.CreateFallbackPlan(testTargets, parallelism)
-		fallbackPlan.Identifier = cfg.Identifier
-		fallbackPlan.Parallelism = parallelism
-		return fallbackPlan
-	}
-
+// requestTestPlan requests a plan from the server and returns it verbatim,
+// without substituting a local fallback. The returned plan may be an "error
+// plan" with an empty task list (i.e. `{"tasks": {}}`) when the server could
+// not generate one; callers that need a runnable plan should fall back
+// themselves.
+func requestTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
 	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
-		return makeFallbackPlan(), err
+		return plan.TestPlan{}, err
 	}
 
-	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
+	return apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
+}
+
+// createTestPlan requests a plan and substitutes a locally-computed fallback
+// when the server errors or returns an error plan, so the caller always gets a
+// runnable plan. Used by the --json and --pipeline-upload output modes.
+func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
+	testPlan, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
 	if err != nil {
-		return makeFallbackPlan(), err
+		return makeFallbackPlan(cfg, testTargets), err
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
-		return makeFallbackPlan(), nil
+		return makeFallbackPlan(cfg, testTargets), nil
 	}
 
 	return testPlan, nil
+}
+
+func makeFallbackPlan(cfg *config.Config, testTargets []string) plan.TestPlan {
+	parallelism := fallbackParallelism(cfg)
+	fallbackPlan := plan.CreateFallbackPlan(testTargets, parallelism)
+	fallbackPlan.Identifier = cfg.Identifier
+	fallbackPlan.Parallelism = parallelism
+	return fallbackPlan
 }
 
 // fallbackParallelism resolves the parallelism for a locally-computed fallback

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -141,15 +141,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 // reflects what the server has. A locally-computed fallback is used only when
 // the server cannot be reached at all, since there is nothing to pass through.
 func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) error {
-	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
-	if err != nil {
-		if handledErr := handleError(err); handledErr != nil {
-			return handledErr
-		}
-		return emitLocalFallback(cfg)
-	}
-
-	testPlan, raw, err := apiClient.CreateTestPlanRaw(ctx, cfg.SuiteSlug, params)
+	testPlan, raw, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
 	if err != nil {
 		// Fatal errors (auth, forbidden, bad request) are returned; soft
 		// errors (timeout, billing, disabled, not found) fall through to a
@@ -229,16 +221,23 @@ func makeFallbackPlan(cfg *config.Config) plan.TestPlan {
 	}
 }
 
+// requestTestPlan builds the request parameters and asks the server for a plan,
+// returning the decoded plan and the raw JSON response. It applies no fallback:
+// callers decide how to handle an error or an empty (error) plan.
+func requestTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, json.RawMessage, error) {
+	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
+	if err != nil {
+		return plan.TestPlan{}, nil, err
+	}
+
+	return apiClient.CreateTestPlanRaw(ctx, cfg.SuiteSlug, params)
+}
+
 // createTestPlan requests a plan and substitutes a locally-computed fallback
 // when the server errors or returns an error plan, so the caller always gets a
 // plan. Used by the --json and --pipeline-upload output modes.
 func createTestPlan(ctx context.Context, cfg *config.Config, testTargets []string, apiClient *api.Client, testRunner runner.TestRunner) (plan.TestPlan, error) {
-	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
-	if err != nil {
-		return makeFallbackPlan(cfg), err
-	}
-
-	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
+	testPlan, _, err := requestTestPlan(ctx, cfg, testTargets, apiClient, testRunner)
 	if err != nil {
 		return makeFallbackPlan(cfg), err
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -212,12 +212,7 @@ func fullJSONPlan(ctx context.Context, cfg *config.Config, testTargets []string,
 func emitLocalFallback(cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
 
-	testPlan := makeFallbackPlan(cfg)
-	if testPlan.Parallelism == 0 {
-		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
-	}
-
-	encoded, err := json.Marshal(newFullPlanOutput(testPlan))
+	encoded, err := json.Marshal(newFullPlanOutput(makeFallbackPlan(cfg)))
 	if err != nil {
 		return err
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -186,8 +186,8 @@ func emitLocalFallback(cfg *config.Config) error {
 		Tasks:       map[string]*plan.Task{},
 	}, "", "  ")
 
-	fmt.Fprintln(planWriter, string(encoded))
-	return nil
+	_, err := fmt.Fprintln(planWriter, string(encoded))
+	return err
 }
 
 // writeIndentedJSON re-indents raw JSON and writes it to planWriter, leaving the

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -135,13 +135,22 @@ func TestPlanFullJSON_Parallelism0(t *testing.T) {
 		t.Errorf("command.Plan(...) error = %v", planErr)
 	}
 
-	// The full plan is still emitted, even at parallelism 0.
+	// The server plan is emitted in full, even at parallelism 0: the
+	// identifier, parallelism, and the task breakdown are all passed through.
 	var got plan.TestPlan
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
 	}
-	if got.Parallelism != 0 {
-		t.Errorf("emitted plan Parallelism = %d, want 0", got.Parallelism)
+
+	want := plan.TestPlan{
+		Identifier:  "facecafe",
+		Parallelism: 0,
+		Tasks: map[string]*plan.Task{
+			"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "testdata/rspec/spec/fruits/apple_spec.rb"}}},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("emitted plan diff (-want +got):\n%s", diff)
 	}
 
 	// The parallelism warning is written to stderr.

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -52,9 +53,9 @@ func TestPlanJSON(t *testing.T) {
 	}
 }
 
-func TestPlanFullJSON(t *testing.T) {
+func TestPlanPlanOut(t *testing.T) {
 	// The server's exact response body, including a field the client struct
-	// does not model (server_only), to prove --full-json passes the response
+	// does not model (server_only), to prove --plan-out passes the response
 	// through unmodified rather than re-marshalling a struct.
 	serverBody := `{"identifier":"facecafe","parallelism":42,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"server_only":"kept"}`
 
@@ -76,6 +77,7 @@ func TestPlanFullJSON(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -87,7 +89,7 @@ func TestPlanFullJSON(t *testing.T) {
 	setPlanWriter(t, &buf)
 
 	// This is the method under test
-	if err := Plan(ctx, cfg, "", PlanOutputFullJSON, ""); err != nil {
+	if err := Plan(ctx, cfg, "", PlanOutputPlanOut, ""); err != nil {
 		t.Errorf("command.Plan(...) error = %v", err)
 	}
 
@@ -99,7 +101,7 @@ func TestPlanFullJSON(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
 	}
 	if gotCompact.String() != serverBody {
-		t.Errorf("full-json output was modified.\n got: %s\nwant: %s", gotCompact.String(), serverBody)
+		t.Errorf("--plan-out output was modified.\n got: %s\nwant: %s", gotCompact.String(), serverBody)
 	}
 
 	// Output should be indented, not compact.
@@ -108,12 +110,69 @@ func TestPlanFullJSON(t *testing.T) {
 	}
 }
 
-func TestPlanFullJSON_Parallelism0(t *testing.T) {
+// --plan-out with a file path writes the plan to that file rather than stdout.
+func TestPlanPlanOut_WritesToFile(t *testing.T) {
+	serverBody := `{"identifier":"facecafe","parallelism":42,"tasks":{"0":{"node_number":0,"tests":[{"path":"a_spec.rb"}]}}}`
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			json.NewEncoder(w).Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			w.Write([]byte(serverBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr.Close()
+
+	outPath := filepath.Join(t.TempDir(), "plan.json")
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = outPath
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	// planWriter (stdout) must stay empty; the plan goes to the file.
+	var stdout bytes.Buffer
+	setPlanWriter(t, &stdout)
+
+	if err := Plan(context.Background(), cfg, "", PlanOutputPlanOut, ""); err != nil {
+		t.Errorf("command.Plan(...) error = %v", err)
+	}
+
+	if stdout.Len() != 0 {
+		t.Errorf("expected no stdout output when writing to a file, got: %s", stdout.String())
+	}
+
+	contents, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("reading --plan-out file: %v", err)
+	}
+
+	var gotCompact bytes.Buffer
+	if err := json.Compact(&gotCompact, contents); err != nil {
+		t.Fatalf("file is not valid JSON: %v\ncontents: %s", err, contents)
+	}
+	if gotCompact.String() != serverBody {
+		t.Errorf("--plan-out file was modified.\n got: %s\nwant: %s", gotCompact.String(), serverBody)
+	}
+}
+
+func TestPlanPlanOut_Parallelism0(t *testing.T) {
 	svr := getZeroParallelismServer()
 	defer svr.Close()
 
 	cfg := getConfig()
 	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -127,7 +186,7 @@ func TestPlanFullJSON_Parallelism0(t *testing.T) {
 	getStderr := captureStderr(t)
 
 	// This is the method under test
-	planErr := Plan(ctx, cfg, "", PlanOutputFullJSON, "")
+	planErr := Plan(ctx, cfg, "", PlanOutputPlanOut, "")
 
 	stderrOutput := getStderr()
 
@@ -930,10 +989,10 @@ func TestPlanJSON_DebugLogging_Fallback(t *testing.T) {
 	}
 }
 
-// When the server cannot be reached (here, a retry timeout), --full-json has
+// When the server cannot be reached (here, a retry timeout), --plan-out has
 // nothing to pass through, so it emits a locally-computed fallback plan on
 // stdout and warns on stderr that it is not a server plan.
-func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
+func TestPlanPlanOut_FallbackWarnsOnStderr(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}))
@@ -943,6 +1002,7 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	cfg.Identifier = "hello"
 	cfg.MaxParallelism = 10
 	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -958,7 +1018,7 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	getStderr := captureStderr(t)
 
 	// This is the method under test
-	planErr := Plan(fetchCtx, cfg, "", PlanOutputFullJSON, "")
+	planErr := Plan(fetchCtx, cfg, "", PlanOutputPlanOut, "")
 
 	stderrOutput := getStderr()
 
@@ -974,7 +1034,7 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
 	}
 	if strings.Contains(strings.ToLower(buf.String()), "fallback") {
-		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
+		t.Errorf("--plan-out output leaked the Fallback field:\n%s", buf.String())
 	}
 	if got.Identifier != "hello" {
 		t.Errorf("fallback plan Identifier = %q, want %q", got.Identifier, "hello")
@@ -989,10 +1049,10 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	}
 }
 
-// When the server returns an error plan (`{"tasks": {}}`), --full-json passes
+// When the server returns an error plan (`{"tasks": {}}`), --plan-out passes
 // it through verbatim rather than substituting a local fallback, so the output
 // reflects the server's actual response. It is not marked as a local fallback.
-func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
+func TestPlanPlanOut_ServerErrorPlanPassedThrough(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
@@ -1014,6 +1074,7 @@ func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -1024,7 +1085,7 @@ func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
 
 	getStderr := captureStderr(t)
 
-	planErr := Plan(context.Background(), cfg, "", PlanOutputFullJSON, "")
+	planErr := Plan(context.Background(), cfg, "", PlanOutputPlanOut, "")
 
 	stderrOutput := getStderr()
 
@@ -1062,9 +1123,9 @@ func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
 }
 
 // A fatal API error (here, 401 Unauthorized) is returned rather than swallowed:
-// --full-json exits with an error and emits nothing on stdout, instead of
+// --plan-out exits with an error and emits nothing on stdout, instead of
 // falling back to a local plan.
-func TestPlanFullJSON_FatalErrorReturnsNoOutput(t *testing.T) {
+func TestPlanPlanOut_FatalErrorReturnsNoOutput(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -1074,6 +1135,7 @@ func TestPlanFullJSON_FatalErrorReturnsNoOutput(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -1082,7 +1144,7 @@ func TestPlanFullJSON_FatalErrorReturnsNoOutput(t *testing.T) {
 	var buf bytes.Buffer
 	setPlanWriter(t, &buf)
 
-	planErr := Plan(context.Background(), cfg, "", PlanOutputFullJSON, "")
+	planErr := Plan(context.Background(), cfg, "", PlanOutputPlanOut, "")
 
 	// A fatal error is propagated (non-nil), so main exits non-zero.
 	if planErr == nil {

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -922,7 +922,7 @@ func TestPlanJSON_DebugLogging_Fallback(t *testing.T) {
 }
 
 // When the server cannot be reached (here, a retry timeout), --full-json has
-// nothing to pass through, so it emits the locally-computed fallback plan on
+// nothing to pass through, so it emits a locally-computed fallback plan on
 // stdout and warns on stderr that it is not a server plan.
 func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -957,8 +957,9 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 		t.Errorf("command.Plan(...) error = %v", planErr)
 	}
 
-	// The fallback plan is still emitted as valid JSON on stdout, without the
-	// Fallback field leaking.
+	// The fallback plan is still emitted as valid JSON on stdout, carrying the
+	// identifier and parallelism, without the client-internal Fallback field
+	// leaking.
 	var got plan.TestPlan
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
@@ -966,21 +967,11 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	if strings.Contains(strings.ToLower(buf.String()), "fallback") {
 		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
 	}
-
-	// The fallback must be a real, usable plan: tasks populated from the
-	// discovered targets, not a null/empty task map.
-	if len(got.Tasks) == 0 {
-		t.Fatalf("fallback --full-json output has no tasks; got: %s", buf.String())
+	if got.Identifier != "hello" {
+		t.Errorf("fallback plan Identifier = %q, want %q", got.Identifier, "hello")
 	}
 	if got.Parallelism != 10 {
 		t.Errorf("fallback plan Parallelism = %d, want 10 (from --max-parallelism)", got.Parallelism)
-	}
-	var fallbackTestCount int
-	for _, task := range got.Tasks {
-		fallbackTestCount += len(task.Tests)
-	}
-	if fallbackTestCount == 0 {
-		t.Errorf("fallback plan distributed no tests across its tasks; got: %s", buf.String())
 	}
 
 	// The fallback caveat is written to stderr.

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -916,8 +916,9 @@ func TestPlanJSON_DebugLogging_Fallback(t *testing.T) {
 	}
 }
 
-// When the server is unreachable, --full-json still emits the locally-computed
-// fallback plan on stdout, but warns on stderr that it is not a server plan.
+// When the server cannot be reached (here, a retry timeout), --full-json has
+// nothing to pass through, so it emits the locally-computed fallback plan on
+// stdout and warns on stderr that it is not a server plan.
 func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -980,5 +981,72 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 	// The fallback caveat is written to stderr.
 	if !strings.Contains(stderrOutput, "locally-computed fallback plan") {
 		t.Errorf("expected stderr to contain the fallback caveat, got: %s", stderrOutput)
+	}
+}
+
+// When the server returns an error plan (`{"tasks": {}}`), --full-json passes
+// it through verbatim rather than substituting a local fallback, so the output
+// reflects the server's actual response. It is not marked as a local fallback.
+func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		enc := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			enc.Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			// Error plan: empty task map.
+			enc.Encode(plan.TestPlan{Identifier: "facecafe", Parallelism: 0, Tasks: map[string]*plan.Task{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	getStderr := captureStderr(t)
+
+	planErr := Plan(context.Background(), cfg, "", PlanOutputFullJSON, "")
+
+	stderrOutput := getStderr()
+
+	if planErr != nil {
+		t.Errorf("command.Plan(...) error = %v", planErr)
+	}
+
+	var got plan.TestPlan
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	// The server's error plan is passed through: empty tasks, server identifier,
+	// no locally-distributed task map.
+	if len(got.Tasks) != 0 {
+		t.Errorf("expected empty tasks passed through from server, got: %s", buf.String())
+	}
+	if got.Identifier != "facecafe" {
+		t.Errorf("expected server identifier %q, got %q", "facecafe", got.Identifier)
+	}
+
+	// The error-plan warning is written to stderr...
+	if !strings.Contains(stderrOutput, "failed to generate a plan") {
+		t.Errorf("expected stderr to contain the error-plan warning, got: %s", stderrOutput)
+	}
+	// ...but it is NOT presented as a locally-computed fallback.
+	if strings.Contains(stderrOutput, "locally-computed fallback plan") {
+		t.Errorf("server error plan should not be reported as a local fallback, got: %s", stderrOutput)
 	}
 }

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -52,6 +52,99 @@ func TestPlanJSON(t *testing.T) {
 	}
 }
 
+func TestPlanFullJSON(t *testing.T) {
+	svr := getHttptestServer()
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	// This is the method under test
+	if err := Plan(ctx, cfg, "", PlanOutputFullJSON, ""); err != nil {
+		t.Errorf("command.Plan(...) error = %v", err)
+	}
+
+	// The full plan is emitted as indented JSON, matching the shape a fetch of
+	// the server's test_plan endpoint would return.
+	want := plan.TestPlan{
+		Identifier:  "facecafe",
+		Parallelism: 42,
+		Tasks: map[string]*plan.Task{
+			"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "testdata/rspec/spec/fruits/apple_spec.rb"}}},
+		},
+	}
+
+	var got plan.TestPlan
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("command.Plan(...) full plan diff = %s", diff)
+	}
+
+	// The client-internal Fallback field must not leak into the output.
+	if strings.Contains(strings.ToLower(buf.String()), "fallback") {
+		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
+	}
+
+	// Output should be indented, not compact.
+	if !strings.Contains(buf.String(), "\n  \"identifier\"") {
+		t.Errorf("expected indented JSON output, got:\n%s", buf.String())
+	}
+}
+
+func TestPlanFullJSON_Parallelism0(t *testing.T) {
+	svr := getZeroParallelismServer()
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	getStderr := captureStderr(t)
+
+	// This is the method under test
+	planErr := Plan(ctx, cfg, "", PlanOutputFullJSON, "")
+
+	stderrOutput := getStderr()
+
+	if planErr != nil {
+		t.Errorf("command.Plan(...) error = %v", planErr)
+	}
+
+	// The full plan is still emitted, even at parallelism 0.
+	var got plan.TestPlan
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if got.Parallelism != 0 {
+		t.Errorf("emitted plan Parallelism = %d, want 0", got.Parallelism)
+	}
+
+	// The parallelism warning is written to stderr.
+	if !strings.Contains(stderrOutput, "Parallelism is 0") {
+		t.Errorf("expected stderr to contain parallelism warning, got: %s", stderrOutput)
+	}
+}
+
 func TestPlanPipelineUpload(t *testing.T) {
 	svr := getHttptestServer()
 	defer svr.Close()
@@ -820,5 +913,56 @@ func TestPlanJSON_DebugLogging_Fallback(t *testing.T) {
 	// Verify debug output is NOT in stdout
 	if strings.Contains(stdoutOutput, "DEBUG") {
 		t.Errorf("debug output should not appear in stdout, got: %s", stdoutOutput)
+	}
+}
+
+// When the server is unreachable, --full-json still emits the locally-computed
+// fallback plan on stdout, but warns on stderr that it is not a server plan.
+func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.Identifier = "hello"
+	cfg.MaxParallelism = 10
+	cfg.ServerBaseURL = svr.URL
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	// Short timeout to trigger fallback quickly
+	fetchCtx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	getStderr := captureStderr(t)
+
+	// This is the method under test
+	planErr := Plan(fetchCtx, cfg, "", PlanOutputFullJSON, "")
+
+	stderrOutput := getStderr()
+
+	if planErr != nil {
+		t.Errorf("command.Plan(...) error = %v", planErr)
+	}
+
+	// The fallback plan is still emitted as valid JSON on stdout, without the
+	// Fallback field leaking.
+	var got plan.TestPlan
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if strings.Contains(strings.ToLower(buf.String()), "fallback") {
+		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
+	}
+
+	// The fallback caveat is written to stderr.
+	if !strings.Contains(stderrOutput, "locally-computed fallback plan") {
+		t.Errorf("expected stderr to contain the fallback caveat, got: %s", stderrOutput)
 	}
 }

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -53,7 +53,25 @@ func TestPlanJSON(t *testing.T) {
 }
 
 func TestPlanFullJSON(t *testing.T) {
-	svr := getHttptestServer()
+	// The server's exact response body, including a field the client struct
+	// does not model (server_only), to prove --full-json passes the response
+	// through unmodified rather than re-marshalling a struct.
+	serverBody := `{"identifier":"facecafe","parallelism":42,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"server_only":"kept"}`
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		switch r.URL.Path {
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan/filter_tests":
+			json.NewEncoder(w).Encode(api.FilteredTestResponse{})
+		case "/v2/analytics/organizations/buildkite/suites/rspec/test_plan":
+			w.Write([]byte(serverBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
 	defer svr.Close()
 
 	cfg := getConfig()
@@ -73,28 +91,15 @@ func TestPlanFullJSON(t *testing.T) {
 		t.Errorf("command.Plan(...) error = %v", err)
 	}
 
-	// The full plan is emitted as indented JSON, matching the shape a fetch of
-	// the server's test_plan endpoint would return.
-	want := plan.TestPlan{
-		Identifier:  "facecafe",
-		Parallelism: 42,
-		Tasks: map[string]*plan.Task{
-			"0": {NodeNumber: 0, Tests: []plan.TestCase{{Path: "testdata/rspec/spec/fruits/apple_spec.rb"}}},
-		},
-	}
-
-	var got plan.TestPlan
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	// stdout is the server's exact response, only re-indented. Comparing the
+	// compacted output against the compacted server body proves no field was
+	// added, dropped, or renamed.
+	var gotCompact bytes.Buffer
+	if err := json.Compact(&gotCompact, buf.Bytes()); err != nil {
 		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
 	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("command.Plan(...) full plan diff = %s", diff)
-	}
-
-	// The client-internal Fallback field must not leak into the output.
-	if strings.Contains(strings.ToLower(buf.String()), "fallback") {
-		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
+	if gotCompact.String() != serverBody {
+		t.Errorf("full-json output was modified.\n got: %s\nwant: %s", gotCompact.String(), serverBody)
 	}
 
 	// Output should be indented, not compact.

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -961,6 +961,22 @@ func TestPlanFullJSON_FallbackWarnsOnStderr(t *testing.T) {
 		t.Errorf("full-json output leaked the Fallback field:\n%s", buf.String())
 	}
 
+	// The fallback must be a real, usable plan: tasks populated from the
+	// discovered targets, not a null/empty task map.
+	if len(got.Tasks) == 0 {
+		t.Fatalf("fallback --full-json output has no tasks; got: %s", buf.String())
+	}
+	if got.Parallelism != 10 {
+		t.Errorf("fallback plan Parallelism = %d, want 10 (from --max-parallelism)", got.Parallelism)
+	}
+	var fallbackTestCount int
+	for _, task := range got.Tasks {
+		fallbackTestCount += len(task.Tests)
+	}
+	if fallbackTestCount == 0 {
+		t.Errorf("fallback plan distributed no tests across its tasks; got: %s", buf.String())
+	}
+
 	// The fallback caveat is written to stderr.
 	if !strings.Contains(stderrOutput, "locally-computed fallback plan") {
 		t.Errorf("expected stderr to contain the fallback caveat, got: %s", stderrOutput)

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -1055,3 +1055,37 @@ func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
 		t.Errorf("server error plan should not be reported as a local fallback, got: %s", stderrOutput)
 	}
 }
+
+// A fatal API error (here, 401 Unauthorized) is returned rather than swallowed:
+// --full-json exits with an error and emits nothing on stdout, instead of
+// falling back to a local plan.
+func TestPlanFullJSON_FatalErrorReturnsNoOutput(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message": "Invalid access token"}`))
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	planErr := Plan(context.Background(), cfg, "", PlanOutputFullJSON, "")
+
+	// A fatal error is propagated (non-nil), so main exits non-zero.
+	if planErr == nil {
+		t.Error("expected a fatal error for a 401 response, got nil")
+	}
+
+	// Nothing is written to stdout: no plan, no fallback.
+	if buf.Len() != 0 {
+		t.Errorf("expected no stdout output on fatal error, got: %s", buf.String())
+	}
+}

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -1046,13 +1046,18 @@ func TestPlanFullJSON_ServerErrorPlanPassedThrough(t *testing.T) {
 		t.Errorf("expected server identifier %q, got %q", "facecafe", got.Identifier)
 	}
 
-	// The error-plan warning is written to stderr...
-	if !strings.Contains(stderrOutput, "failed to generate a plan") {
-		t.Errorf("expected stderr to contain the error-plan warning, got: %s", stderrOutput)
+	// The empty-plan warning is written to stderr...
+	if !strings.Contains(stderrOutput, "returned an empty plan") {
+		t.Errorf("expected stderr to contain the empty-plan warning, got: %s", stderrOutput)
 	}
-	// ...but it is NOT presented as a locally-computed fallback.
+	// ...but it is NOT presented as a locally-computed fallback, nor does it
+	// claim a fallback to non-intelligent splitting, since the server's plan is
+	// what gets emitted.
 	if strings.Contains(stderrOutput, "locally-computed fallback plan") {
 		t.Errorf("server error plan should not be reported as a local fallback, got: %s", stderrOutput)
+	}
+	if strings.Contains(stderrOutput, "Falling back to non-intelligent splitting") {
+		t.Errorf("server error plan should not claim a fallback to non-intelligent splitting, got: %s", stderrOutput)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	Output string `json:"-"`
 	// Parallelism is the number of parallel tasks to run.
 	Parallelism int `json:"-"`
+	// PlanOut is the destination for the `bktec plan --plan-out` output: "-" for
+	// stdout, or a file path. The full test plan is written as the server's
+	// response, unmodified.
+	PlanOut string `json:"-"`
 	// Remote is the git remote name for fetching missing commits and detecting default branch (default "origin").
 	Remote string `json:"-"`
 	// ResultPath is the path to the result file.

--- a/main.go
+++ b/main.go
@@ -51,9 +51,12 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("invalid configuration...\n%w", err)
 	}
 
-	if cmd.Bool("json") {
+	switch {
+	case cmd.Bool("json"):
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputJSON, "")
-	} else {
+	case cmd.Bool("full-json"):
+		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputFullJSON, "")
+	default:
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputPipelineUpload, cmd.String("pipeline-upload"))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,8 +54,8 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 	switch {
 	case cmd.Bool("json"):
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputJSON, "")
-	case cmd.Bool("full-json"):
-		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputFullJSON, "")
+	case cmd.IsSet("plan-out"):
+		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputPlanOut, "")
 	default:
 		return command.Plan(ctx, &cfg, cmd.String("files"), command.PlanOutputPipelineUpload, cmd.String("pipeline-upload"))
 	}


### PR DESCRIPTION
### Description

Add `--plan-out` to `bktec plan`: it writes the full test plan without running any tests, so users can pull down a copy of the plan instead of curling the unpublished `test_plan` endpoint by hand.

`bktec plan` already creates a plan without running tests, but `--json` emits only the plan identifier and parallelism. `--plan-out` writes the whole plan — tasks, the per-node test breakdown, muted and skipped tests, and timing metadata — as the server's response, byte-for-byte, only re-indented. It takes a destination: `-` for stdout, or a file path. It is an additive third arm of the existing, mutually-exclusive PLAN OUTPUT group; `--json` and `--pipeline-upload` are unchanged, so existing call sites keep working.

Emitting the server's raw JSON (rather than decoding into `plan.TestPlan` and re-marshalling) means any field the client does not model is preserved, and the output cannot drift from what a fetch of the endpoint returns. `--plan-out` also does not substitute a local fallback for a server *error* plan: an empty plan (`{"tasks": {}}`) is passed through as-is, with a warning on stderr. Only when the server is unreachable does it emit a minimal locally-generated plan (identifier + parallelism, no tasks — not a computed split), noted on stderr. Fatal API errors (auth, forbidden, bad request) exit non-zero with no output.

**Naming:** this started as `--full-json` (see the branch/early commits) and became `--plan-out <path|->` after review — a destination-taking flag is more flexible (writes straight to a file) and reads better next to `--json`/`--pipeline-upload`. A `--plan-out-mode` flag was considered and dropped: with only a `raw` mode it would be inert, and it can be added non-breakingly later.

### Context

Linear: [TE-6254](https://linear.app/buildkite/issue/TE-6254), a sub-issue of [TE-6168](https://linear.app/buildkite/issue/TE-6168) (self-serve evaluation of Test Prediction). This productises the manual `curl GET .../test_plan` capture the evaluation flow relies on, alongside the sibling `--plan-identifier` work (TE-6228, #566).

### Changes

The branch evolved through review (full-json → raw passthrough → --plan-out); best reviewed as the net diff rather than commit-by-commit. The final shape:

- `cli.go` / `main.go`: `--plan-out` flag in the PLAN OUTPUT mutually-exclusive group, bound to `cfg.PlanOut`; dispatched via `cmd.IsSet`.
- `internal/api/create_test_plan.go`: `CreateTestPlanRaw` returns the decoded plan plus the raw JSON response.
- `internal/command/plan.go`: `planOut` writes the raw response to the destination (`planOutWriter`: stdout or a file); empty/unreachable handling as above.
- Tests in `plan_test.go` (stdout + file destinations, parallelism 0, error-plan passthrough, unreachable fallback, fatal error) and `cli_test.go`; README + changelog.

### Testing

`go test ./internal/command/... ./internal/api/... .` passes. Manually verified with `go run . plan`: `--plan-out` appears in `--help`; combining it with `--json` errors; omitting all output flags errors with the required-group message. Buildkite CI (build #2363) passed on an earlier head; will re-run on the latest.

The `internal/runner` Jest test fails locally without a node/jest environment; that failure is present on `main` and is unrelated to this change.

AI assisted.
