### PR TITLE
Support selector based splitting for jest, playwright, cypress, cucumber, and pytest

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -119,9 +119,6 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 }
 
 func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bool {
-	if cfg.TagFilters != "" {
-		return false
-	}
 	// Pytest tag filters are applied during local example collection.
 	// Selector requests skip that step, so fall back to example splitting.
 	if cfg.TagFilters != "" {

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -122,7 +122,11 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 	if cfg.TagFilters != "" {
 		return false
 	}
-
+// Pytest tag filters are applied during local example collection.
+// Selector requests skip that step, so fall back to example splitting.
+if cfg.TagFilters != "" {
+	return false
+}
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -122,11 +122,11 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 	if cfg.TagFilters != "" {
 		return false
 	}
-// Pytest tag filters are applied during local example collection.
-// Selector requests skip that step, so fall back to example splitting.
-if cfg.TagFilters != "" {
-	return false
-}
+	// Pytest tag filters are applied during local example collection.
+	// Selector requests skip that step, so fall back to example splitting.
+	if cfg.TagFilters != "" {
+		return false
+	}
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -119,6 +119,10 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 }
 
 func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bool {
+	if cfg.TagFilters != "" {
+		return false
+	}
+
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -770,6 +770,68 @@ func TestCreateRequestParams_WithTagFilters(t *testing.T) {
 	}
 }
 
+func TestCreateRequestParams_SelectorOptInIgnoredForTagFilters(t *testing.T) {
+	cfg := config.Config{
+		OrganizationSlug:  "my-org",
+		SuiteSlug:         "my-suite",
+		Identifier:        "identifier",
+		Parallelism:       2,
+		Branch:            "main",
+		TestRunner:        "pytest",
+		SelectorSplitting: true,
+		TagFilters:        "team:frontend",
+	}
+
+	client := api.NewClient(api.ClientConfig{
+		ServerBaseURL: "example.com",
+	})
+
+	files := []string{
+		"../runner/testdata/pytest/failed_test.py",
+		"../runner/testdata/pytest/test_sample.py",
+		"../runner/testdata/pytest/spells/test_expelliarmus.py",
+	}
+
+	got, err := createRequestParam(context.Background(), &cfg, files, *client, runner.Pytest{
+		RunnerConfig: runner.RunnerConfig{
+			TestCommand: "pytest",
+			TagFilters:  "team:frontend",
+		},
+	})
+	if err != nil {
+		t.Errorf("createRequestParam() error = %v", err)
+	}
+
+	want := api.TestPlanParams{
+		Identifier:  "identifier",
+		Parallelism: 2,
+		Branch:      "main",
+		Runner:      "pytest",
+		Tests: api.TestPlanParamsTest{
+			Examples: []plan.TestCase{
+				{
+					Format:     "example",
+					Identifier: "runner/testdata/pytest/test_sample.py::test_happy",
+					Name:       "test_happy",
+					Path:       "runner/testdata/pytest/test_sample.py::test_happy",
+					Scope:      "runner/testdata/pytest/test_sample.py",
+				},
+				{
+					Format:     "example",
+					Identifier: "runner/testdata/pytest/spells/test_expelliarmus.py::TestExpelliarmus::test_knocks_wand_out",
+					Name:       "test_knocks_wand_out",
+					Path:       "runner/testdata/pytest/spells/test_expelliarmus.py::TestExpelliarmus::test_knocks_wand_out",
+					Scope:      "runner/testdata/pytest/spells/test_expelliarmus.py::TestExpelliarmus",
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCreateRequestParams_WithTagFilters_NonPytest(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -328,46 +328,6 @@ func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 	}
 }
 
-func TestCreateRequestParams_SelectorOptInIgnoredForFileRunner(t *testing.T) {
-	cfg := config.Config{
-		Identifier:        "identifier",
-		Parallelism:       2,
-		Branch:            "main",
-		TestRunner:        "jest",
-		SelectorSplitting: true,
-	}
-
-	client := api.NewClient(api.ClientConfig{
-		ServerBaseURL: "http://example.com",
-	})
-	files := []string{
-		"testdata/fruits/apple.spec.js",
-		"testdata/fruits/banana.spec.js",
-	}
-
-	got, err := createRequestParam(context.Background(), &cfg, files, *client, runner.Jest{})
-	if err != nil {
-		t.Errorf("createRequestParam() error = %v", err)
-	}
-
-	want := api.TestPlanParams{
-		Identifier:  "identifier",
-		Parallelism: 2,
-		Branch:      "main",
-		Runner:      "jest",
-		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
-				{Path: "testdata/fruits/apple.spec.js"},
-				{Path: "testdata/fruits/banana.spec.js"},
-			},
-		},
-	}
-
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
-	}
-}
-
 func TestCreateRequestParams_SelectorOptInIgnoredForSplitByExampleRunner(t *testing.T) {
 	filterRequestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runner/cucumber.go
+++ b/internal/runner/cucumber.go
@@ -53,6 +53,7 @@ func (c Cucumber) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            true,
+		SplitBySelector: true,
 	}
 }
 
@@ -79,6 +80,10 @@ func (c Cucumber) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (c Cucumber) GetSelectors() ([]string, error) {
+	return c.GetFiles()
 }
 
 // Run executes the Cucumber command and records results.

--- a/internal/runner/cucumber_test.go
+++ b/internal/runner/cucumber_test.go
@@ -152,6 +152,29 @@ func TestCucumberGetFiles(t *testing.T) {
 	}
 }
 
