### PR TITLE
[TE-6257] Isolate per-command cli.Flag parse state to fix order-dependent test failures

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -711,9 +711,9 @@ var cliCommand = &cli.Command{
 					Required: true,
 					Category: "PLAN OUTPUT",
 					Flags: [][]cli.Flag{
-						{jsonFlag},
-						{planOutFlag},
-						{pipelineUploadFlag},
+						{freshFlag(jsonFlag)},
+						{freshFlag(planOutFlag)},
+						{freshFlag(pipelineUploadFlag)},
 					},
 				},
 			},

--- a/cli.go
+++ b/cli.go
@@ -638,9 +638,11 @@ func freshFlag(f cli.Flag) cli.Flag {
 		c := *v
 		return &c
 	default:
-		// Unknown flag type: return as-is rather than silently dropping it. This
-		// preserves behaviour if a new flag type is introduced, at the cost of
-		// that flag not being isolated until added above.
+		// Unknown flag type: return the shared global as-is rather than dropping
+		// it, so the flag still registers and works. It is NOT isolated; its
+		// parse state can leak between commands until a case is added above.
+		// TestCommandFlagsAllReturnFreshInstances fails when an unhandled type
+		// reaches this branch, so the gap surfaces in CI rather than silently.
 		return f
 	}
 }

--- a/cli.go
+++ b/cli.go
@@ -613,6 +613,46 @@ func previewSelectionFlags() []cli.Flag {
 	}
 }
 
