### PR TITLE
[TE-6274] Fall bktec plan fallback parallelism back to BUILDKITE_PARALLEL_JOB_COUNT

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -235,11 +235,10 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 	return cmd
 }
 
-// fallbackParallelism resolves the parallelism for a locally-computed fallback
-// plan, matching how bktec run derives it: prefer the dynamic --max-parallelism,
-// then fall back to the static BUILDKITE_PARALLEL_JOB_COUNT. Without this, an
-// unset --max-parallelism yields parallelism 0, so the fallback runs nothing.
-// May still be 0 off-agent, where BUILDKITE_PARALLEL_JOB_COUNT is unset too.
+// fallbackParallelism resolves the fallback plan's parallelism like bktec run
+// does: prefer --max-parallelism, else the static BUILDKITE_PARALLEL_JOB_COUNT.
+// Without this an unset --max-parallelism yields parallelism 0, so the fallback
+// runs nothing. Still 0 off-agent, where BUILDKITE_PARALLEL_JOB_COUNT is unset.
 func fallbackParallelism(cfg *config.Config) int {
 	if cfg.MaxParallelism > 0 {
 		return cfg.MaxParallelism

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -206,7 +206,7 @@ func emitLocalFallback(out io.Writer, cfg *config.Config) error {
 		Tasks       map[string]*plan.Task `json:"tasks"`
 	}{
 		Identifier:  cfg.Identifier,
-		Parallelism: cfg.MaxParallelism,
+		Parallelism: fallbackParallelism(cfg),
 		Tasks:       map[string]*plan.Task{},
 	}, "", "  ")
 
@@ -235,12 +235,24 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 	return cmd
 }
 
+// fallbackParallelism resolves the parallelism for a locally-computed fallback
+// plan, matching how bktec run derives it: prefer the dynamic --max-parallelism,
+// then fall back to the static BUILDKITE_PARALLEL_JOB_COUNT. Without this, an
+// unset --max-parallelism yields parallelism 0, so the fallback runs nothing.
+// May still be 0 off-agent, where BUILDKITE_PARALLEL_JOB_COUNT is unset too.
+func fallbackParallelism(cfg *config.Config) int {
+	if cfg.MaxParallelism > 0 {
+		return cfg.MaxParallelism
+	}
+	return cfg.Parallelism
+}
+
 // makeFallbackPlan returns the locally-computed fallback plan used when the
 // server cannot generate or return one.
 func makeFallbackPlan(cfg *config.Config) plan.TestPlan {
 	return plan.TestPlan{
 		Identifier:  cfg.Identifier,
-		Parallelism: cfg.MaxParallelism,
+		Parallelism: fallbackParallelism(cfg),
 		Fallback:    true,
 	}
 }

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -555,10 +555,11 @@ called with testtemplate.yml
 	}
 }
 
-// When the resolved plan has parallelism 0, --pipeline-upload must not run
-// buildkite-agent. This is reachable via a fallback plan whose parallelism
-// comes from both --max-parallelism and BUILDKITE_PARALLEL_JOB_COUNT being 0
-// (the residual off-agent gap), triggered here by a server error plan.
+// Plan()'s parallelism-0 guard must not run buildkite-agent for a
+// --pipeline-upload plan with parallelism 0. ValidateForPlan now rejects the
+// both-unset config that produces this fallback, so the guard is defence in
+// depth; this drives it directly by leaving both parallelism sources at 0 and
+// skipping validation.
 func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	svr := getErrorPlanServer()
 	defer svr.Close()
@@ -569,10 +570,6 @@ func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	// Both MaxParallelism and Parallelism 0, so the fallback plan has
 	// parallelism 0.
 	cfg.Parallelism = 0
-
-	if err := cfg.ValidateForPlan(); err != nil {
-		t.Errorf("Invalid config: %v", err)
-	}
 
 	ctx := context.Background()
 

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -557,8 +557,8 @@ called with testtemplate.yml
 
 // When the resolved plan has parallelism 0, --pipeline-upload must not run
 // buildkite-agent. This is reachable via a fallback plan whose parallelism
-// comes from an unset --max-parallelism (cfg.MaxParallelism == 0), triggered
-// here by a server error plan.
+// comes from both --max-parallelism and BUILDKITE_PARALLEL_JOB_COUNT being 0
+// (the residual off-agent gap), triggered here by a server error plan.
 func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	svr := getErrorPlanServer()
 	defer svr.Close()
@@ -566,7 +566,9 @@ func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	cfg := getConfig()
 	cfg.ServerBaseURL = svr.URL
 	cfg.Identifier = "local-id"
