### PR TITLE
Send `test_runner` when uploading test results from bktec

### DIFF
--- a/internal/api/upload_test_results.go
+++ b/internal/api/upload_test_results.go
@@ -28,8 +28,8 @@ var (
 //
 // Transient failures (network errors, 429, 5xx) are retried via doWithRetry
 // before giving up. The multipart body is built once and re-sent on each attempt.
-func (c *Client) UploadTestResults(ctx context.Context, token string, filePath string, format string, locationPrefix string, tags map[string]string) error {
-	body, contentType, err := buildTestResultsMultipartBody(filePath, format, locationPrefix, tags)
+func (c *Client) UploadTestResults(ctx context.Context, token string, filePath string, format string, runner string, locationPrefix string, tags map[string]string) error {
+	body, contentType, err := buildTestResultsMultipartBody(filePath, format, runner, locationPrefix, tags)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (c *Client) UploadTestResults(ctx context.Context, token string, filePath s
 	return nil
 }
 
-func buildTestResultsMultipartBody(filePath string, format string, locationPrefix string, tags map[string]string) (*bytes.Buffer, string, error) {
+func buildTestResultsMultipartBody(filePath string, format string, runner string, locationPrefix string, tags map[string]string) (*bytes.Buffer, string, error) {
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
@@ -88,6 +88,7 @@ func buildTestResultsMultipartBody(filePath string, format string, locationPrefi
 		"message":         os.Getenv("BUILDKITE_MESSAGE"),
 		"location_prefix": locationPrefix,
 		"collector":       "bktec",
+		"test_runner":     runner,
 		"version":         version.Version,
 	}
 	if buildID != "" {

--- a/internal/api/upload_test_results_test.go
+++ b/internal/api/upload_test_results_test.go
@@ -69,7 +69,7 @@ func TestUploadTestResults(t *testing.T) {
 	defer svr.Close()
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
-	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "./", nil)
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "rspec", "./", nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Token token=my-token", gotToken)
@@ -92,7 +92,7 @@ func TestUploadTestResults_ServerError(t *testing.T) {
 	defer svr.Close()
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
-	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "rspec", "", nil)
 	// 5xx is retried until the retry timeout, after which doWithRetry returns
 	// ErrRetryTimeout.
 	assert.ErrorIs(t, err, ErrRetryTimeout)
@@ -122,7 +122,7 @@ func TestUploadTestResults_RetriesThenSucceeds(t *testing.T) {
 	defer svr.Close()
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
-	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "rspec", "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), attempts.Load())
 	// The multipart body is re-sent in full on the retry.
@@ -146,7 +146,7 @@ func TestUploadTestResults_NoRetryOn4xx(t *testing.T) {
 	defer svr.Close()
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
-	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "", nil)
+	err = client.UploadTestResults(t.Context(), "my-token", resultFile.Name(), "rspec-json", "rspec", "", nil)
 	assert.ErrorContains(t, err, "upload failed with status 400")
 	assert.Equal(t, int32(1), attempts.Load())
 }
@@ -158,7 +158,7 @@ func TestUploadTestResults_MissingFile(t *testing.T) {
 	defer svr.Close()
 
 	client := NewClient(ClientConfig{UploadBaseURL: svr.URL})
-	err := client.UploadTestResults(t.Context(), "my-token", "/nonexistent/path/results.json", "rspec-json", "", nil)
+	err := client.UploadTestResults(t.Context(), "my-token", "/nonexistent/path/results.json", "rspec-json", "rspec", "", nil)
 	assert.ErrorContains(t, err, "opening result file")
 }
 
@@ -181,7 +181,7 @@ func TestBuildTestResultsMultipartBody(t *testing.T) {
 	require.NoError(t, err)
 	resultFile.Close()
 
-	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "my/prefix", nil)
+	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "rspec", "my/prefix", nil)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(contentType, "multipart/form-data"))
 
@@ -213,6 +213,7 @@ func TestBuildTestResultsMultipartBody(t *testing.T) {
 	assert.Equal(t, "abc123", fields["run_env[commit_sha]"])
 	assert.Equal(t, "my/prefix", fields["run_env[location_prefix]"])
 	assert.Equal(t, "bktec", fields["run_env[collector]"])
+	assert.Equal(t, "rspec", fields["run_env[test_runner]"])
 	assert.Equal(t, dummyVersion, fields["run_env[version]"])
 	assert.Equal(t, cwd, fields["run_env[cwd]"])
 }
@@ -224,7 +225,7 @@ func TestBuildTestResultsMultipartBody_WithTags(t *testing.T) {
 	resultFile.Close()
 
 	tags := map[string]string{"env": "production", "team": "platform"}
-	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "", tags)
+	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "rspec", "", tags)
 	require.NoError(t, err)
 
 	_, params, err := mime.ParseMediaType(contentType)
@@ -256,7 +257,7 @@ func TestBuildTestResultsMultipartBody_NoCwdOutsideBuildkite(t *testing.T) {
 	defer os.Remove(resultFile.Name())
 	resultFile.Close()
 
-	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "", nil)
+	buf, contentType, err := buildTestResultsMultipartBody(resultFile.Name(), "rspec-json", "rspec", "", nil)
 	require.NoError(t, err)
 
 	_, params, err := mime.ParseMediaType(contentType)

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -295,7 +295,7 @@ func uploadResults(ctx context.Context, apiClient *api.Client, cfg *config.Confi
 		return
 	}
 	fmt.Println("Buildkite Test Engine Client: Uploading test results to Test Engine")
-	if err := apiClient.UploadTestResults(ctx, cfg.UploadToken, testRunner.ResultFilePath(), format, testRunner.LocationPrefix(), cfg.UploadTags); err != nil {
+	if err := apiClient.UploadTestResults(ctx, cfg.UploadToken, testRunner.ResultFilePath(), format, cfg.TestRunner, testRunner.LocationPrefix(), cfg.UploadTags); err != nil {
 		fmt.Printf("Buildkite Test Engine Client: Failed to upload test results to Test Engine: %v\n", err)
 	}
 }


### PR DESCRIPTION
### Description

Ingestion needs to know which test runner produced the results so it can decide how to set the `test.selector.primary` tag. This PR adds a `test_runner` field to the multipart body we send when uploading test results, using the runner name from `cfg.TestRunner`.

### Context

https://linear.app/buildkite/issue/TE-6269/send-test-runner-information-when-uploading-test-data-from-bktec

### Testing

Updated existing unit tests in `upload_test_results_test.go` to assert the new `test_runner` field is included in the upload payload.