### PR TITLE
[TE-6275] Validate parallelism > 0 client-side in ValidateForPlan

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -255,6 +255,16 @@ func (c *Config) ValidateForPlan() error {
 		}
 	}
 
+	// The server enforces parallelism > 0, but only when it is reachable. When
+	// both --max-parallelism and BUILDKITE_PARALLEL_JOB_COUNT are 0 the plan
+	// parallelism resolves to 0, and if the server is also unreachable the
+	// request is never validated and bktec silently falls back to a
+	// parallelism-0 plan (nothing runs). Enforce it client-side so the
+	// misconfiguration fails fast, before any network call.
+	if c.MaxParallelism == 0 && c.Parallelism == 0 {
+		c.errs.appendFieldError("parallelism", "parallelism must be greater than 0; set --max-parallelism or BUILDKITE_PARALLEL_JOB_COUNT")
+	}
+
 	if len(c.errs) > 0 {
 		return c.errs
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -261,7 +261,7 @@ func (c *Config) ValidateForPlan() error {
 	// request is never validated and bktec silently falls back to a
 	// parallelism-0 plan (nothing runs). Enforce it client-side so the
 	// misconfiguration fails fast, before any network call.
-	if c.MaxParallelism == 0 && c.Parallelism == 0 {
+	if c.MaxParallelism == 0 && c.Parallelism <= 0 {
 		c.errs.appendFieldError("parallelism", "parallelism must be greater than 0; set --max-parallelism or BUILDKITE_PARALLEL_JOB_COUNT")
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -255,12 +255,11 @@ func (c *Config) ValidateForPlan() error {
 		}
 	}
 
-	// The server enforces parallelism > 0, but only when it is reachable. When
-	// both --max-parallelism and BUILDKITE_PARALLEL_JOB_COUNT are 0 the plan
-	// parallelism resolves to 0, and if the server is also unreachable the
-	// request is never validated and bktec silently falls back to a
-	// parallelism-0 plan (nothing runs). Enforce it client-side so the
-	// misconfiguration fails fast, before any network call.
+	// The server enforces parallelism > 0 only when reachable. With both
+	// --max-parallelism and BUILDKITE_PARALLEL_JOB_COUNT at 0, parallelism
+	// resolves to 0; if the server is also unreachable the request is never
+	// validated and bktec falls back to a parallelism-0 plan (nothing runs).
+	// Enforce it client-side to fail fast, before any network call.
 	if c.MaxParallelism == 0 && c.Parallelism <= 0 {
 		c.errs.appendFieldError("parallelism", "parallelism must be greater than 0; set --max-parallelism or BUILDKITE_PARALLEL_JOB_COUNT")
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -441,13 +441,55 @@ func TestMaxParallelismOutOfRange(t *testing.T) {
 func TestValidateForPlan_SkipsParallelismAndNodeIndexValidation(t *testing.T) {
 	c := createConfig()
 
-	// These 2 fields are only required on ValidateForRun
+	// NodeIndex is only required on ValidateForRun. Parallelism may be 0 for
+	// plan as long as --max-parallelism supplies a non-zero parallelism.
 	c.Parallelism = 0
+	c.MaxParallelism = 10
 	c.NodeIndex = 0
 	err := c.ValidateForPlan()
 	if err != nil {
 		t.Errorf("config.validate() err = %v, want nil", err)
 	}
+}
+
+// plan resolves parallelism from --max-parallelism then
+// BUILDKITE_PARALLEL_JOB_COUNT; when both are 0 it would silently fall back to a
+// parallelism-0 plan that runs nothing, so validation must reject it up front.
+func TestValidateForPlan_RejectsZeroParallelism(t *testing.T) {
+	c := createConfig()
+	c.MaxParallelism = 0
+	c.Parallelism = 0
+
+	err := c.ValidateForPlan()
+
+	var invConfigError InvalidConfigError
+	if !errors.As(err, &invConfigError) {
+		t.Fatalf("ValidateForPlan() error = %v, want InvalidConfigError", err)
+	}
+	if len(invConfigError["parallelism"]) != 1 {
+		t.Errorf("ValidateForPlan() parallelism errors = %v, want 1", invConfigError["parallelism"])
+	}
+}
+
+// Either parallelism source alone is enough to satisfy the parallelism > 0 rule.
+func TestValidateForPlan_ParallelismSourcesSatisfyGuard(t *testing.T) {
+	t.Run("BUILDKITE_PARALLEL_JOB_COUNT only", func(t *testing.T) {
+		c := createConfig()
+		c.MaxParallelism = 0
+		c.Parallelism = 5
+		if err := c.ValidateForPlan(); err != nil {
+			t.Errorf("ValidateForPlan() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("--max-parallelism only", func(t *testing.T) {
+		c := createConfig()
+		c.MaxParallelism = 5
+		c.Parallelism = 0
+		if err := c.ValidateForPlan(); err != nil {
+			t.Errorf("ValidateForPlan() error = %v, want nil", err)
+		}
+	})
 }
 
 func TestConfigValidate_SelectionParamsRequireStrategy(t *testing.T) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -455,19 +455,21 @@ func TestValidateForPlan_SkipsParallelismAndNodeIndexValidation(t *testing.T) {
 // plan resolves parallelism from --max-parallelism then
 // BUILDKITE_PARALLEL_JOB_COUNT; when both are 0 it would silently fall back to a
 // parallelism-0 plan that runs nothing, so validation must reject it up front.
-func TestValidateForPlan_RejectsZeroParallelism(t *testing.T) {
-	c := createConfig()
-	c.MaxParallelism = 0
-	c.Parallelism = 0
+func TestValidateForPlan_RejectsNonPositiveParallelism(t *testing.T) {
+	for _, parallelism := range []int{0, -1} {
+		c := createConfig()
+		c.MaxParallelism = 0
+		c.Parallelism = parallelism
 
-	err := c.ValidateForPlan()
+		err := c.ValidateForPlan()
 
-	var invConfigError InvalidConfigError
-	if !errors.As(err, &invConfigError) {
-		t.Fatalf("ValidateForPlan() error = %v, want InvalidConfigError", err)
-	}
-	if len(invConfigError["parallelism"]) != 1 {
-		t.Errorf("ValidateForPlan() parallelism errors = %v, want 1", invConfigError["parallelism"])
+		var invConfigError InvalidConfigError
+		if !errors.As(err, &invConfigError) {
+			t.Fatalf("ValidateForPlan() with Parallelism=%d error = %v, want InvalidConfigError", parallelism, err)
+		}
+		if len(invConfigError["parallelism"]) != 1 {
+			t.Errorf("ValidateForPlan() with Parallelism=%d parallelism errors = %v, want 1", parallelism, invConfigError["parallelism"])
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

Validate `parallelism > 0` client-side in `ValidateForPlan`, so `bktec plan`
fails fast when both `--max-parallelism` (`BUILDKITE_TEST_ENGINE_MAX_PARALLELISM`)
and `BUILDKITE_PARALLEL_JOB_COUNT` are 0, rather than relying on the server to
reject it.

The `parallelism > 0` rule currently lives only server-side — a reachable server
rejects a parallelism-0 request with "Parallelism must be greater than 0". But
because bktec does not enforce it itself, the guard only fires while the server is
reachable. If the server is *unreachable* and parallelism is 0, the request is
never validated, `handleError` treats the transport failure as a soft error, and
bktec falls back to a parallelism-0 plan that runs nothing (a green build that
tested nothing). Enforcing it client-side closes that hole, surfaces the
misconfiguration before any network call, and removes the dependency on the
server's rejection status code being a fatal 400.

This is the fail-open-friendly first resort for the narrow off-agent case the
static-parallelism fallback (TE-6274) cannot reach: it catches a misconfiguration
up front rather than turning outages into failures.

### Context

TE-6275. Companion to TE-6274 (static-parallelism fallback). Both surfaced during
review of TE-6254 (`bktec plan --plan-out`, merged); independent of it.

### Changes

- Add the `parallelism > 0` check to `ValidateForPlan` in
  `internal/config/validate.go` (fires only when both `MaxParallelism` and
  `Parallelism` are 0).

### Testing

Backed by specs: added cases for the both-zero rejection and for each parallelism
source satisfying the guard on its own, and updated the existing
skips-parallelism test to set `--max-parallelism` (it exercised the now-guarded
both-zero shape). AI assisted.