+// freshFlag returns a shallow copy of a flag with a distinct backing struct, so
+// urfave/cli's per-flag parse state (hasBeenSet, applied, count, value) does not
+// leak between commands built from the same package-global flag definitions. The
+// copy keeps the shared Destination pointer, so parsed values still land in cfg.
+func freshFlag(f cli.Flag) cli.Flag {
+	switch v := f.(type) {
+	case *cli.BoolFlag:
+		c := *v
+		return &c
+	case *cli.StringFlag:
+		c := *v
+		return &c
+	case *cli.IntFlag:
+		c := *v
+		return &c
+	case *cli.DurationFlag:
+		c := *v
+		return &c
+	case *cli.StringSliceFlag:
+		c := *v
+		return &c
+	case *cli.BoolWithInverseFlag:
+		c := *v
+		return &c
+	default:
+		// Unknown flag type: return as-is rather than silently dropping it. This
+		// preserves behaviour if a new flag type is introduced, at the cost of
+		// that flag not being isolated until added above.
+		return f
+	}
+}
+
+func freshFlags(flags []cli.Flag) []cli.Flag {
+	out := make([]cli.Flag, len(flags))
+	for i, f := range flags {
+		out[i] = freshFlag(f)
+	}
+	return out
+}
+
 func runCommandFlags() []cli.Flag {
 	flags := []cli.Flag{
 		filesFlag,
@@ -626,7 +666,7 @@ func runCommandFlags() []cli.Flag {
 	flags = append(flags, failOnNoTestsFlag)
 	flags = append(flags, promiseFailureFlag)
 	flags = append(flags, previewSelectionFlags()...)
-	return flags
+	return freshFlags(flags)
 }
 
 func planCommandFlags() []cli.Flag {
@@ -645,7 +685,7 @@ func planCommandFlags() []cli.Flag {
 	flags = append(flags, runnerEnvironmentFlags...)
 	flags = append(flags, parallelismFlag)
 	flags = append(flags, previewSelectionFlags()...)
-	return flags
+	return freshFlags(flags)
 }
 
 var cliCommand = &cli.Command{

--- a/cli.go
+++ b/cli.go
@@ -617,6 +617,8 @@ func previewSelectionFlags() []cli.Flag {
 // urfave/cli's per-flag parse state (hasBeenSet, applied, count, value) does not
 // leak between commands built from the same package-global flag definitions. The
 // copy keeps the shared Destination pointer, so parsed values still land in cfg.
+// urfave/cli v3 exposes no public reset for that state, so a fresh copy per
+// command is the mechanism, matching the library's own per-command flag pattern.
 func freshFlag(f cli.Flag) cli.Flag {
 	switch v := f.(type) {
 	case *cli.BoolFlag:

--- a/cli.go
+++ b/cli.go
@@ -619,6 +619,9 @@ func previewSelectionFlags() []cli.Flag {
 // copy keeps the shared Destination pointer, so parsed values still land in cfg.
 // urfave/cli v3 exposes no public reset for that state, so a fresh copy per
 // command is the mechanism, matching the library's own per-command flag pattern.
+// urfave/cli's own tests reset flags the same way, reassigning fresh flag
+// literals before re-running a command "since they are set previously":
+// https://github.com/urfave/cli/blob/4937c163f8e8bd88fdb06c4eab67cde61436c205/command_test.go#L3202
 func freshFlag(f cli.Flag) cli.Flag {
 	switch v := f.(type) {
 	case *cli.BoolFlag:

--- a/cli_test.go
+++ b/cli_test.go
@@ -194,7 +194,7 @@ func TestRunCommandEnvVarsBindToConfig(t *testing.T) {
 
 	cmd := &cli.Command{
 		Name:  "bktec",
-		Flags: []cli.Flag{debugFlag},
+		Flags: freshFlags([]cli.Flag{debugFlag}),
 		Commands: []*cli.Command{
 			{
 				Name:                      "run",
@@ -352,5 +352,30 @@ func TestRunCommandFlagsDoNotShareParseState(t *testing.T) {
 
 	if !cfg.SelectorSplitting {
 		t.Fatalf("cfg.SelectorSplitting = false, want true; flag parse state leaked between commands")
+	}
+}
+
+// TestCommandFlagsAllReturnFreshInstances asserts every flag handed out by the
+// run and plan helpers is a distinct instance, i.e. freshFlag matched a concrete
+// case rather than falling through to its default (which returns the shared
+// global unchanged). This catches a new flag type being added without a
+// corresponding freshFlag case, which would silently reintroduce the TE-6257
+// parse-state leak for that flag.
+func TestCommandFlagsAllReturnFreshInstances(t *testing.T) {
+	// Enable preview so the selection flags are included in the sweep.
+	t.Setenv(previewSelectionEnvVar, "true")
+
+	for _, tc := range []struct {
+		name  string
+		flags []cli.Flag
+	}{
+		{"run", runCommandFlags()},
+		{"plan", planCommandFlags()},
+	} {
+		for _, f := range tc.flags {
+			if freshFlag(f) == f {
+				t.Errorf("%s: freshFlag(%v) returned the shared global (type %T); add a case to freshFlag so its parse state is isolated", tc.name, f.Names(), f)
+			}
+		}
 	}
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -306,3 +306,51 @@ func TestSelectorSplittingFlagBindsToPlanConfig(t *testing.T) {
 		t.Fatalf("cfg.SelectorSplitting = false, want true")
 	}
 }
+
+// TestRunCommandFlagsDoNotShareParseState guards against the order-dependent
+// failure from TE-6257: runCommandFlags() must hand out fresh flag instances so
+// that explicitly setting a flag on one command does not leave urfave/cli's
+// hasBeenSet state on a shared flag object, which would make a later command
+// ignore the flag's env var source.
+func TestRunCommandFlagsDoNotShareParseState(t *testing.T) {
+	cfg = config.New()
+	t.Cleanup(func() { cfg = config.New() })
+
+	// First command parses --selector-splitting on the CLI.
+	first := &cli.Command{
+		Name: "bktec",
+		Commands: []*cli.Command{
+			{
+				Name:   "run",
+				Action: func(ctx context.Context, cmd *cli.Command) error { return nil },
+				Flags:  runCommandFlags(),
+			},
+		},
+	}
+	if err := first.Run(context.Background(), []string{"bktec", "run", "--selector-splitting"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second command, built independently, relies on the env var source. If the
+	// two commands shared the same flag instance, the flag's hasBeenSet state
+	// from the first parse would suppress the env var here.
+	cfg = config.New()
+	t.Setenv("BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING", "true")
+	second := &cli.Command{
+		Name: "bktec",
+		Commands: []*cli.Command{
+			{
+				Name:   "run",
+				Action: func(ctx context.Context, cmd *cli.Command) error { return nil },
+				Flags:  runCommandFlags(),
+			},
+		},
+	}
+	if err := second.Run(context.Background(), []string{"bktec", "run"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.SelectorSplitting {
+		t.Fatalf("cfg.SelectorSplitting = false, want true; flag parse state leaked between commands")
+	}
+}


### PR DESCRIPTION
### Description

Fix order-dependent failures in `cli_test.go` by giving each command its own `cli.Flag` instances.

`runCommandFlags()` and `planCommandFlags()` returned shared package-global flag pointers. urfave/cli stores per-flag parse state (`hasBeenSet`, `applied`, `count`, `value`) on the flag struct itself, so that state leaked between commands built in the same process. Once a test parsed `--selector-splitting` on the CLI, `hasBeenSet` stayed set on the shared `selectorSplittingFlag`, and `PostParse` skips the env var lookup when `hasBeenSet` is already true. A later `TestRunCommandEnvVarsBindToConfig` (which relies on `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING`) then saw `cfg.SelectorSplitting = false, want true`. The order only matters within a process, and CI runs the suite through `bktec run` test-splitting, so the order is non-deterministic across nodes.

`freshFlag`/`freshFlags` hand each command shallow copies with distinct backing structs. The copies keep the shared `Destination` pointers, so parsed values still land in `cfg`; only the leaked parse state is reset. No production behaviour change: each process builds one command.

**Decision: copy rather than reset.** urfave/cli v3 keeps `hasBeenSet`/`applied`/`count`/`value` unexported with no public reset method, so a fresh instance per command is the only way to clear the state. urfave/cli's own tests do the same, reassigning fresh flag literals before re-running a command ["since they are set previously"](https://github.com/urfave/cli/blob/4937c163f8e8bd88fdb06c4eab67cde61436c205/command_test.go#L3202). `freshFlag` centralises that reset in the flag helpers, so freshness is the default for every command rather than a per-call-site convention. The shallow copy is safe because the globals are only ever cloned, never parsed directly, so every copy starts from clean state. Converting the ~50 flag globals to constructor functions (ticket option 2), or reassigning fresh literals per test (ticket option 1), would land the same behaviour but duplicate the shared `run`/`plan`/`backfill` flag groupings, so both were rejected as disproportionate for a test-only bug.

### Context

[TE-6257](https://linear.app/buildkite/issue/TE-6257/isolate-shared-cliflag-state-in-cli-testgo-to-fix-order-dependent-test). Surfaced during buildsworth-bk review of PR #570 (TE-6254). Pre-existing on `main`, not introduced by that work.

### Changes

Best reviewed commit-by-commit.

- `cli.go`: add `freshFlag`/`freshFlags`; `runCommandFlags()`, `planCommandFlags()`, and the plan-output mutually-exclusive flags now return fresh instances.
- `cli_test.go`: build the root `debug` flag from a fresh copy; add `TestRunCommandFlagsDoNotShareParseState` (fails without the fix) and `TestCommandFlagsAllReturnFreshInstances` (fails if a new flag type slips past `freshFlag`'s type switch into the un-isolated `default` branch).

### Testing

Reproduce the failure on current `main` (before this PR):

```
git checkout main
# Minimal two-test ordering: CLI-parse test first, env-binding test second, same process
go test . -count=1 -shuffle=1 \
  -run '^(TestSelectorSplittingFlagBindsToConfig|TestRunCommandEnvVarsBindToConfig)$'
# --- FAIL: TestRunCommandEnvVarsBindToConfig
#     cli_test.go:252: cfg.SelectorSplitting = false, want true
```

Proof it is purely ordering, not a logic bug in either test:

```
# Reverse order (env-binding first) passes
go test . -count=1 -shuffle=2 \
  -run '^(TestSelectorSplittingFlagBindsToConfig|TestRunCommandEnvVarsBindToConfig)$'   # ok

# The env-binding test passes in isolation
go test . -count=1 -run '^TestRunCommandEnvVarsBindToConfig$'                            # ok
```

Full-package shuffle sweep on `main` fails on roughly 40% of seeds (1, 3, 6, 8, 12, 13, 15 of the first 15):

```
for s in $(seq 1 15); do go test . -count=1 -shuffle=$s >/dev/null 2>&1 && echo "seed=$s ok" || echo "seed=$s FAIL"; done
```

With this PR, every previously-failing seed passes under `-race`:

```
go test . -count=1                                                   # ok
for s in 1 3 6 8 12 13 15; do go test . -count=1 -race -shuffle=$s; done   # all ok
```

AI assisted.