-	// MaxParallelism left at 0, so the fallback plan has parallelism 0.
+	// Both MaxParallelism and Parallelism 0, so the fallback plan has
+	// parallelism 0.
+	cfg.Parallelism = 0
 
 	if err := cfg.ValidateForPlan(); err != nil {
 		t.Errorf("Invalid config: %v", err)
@@ -599,6 +601,44 @@ func TestPlanPipelineUpload_Parallelism0(t *testing.T) {
 	// Verify the parallelism-0 warning was logged to stderr.
 	if !strings.Contains(stderrOutput, "Parallelism is 0") {
 		t.Errorf("expected stderr to contain parallelism-0 warning, got: %s", stderrOutput)
+	}
+}
+
+// When --max-parallelism is unset but BUILDKITE_PARALLEL_JOB_COUNT
+// (cfg.Parallelism) is set, the fallback plan falls back to the static
+// parallelism, so the suite runs un-optimised rather than being skipped.
+func TestPlanPipelineUpload_FallbackToStaticParallelism(t *testing.T) {
+	svr := getErrorPlanServer()
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.ServerBaseURL = svr.URL
+	cfg.Identifier = "local-id"
+	// MaxParallelism left at 0; Parallelism (BUILDKITE_PARALLEL_JOB_COUNT) is 3.
+	cfg.Parallelism = 3
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+
+	setPipelineUploadCommand(t, "echo", "called with")
+
+	planErr := Plan(ctx, cfg, "", PlanOutputPipelineUpload, "testtemplate.yml")
+	if planErr != nil {
+		t.Errorf("command.Plan(...) error = %v", planErr)
+	}
+
+	// The fallback uses the static parallelism (3), so pipeline upload runs.
+	want := `Executing buildkite-agent pipeline upload with BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER=local-id BUILDKITE_TEST_ENGINE_PARALLELISM=3
+called with testtemplate.yml
+`
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Errorf("command.Plan(...) diff = %s", diff)
 	}
 }
 
@@ -1135,6 +1175,46 @@ func TestPlanPlanOut_FallbackWarnsOnStderr(t *testing.T) {
 	// The fallback caveat is written to stderr.
 	if !strings.Contains(stderrOutput, "locally-computed fallback plan") {
 		t.Errorf("expected stderr to contain the fallback caveat, got: %s", stderrOutput)
+	}
+}
+
+// When --max-parallelism is unset, the --plan-out local fallback falls back to
+// the static BUILDKITE_PARALLEL_JOB_COUNT (cfg.Parallelism).
+func TestPlanPlanOut_FallbackToStaticParallelism(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	cfg := getConfig()
+	cfg.Identifier = "hello"
+	// MaxParallelism left at 0; Parallelism (BUILDKITE_PARALLEL_JOB_COUNT) is 3.
+	cfg.Parallelism = 3
+	cfg.ServerBaseURL = svr.URL
+	cfg.PlanOut = "-"
+
+	if err := cfg.ValidateForPlan(); err != nil {
+		t.Errorf("Invalid config: %v", err)
+	}
+
+	fetchCtx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	var buf bytes.Buffer
+	setPlanWriter(t, &buf)
+	captureStderr(t)
+
+	planErr := Plan(fetchCtx, cfg, "", PlanOutputPlanOut, "")
+	if planErr != nil {
+		t.Errorf("command.Plan(...) error = %v", planErr)
+	}
+
+	var got plan.TestPlan
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if got.Parallelism != 3 {
+		t.Errorf("fallback plan Parallelism = %d, want 3 (from BUILDKITE_PARALLEL_JOB_COUNT)", got.Parallelism)
 	}
 }
 


### PR DESCRIPTION
### Description

Fall the `bktec plan` fallback parallelism back to the static
`BUILDKITE_PARALLEL_JOB_COUNT` (`cfg.Parallelism`) when `--max-parallelism`
(`BUILDKITE_TEST_ENGINE_MAX_PARALLELISM`) is unset, so an unavailable Test Engine
degrades to "runs the full suite un-optimised" instead of "silently runs nothing".

When the API is unreachable or returns an error plan, `bktec plan` substitutes a
local fallback and exits 0. The fallback took `cfg.MaxParallelism` verbatim, so an
unset `--max-parallelism` gave parallelism 0: `--pipeline-upload` uploaded nothing,
`--json` emitted `"0"`, and the suite was skipped. A green build that tested
nothing is the dangerous shape; "runs un-optimised" (non-zero parallelism) is the
acceptable fail-open degradation `bktec run` already makes.

This resolves the fallback parallelism like `bktec run` does —
`MaxParallelism → Parallelism → 0` — aligning the two commands. It only *adds*
runs where there were none, so plans with a non-zero parallelism are unchanged.
The `--max-parallelism` help text already promises "when 0 ... the test plan
parallelism will be derived from `BUILDKITE_PARALLEL_JOB_COUNT`"; this honours that
in the fallback path.

**Residual both-unset gap:** when *both* `--max-parallelism` and
`BUILDKITE_PARALLEL_JOB_COUNT` are 0 (e.g. off-agent `plan --plan-identifier`), the
fallback would still be parallelism 0. #578 (TE-6275, merged) now catches this up
front with a client-side `parallelism > 0` check that rejects the config before any
network call, so it no longer reaches this fallback.

### Context

TE-6274. Surfaced during review of TE-6254 (`bktec plan --plan-out`, merged);
independent of it. Companion to #578 (TE-6275), the client-side `parallelism > 0`
check.

### Changes

- Add `fallbackParallelism(cfg)` and wire it into `makeFallbackPlan` and the
  `--plan-out` `emitLocalFallback` path in `internal/command/plan.go`.

### Testing

Backed by specs: `--pipeline-upload` and `--plan-out` cases assert the fallback
uses the static parallelism when `--max-parallelism` is unset. Since #578 landed on
main, the parallelism-0 guard test drives `Plan()`'s guard directly (`ValidateForPlan`
now rejects the both-unset config before it reaches the guard; the guard stays as
defence in depth). AI assisted.
