### PR TITLE
[TE-6238] Prepend and trim location prefix when split by selector

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/v2/internal/api"
@@ -29,7 +30,15 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 		// selector values, e.g. Go package import paths, not file paths.
 		selectors := make([]api.TestPlanParamsSelector, 0, len(testTargets))
 		for _, target := range testTargets {
-			selectors = append(selectors, api.TestPlanParamsSelector{Value: target})
+			var selector string
+			// not all selector is a file path. For instance selector for go is package name.
+			// therefore we should only prepend the location prefix to the selector when it is a valid file.
+			if _, err := os.Stat(target); err == nil {
+				selector = prefixPath(target, runner.LocationPrefix())
+			} else {
+				selector = target
+			}
+			selectors = append(selectors, api.TestPlanParamsSelector{Value: selector})
 		}
 
 		return api.TestPlanParams{

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -106,14 +106,18 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 func trimTaskLocationPrefix(task *plan.Task, locationPrefix string) error {
 	for i, test := range task.Tests {
 		if test.Format == plan.TestCaseFormatSelector {
-			continue
+			selector, err := trimFilePathPrefix(test.Value, locationPrefix)
+			if err != nil {
+				return fmt.Errorf("failed to trim prefix: %w", err)
+			}
+			task.Tests[i].Value = selector
+		} else {
+			path, err := trimFilePathPrefix(test.Path, locationPrefix)
+			if err != nil {
+				return fmt.Errorf("failed to trim path prefix: %w", err)
+			}
+			task.Tests[i].Path = path
 		}
-
-		path, err := trimFilePathPrefix(test.Path, locationPrefix)
-		if err != nil {
-			return fmt.Errorf("failed to trim path prefix: %w", err)
-		}
-		task.Tests[i].Path = path
 	}
 
 	return nil


### PR DESCRIPTION
### Description
This is a spike for one of the options we're weighing for how location prefix should interact with selector based splitting (see Context). Specifically, it's what `bktec` needs to look like under the option where `test.selector.primary` includes the location prefix.

Right now, selector based splitting sends discovered test targets straight to the Test Plan API as raw selectors, with no location prefix applied. If ingestion ends up setting `test.selector.primary` with the prefix included, our selector won't match what's stored, and the test plan will come back with no historical duration.

This PR makes `bktec` prepend the location prefix to a selector before sending it, but only when the selector is actually a file path (e.g. Rspec). Some runners use selectors that aren't file paths at all (e.g. Go package names), so we check with `os.Stat` first and leave those untouched.

I also fixed `trimTaskLocationPrefix` in `run.go`, which previously skipped selector-format tests entirely when trimming the prefix from the plan we get back. Now it trims the prefix from `test.Value` for those too, so the runner gets a selector it can actually use.

### Context
We hit this while testing selector based splitting for rspec in `buildkite/buildkite` ([build](https://buildkite.com/buildkite/buildkite/builds/199535/canvas?jid=019f1bfd-f21f-4ef5-aa50-b273b4c1012c&tab=output)) and the plan came back with no historical duration.

We're still deciding how ingestion should set `test.selector.primary` when location prefix is configured: leave the prefix out, or include it. This PR is a spike for what `bktec` looks like if we go with including it. Wrote up the full problem in [this doc](https://app.notion.com/p/Selector-Splitting-Location-Prefix-Strikes-Back-390b8dbc2c898009bb2ce151a83bdf76) if you want more background.

Linear: [TE-6238](https://linear.app/buildkite/issue/TE-6238/support-selector-based-splitting-for-rspec)

### Testing
Covered by unit tests.