### PR TITLE
[TE-6238] Support selector based splitting for RSpec

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -51,6 +51,7 @@ func (r Rspec) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            true,
+		SplitBySelector: true,
 	}
 }
 
@@ -77,6 +78,10 @@ func (r Rspec) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (r Rspec) GetSelectors() ([]string, error) {
+	return r.GetFiles()
 }
 
 // Run executes the test command with the given test cases.

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -371,6 +371,25 @@ func TestRspecCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 	}
 }
 
+func TestRspecGetSelectors(t *testing.T) {
+	rspec := NewRspec(RunnerConfig{
+		TestFilePattern: "testdata/rspec/spec/spells/**/*_spec.rb",
+	})
+
+	got, err := rspec.GetSelectors()
+	if err != nil {
+		t.Errorf("Rspec.GetSelectors() error = %v", err)
+	}
+
+	// Selector based splitting for RSpec splits by file, so the selectors are
+	// the discovered test files (the same result as GetFiles).
+	want := []string{"testdata/rspec/spec/spells/expelliarmus_spec.rb"}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Rspec.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestRspecGetExamples(t *testing.T) {
 	rspec := NewRspec(RunnerConfig{
 		TestCommand: "rspec",

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -49,10 +49,9 @@ func (rc RunnerConfig) ResultFilePath() string {
 	return rc.ResultPath
 }
 
-// GetSelectors returns a "not supported" error by default. Selector based
-// splitting is currently only implemented by the Go runner, which overrides
-// this. Every other runner inherits this default until it gains selector
-// support.
+// GetSelectors returns a "not supported" error by default. Runners that
+// support selector based splitting override this. Every other runner
+// inherits this default until it gains selector support.
 func (rc RunnerConfig) GetSelectors() ([]string, error) {
 	return nil, fmt.Errorf("selector based splitting is not supported for the %s runner", rc.TestRunner)
 }

--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -41,7 +41,7 @@ func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 		nunit,
 	}
 
-	supportedRunners := []string{gotest.Name(), custom.Name()}
+	supportedRunners := []string{gotest.Name(), rspec.Name(), custom.Name()}
 
 	for _, runner := range runners {
 		got := runner.SupportedFeatures().SplitBySelector


### PR DESCRIPTION
We're moving towards selector based splitting as the general way bktec splits test suites, eventually replacing file based splitting entirely. Each runner decides what a selector means for it. For `go` that's a package, for `custom` it's a user provided list, and this PR adds `rspec` where a selector is a file.

For now we're adding selector based splitting alongside the existing file based splitting, and they need to behave the same way for RSpec. That's what makes it easy to eventually deprecate the file based path and just use selector based splitting by default.

Note this is still experimental. It requires a feature flag on the server for intelligent test plan, so it won't do anything without that flag enabled.

### Changes

- Added `SplitBySelector: true` to RSpec's supported features
- Added `GetSelectors` to the RSpec runner, delegating to `GetFiles`