### PR TITLE
[TE-6238] Prepend `./` when collecting selectors for RSpec

### DIFF
--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -80,8 +80,20 @@ func (r Rspec) GetFiles() ([]string, error) {
 	return files, nil
 }
 
-func (r Rspec) GetSelectors() ([]string, error) {
-	return r.GetFiles()
+func (r Rspec) GetSelectors() (selectors []string, err error) {
+	files, err := r.GetFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	// Unlike file based splitting, selector based splitting always uses the original
+	// file name reported by the test runner, so the location prefix is not prepended
+	// when requesting the test plan (see command.createRequestParam). RSpec reports
+	// file names with a leading "./", so we prepend it here too to match.
+	for _, file := range files {
+		selectors = append(selectors, "./"+file)
+	}
+	return selectors, nil
 }
 
 // Run executes the test command with the given test cases.

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -383,7 +383,7 @@ func TestRspecGetSelectors(t *testing.T) {
 
 	// Selector based splitting for RSpec splits by file, so the selectors are
 	// the discovered test files (the same result as GetFiles).
-	want := []string{"testdata/rspec/spec/spells/expelliarmus_spec.rb"}
+	want := []string{"./testdata/rspec/spec/spells/expelliarmus_spec.rb"}
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Rspec.GetSelectors() diff (-got +want):\n%s", diff)


### PR DESCRIPTION
### Description

RSpec's selector based splitting was sending selectors without RSpec's native `./` prefix, so they didn't match `test.selector.primary` on the Test Engine side. This meant test plans came back with no historical duration, since nothing matched.

`GetSelectors()` now prepends `./` to each discovered file, matching the format RSpec itself reports.

### Context

Found this while testing selector based splitting for rspec in `buildkite/buildkite` ([build](https://buildkite.com/buildkite/buildkite/builds/199535/canvas?jid=019f1bfd-f21f-4ef5-aa50-b273b4c1012c&tab=output)) — the test plan came back without historical duration. `test.selector.primary` is currently set manually from the file name RSpec reports (see [test_engine_helper.rb](https://github.com/buildkite/buildkite/blob/b2883edcabb129a106dab4aee6107fbc968759ae/spec/test_engine_helper.rb#L138)), which includes RSpec's `./` prefix, but `bktec` wasn't including it when requesting the plan.

The sentiment is that we want `test.selector.primary` to stay "pure", so we're not applying location prefix to selectors for splitting purposes, even though we still want to support location prefix for result reporting. This is discussed further in [this doc](https://app.notion.com/p/buildkite/Selector-Splitting-Location-Prefix-Strikes-Back-390b8dbc2c898009bb2ce151a83bdf76).

### Testing

Updated `TestRspecGetSelectors` to assert the `./` prefix is included.