+func TestCucumberGetSelectors(t *testing.T) {
+	cucumber := NewCucumber(RunnerConfig{
+		TestFilePattern: "testdata/cucumber/features/**/*.feature",
+	})
+
+	gotFiles, err := cucumber.GetFiles()
+	if err != nil {
+		t.Errorf("Cucumber.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := cucumber.GetSelectors()
+	if err != nil {
+		t.Errorf("Cucumber.GetSelectors() error = %v", err)
+	}
+
+	sort.Strings(gotFiles)
+	sort.Strings(gotSelectors)
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Cucumber.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCucumberGetExamples(t *testing.T) {
 	changeCwd(t, "./testdata/cucumber")
 

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -45,6 +45,7 @@ func (c Cypress) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       false,
 		Mute:            false,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -73,6 +74,10 @@ func (c Cypress) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (c Cypress) GetSelectors() ([]string, error) {
+	return c.GetFiles()
 }
 
 func (c Cypress) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -116,6 +116,24 @@ func TestCypressGetFiles(t *testing.T) {
 	}
 }
 
+func TestCypressGetSelectors(t *testing.T) {
+	cypress := NewCypress(RunnerConfig{})
+
+	gotFiles, err := cypress.GetFiles()
+	if err != nil {
+		t.Errorf("Cypress.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := cypress.GetSelectors()
+	if err != nil {
+		t.Errorf("Cypress.GetSelectors() error = %v", err)
+	}
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Cypress.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCypressCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []plan.TestCase{{Path: "cypress/e2e/passing_spec.cy.js"}, {Path: "cypress/e2e/flaky_spec.cy.js"}}
 	testCommand := "cypress run --spec {{testExamples}}"

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -45,6 +45,7 @@ func (j Jest) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -71,6 +72,10 @@ func (j Jest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (j Jest) GetSelectors() ([]string, error) {
+	return j.GetFiles()
 }
 
 func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -624,3 +624,22 @@ func TestJestGetFiles(t *testing.T) {
 		t.Errorf("Jest.GetFiles() diff (-got +want):\n%s", diff)
 	}
 }
+
+func TestJestGetSelectors(t *testing.T) {
+	changeCwd(t, "./testdata/jest")
+	jest := NewJest(RunnerConfig{})
+
+	gotFiles, err := jest.GetFiles()
+	if err != nil {
+		t.Errorf("Jest.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := jest.GetSelectors()
+	if err != nil {
+		t.Errorf("Jest.GetSelectors() error = %v", err)
+	}
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Jest.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -56,6 +56,7 @@ func (p Playwright) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -173,6 +174,10 @@ func (p Playwright) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (p Playwright) GetSelectors() ([]string, error) {
+	return p.GetFiles()
 }
 
 // GetExamples returns an array of test examples within the given files.

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -264,6 +264,25 @@ func TestPlaywrightGetFiles(t *testing.T) {
 	}
 }
 
+func TestPlaywrightGetSelectors(t *testing.T) {
+	changeCwd(t, "./testdata/playwright")
+	playwright := NewPlaywright(RunnerConfig{})
+
+	gotFiles, err := playwright.GetFiles()
+	if err != nil {
+		t.Errorf("Playwright.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := playwright.GetSelectors()
+	if err != nil {
+		t.Errorf("Playwright.GetSelectors() error = %v", err)
+	}
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Playwright.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestPlaywrightGetExamples(t *testing.T) {
 	changeCwd(t, "./testdata/playwright")
 

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -106,6 +106,7 @@ func (p Pytest) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -275,6 +276,10 @@ func (p Pytest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (p Pytest) GetSelectors() ([]string, error) {
+	return p.GetFiles()
 }
 
 // GetExamples returns an array of test examples within the given files.

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -496,6 +496,26 @@ func TestPytestGetFiles(t *testing.T) {
 	}
 }
 
+func TestPytestGetSelectors(t *testing.T) {
+	changeCwd(t, "./testdata/pytest")
+
+	pytest := NewPytest(RunnerConfig{})
+
+	gotFiles, err := pytest.GetFiles()
+	if err != nil {
+		t.Errorf("Pytest.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := pytest.GetSelectors()
+	if err != nil {
+		t.Errorf("Pytest.GetSelectors() error = %v", err)
+	}
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Pytest.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestPytestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []plan.TestCase{{Path: "failed_test.py"}, {Path: "test_sample.py"}}
 	testCommand := "pytest {{testExamples}} --full-trace --json={{resultPath}}"

--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -41,7 +41,16 @@ func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 		nunit,
 	}
 
-	supportedRunners := []string{gotest.Name(), rspec.Name(), custom.Name()}
+	supportedRunners := []string{
+		gotest.Name(),
+		rspec.Name(),
+		custom.Name(),
+		jest.Name(),
+		playwright.Name(),
+		cypress.Name(),
+		pytest.Name(),
+		cucumber.Name(),
+	}
 
 	for _, runner := range runners {
 		got := runner.SupportedFeatures().SplitBySelector


### PR DESCRIPTION
We're moving towards selector based splitting as the general way bktec splits test suites, eventually replacing file based splitting entirely. Each runner decides what a selector means for it. For `go` that's a package, for `custom` it's a user provided list, and `rspec` already added selector support where a selector is a file.

This PR adds the same file-based selector support to `jest`, `playwright`, `cypress`, `cucumber`, and `pytest`. For all of these, a selector is still just a file, so `GetSelectors` delegates straight to `GetFiles`.

Two runners aren't part of this PR:
- `nunit` is going to use class name as the selector instead of file, so it needs its own implementation.
- `pytest-pants` isn't included either. We're likely going to deprecate it soon, so it's not worth adding selector support for now.

For now selector based splitting runs alongside the existing file based splitting, and they need to behave the same way. That's what makes it easy to eventually deprecate the file based path and just use selector based splitting by default.

Note this is still experimental. It requires a feature flag on the server for intelligent test plan, so it won't do anything without that flag enabled.

### Changes

- Added `SplitBySelector: true` to jest, playwright, cypress, cucumber, and pytest's supported features
- Added `GetSelectors` to each of those runners, delegating to `GetFiles`