### PR TITLE
[TE-6302] Support selector based splitting for NUnit

### DIFF
--- a/docs/nunit.md
+++ b/docs/nunit.md
@@ -8,10 +8,10 @@ dotnet add package JUnitXml.TestLogger
 
 ## How it works
 
-`bktec` discovers `.cs` test files using a glob pattern, then maps each file to a class name (the filename without the `.cs` extension). When selector based splitting is enabled, `bktec` also reads each file's `namespace` declaration and qualifies the class name with it (e.g. `MyLib.Tests.CalculatorTests`), since that's the value NUnit itself writes to the `classname` attribute in its JUnit output. It builds a `dotnet test --filter` expression using `FullyQualifiedName~.ClassName` predicates joined with `|` (OR), so only the test classes assigned to this node are executed.
+`bktec` discovers `.cs` test files using a glob pattern, then maps each file to a class name (the filename without the `.cs` extension). It builds a `dotnet test --filter` expression using `FullyQualifiedName~.ClassName` predicates joined with `|` (OR), so only the test classes assigned to this node are executed.
 
 > [!IMPORTANT]
-> Because test splitting is based on file/class name mapping, each `.cs` test file should contain a single test class whose name matches the filename (e.g. `CalculatorTests.cs` contains class `CalculatorTests`), declared in a single `namespace`. This is the standard NUnit convention.
+> Because test splitting is based on file/class name mapping, each `.cs` test file should contain a single test class whose name matches the filename (e.g. `CalculatorTests.cs` contains class `CalculatorTests`). This is the standard NUnit convention.
 
 ## Quick start
 

--- a/docs/nunit.md
+++ b/docs/nunit.md
@@ -8,10 +8,10 @@ dotnet add package JUnitXml.TestLogger
 
 ## How it works
 
-`bktec` discovers `.cs` test files using a glob pattern, then maps each file to a class name (the filename without the `.cs` extension). It builds a `dotnet test --filter` expression using `FullyQualifiedName~.ClassName` predicates joined with `|` (OR), so only the test classes assigned to this node are executed.
+`bktec` discovers `.cs` test files using a glob pattern, then maps each file to a class name (the filename without the `.cs` extension). When selector based splitting is enabled, `bktec` also reads each file's `namespace` declaration and qualifies the class name with it (e.g. `MyLib.Tests.CalculatorTests`), since that's the value NUnit itself writes to the `classname` attribute in its JUnit output. It builds a `dotnet test --filter` expression using `FullyQualifiedName~.ClassName` predicates joined with `|` (OR), so only the test classes assigned to this node are executed.
 
 > [!IMPORTANT]
-> Because test splitting is based on file/class name mapping, each `.cs` test file should contain a single test class whose name matches the filename (e.g. `CalculatorTests.cs` contains class `CalculatorTests`). This is the standard NUnit convention.
+> Because test splitting is based on file/class name mapping, each `.cs` test file should contain a single test class whose name matches the filename (e.g. `CalculatorTests.cs` contains class `CalculatorTests`), declared in a single `namespace`. This is the standard NUnit convention.
 
 ## Quick start
 

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -119,6 +119,10 @@ func (n NUnit) GetSelectors() ([]string, error) {
 // docs/nunit.md) that each file contains a single class matching its
 // filename. Files with no namespace declaration (the global namespace) fall
 // back to the bare class name.
+//
+// Nested block-scoped namespaces (e.g. "namespace MyLib { namespace Tests {
+// ... } }") are collected in order and joined, since each nested declaration
+// only contributes its own segment to the fully qualified name.
 func namespacedClassNameForFile(path string) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -127,12 +131,18 @@ func namespacedClassNameForFile(path string) (string, error) {
 
 	className := strings.TrimSuffix(filepath.Base(path), ".cs")
 
-	match := namespaceDeclarationPattern.FindSubmatch(content)
-	if match == nil {
+	matches := namespaceDeclarationPattern.FindAllSubmatch(content, -1)
+	if matches == nil {
 		return className, nil
 	}
 
-	return string(match[1]) + "." + className, nil
+	segments := make([]string, 0, len(matches)+1)
+	for _, match := range matches {
+		segments = append(segments, string(match[1]))
+	}
+	segments = append(segments, className)
+
+	return strings.Join(segments, "."), nil
 }
 
 // Run executes dotnet test with a --filter expression built from the test cases.

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/v2/internal/debug"
@@ -21,6 +23,7 @@ func (n NUnit) SupportedFeatures() SupportedFeatures {
 	return SupportedFeatures{
 		SplitByFile:     true,
 		SplitByExample:  false,
+		SplitBySelector: true,
 		FilterTestFiles: true,
 		FilterTestByTag: false,
 		AutoRetry:       true,
@@ -76,6 +79,62 @@ func (n NUnit) GetExamples(files []string) ([]plan.TestCase, error) {
 	return nil, fmt.Errorf("not supported in NUnit")
 }
 
+// namespaceDeclarationPattern matches a C# namespace declaration at the start
+// of a line, in either the block-scoped ("namespace Foo.Bar {") or
+// file-scoped ("namespace Foo.Bar;") form.
+var namespaceDeclarationPattern = regexp.MustCompile(`(?m)^\s*namespace\s+([\w.]+)\s*[{;]`)
+
+// GetSelectors returns the namespace-qualified class names discovered from the
+// test files, for use as the explicit selector list sent to the test plan
+// API. The namespace is read from each file's `namespace` declaration, since
+// that's the value NUnit itself writes as the JUnit `classname` attribute
+// (and what ta-ingestion attributes as test.selector.primary), so the
+// selectors bktec sends line up with the historical duration data keyed on
+// that same value.
+func (n NUnit) GetSelectors() ([]string, error) {
+	files, err := n.GetFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	selectors := make([]string, 0, len(files))
+	for _, file := range files {
+		className, err := namespacedClassNameForFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine class name for %q: %w", file, err)
+		}
+		if !seen[className] {
+			selectors = append(selectors, className)
+			seen[className] = true
+		}
+	}
+
+	return selectors, nil
+}
+
+// namespacedClassNameForFile derives the namespace-qualified class name for a
+// .cs file, e.g. "MyLib.Tests.CalculatorTests" for a file declaring
+// "namespace MyLib.Tests" and relying on the documented NUnit convention (see
+// docs/nunit.md) that each file contains a single class matching its
+// filename. Files with no namespace declaration (the global namespace) fall
+// back to the bare class name.
+func namespacedClassNameForFile(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	className := strings.TrimSuffix(filepath.Base(path), ".cs")
+
+	match := namespaceDeclarationPattern.FindSubmatch(content)
+	if match == nil {
+		return className, nil
+	}
+
+	return string(match[1]) + "." + className, nil
+}
+
 // Run executes dotnet test with a --filter expression built from the test cases.
 // Test cases are mapped from .cs file paths to class names, and joined into a
 // FullyQualifiedName~ filter expression.
@@ -104,15 +163,17 @@ func (n NUnit) Run(result *RunResult, testCases []plan.TestCase, retry bool) err
 	return cmdErr
 }
 
-// extractClassNames extracts unique class names from test case paths.
-// Each path is expected to be a .cs file path like "tests/MyLib.Tests/CalculatorTests.cs".
-// The class name is the filename without extension, e.g. "CalculatorTests".
+// extractClassNames extracts unique class names from test cases.
+// For selector-based test cases, the class name is already resolved in
+// tc.Value. For file-based test cases, tc.Path is expected to be a .cs file
+// path like "tests/MyLib.Tests/CalculatorTests.cs", and the class name is the
+// filename without extension, e.g. "CalculatorTests".
 func extractClassNames(testCases []plan.TestCase) []string {
 	seen := map[string]bool{}
 	var classNames []string
 
 	for _, tc := range testCases {
-		className := strings.TrimSuffix(filepath.Base(tc.Path), ".cs")
+		className := classNameFromTestCase(tc)
 		if !seen[className] {
 			classNames = append(classNames, className)
 			seen[className] = true
@@ -120,6 +181,17 @@ func extractClassNames(testCases []plan.TestCase) []string {
 	}
 
 	return classNames
+}
+
+// classNameFromTestCase resolves the NUnit class name for a single test case,
+// mirroring how gotest's packageFromTestCase resolves a package name: use the
+// explicit selector value when the test plan already gave us one, otherwise
+// derive it from the .cs file path.
+func classNameFromTestCase(tc plan.TestCase) string {
+	if tc.Format == plan.TestCaseFormatSelector {
+		return tc.Value
+	}
+	return strings.TrimSuffix(filepath.Base(tc.Path), ".cs")
 }
 
 // buildTestFilter constructs a dotnet test --filter expression from class names.

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,12 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/kballard/go-shellquote"
 )
+
+// utf8BOM is the byte sequence Visual Studio commonly writes at the start of
+// a .cs file. Go's regexp \s class doesn't treat it as whitespace, so a
+// namespace declaration on the file's first line would otherwise fail to
+// match namespaceDeclarationPattern's "^" anchor.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 type NUnit struct {
 	RunnerConfig
@@ -124,6 +131,7 @@ func namespacedClassNameForFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	content = bytes.TrimPrefix(content, utf8BOM)
 
 	className := strings.TrimSuffix(filepath.Base(path), ".cs")
 

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -195,14 +195,23 @@ func classNameFromTestCase(tc plan.TestCase) string {
 }
 
 // buildTestFilter constructs a dotnet test --filter expression from class names.
-// Each class name becomes a "FullyQualifiedName~.ClassName" predicate,
-// joined with "|" (OR).
-// The "~" operator is a "contains" match and the leading "." anchors to a
-// namespace boundary, preventing false positives on partial name matches.
+// Each class name becomes a "FullyQualifiedName~" predicate, joined with "|" (OR).
+// The "~" operator is a "contains" match.
+//
+// Namespace-qualified class names (e.g. "MyLib.Tests.CalculatorTests") already
+// spell out the full path from the root namespace, so they're matched as-is;
+// a leading "." would never match, since there's no namespace segment before
+// the root one. Bare class names (e.g. "CalculatorTests") get a leading "."
+// to anchor to a namespace/class boundary, preventing false positives on
+// partial name matches (e.g. "SubCalculatorTests").
 func buildTestFilter(classNames []string) string {
 	parts := make([]string, len(classNames))
 	for i, name := range classNames {
-		parts[i] = fmt.Sprintf("FullyQualifiedName~.%s", name)
+		if strings.Contains(name, ".") {
+			parts[i] = fmt.Sprintf("FullyQualifiedName~%s", name)
+		} else {
+			parts[i] = fmt.Sprintf("FullyQualifiedName~.%s", name)
+		}
 	}
 	return strings.Join(parts, "|")
 }

--- a/internal/runner/nunit.go
+++ b/internal/runner/nunit.go
@@ -117,12 +117,8 @@ func (n NUnit) GetSelectors() ([]string, error) {
 // .cs file, e.g. "MyLib.Tests.CalculatorTests" for a file declaring
 // "namespace MyLib.Tests" and relying on the documented NUnit convention (see
 // docs/nunit.md) that each file contains a single class matching its
-// filename. Files with no namespace declaration (the global namespace) fall
-// back to the bare class name.
-//
-// Nested block-scoped namespaces (e.g. "namespace MyLib { namespace Tests {
-// ... } }") are collected in order and joined, since each nested declaration
-// only contributes its own segment to the fully qualified name.
+// filename. Files with no enclosing namespace declaration (the global
+// namespace, or the class can't be located) fall back to the bare class name.
 func namespacedClassNameForFile(path string) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -131,18 +127,101 @@ func namespacedClassNameForFile(path string) (string, error) {
 
 	className := strings.TrimSuffix(filepath.Base(path), ".cs")
 
-	matches := namespaceDeclarationPattern.FindAllSubmatch(content, -1)
-	if matches == nil {
-		return className, nil
+	classIndex := len(content)
+	if loc := classDeclarationPattern(className).FindIndex(content); loc != nil {
+		classIndex = loc[0]
 	}
 
-	segments := make([]string, 0, len(matches)+1)
-	for _, match := range matches {
-		segments = append(segments, string(match[1]))
-	}
-	segments = append(segments, className)
+	segments := append(enclosingNamespaceSegments(content, classIndex), className)
 
 	return strings.Join(segments, "."), nil
+}
+
+// classDeclarationPattern builds a pattern matching a "class ClassName"
+// declaration, used to locate the byte offset the enclosing namespace lookup
+// should stop at.
+func classDeclarationPattern(className string) *regexp.Regexp {
+	return regexp.MustCompile(`\bclass\s+` + regexp.QuoteMeta(className) + `\b`)
+}
+
+// enclosingNamespaceSegments walks the namespace declarations before
+// byte offset upTo, tracking brace depth, and returns the segments of the
+// ones still open at that point, in outer-to-inner order.
+//
+// This scopes the lookup to namespaces that actually enclose the target
+// class, rather than every namespace declared anywhere in the file: a sibling
+// namespace declared before or after the target class's block (e.g.
+// "namespace MyLib.Tests { class CalculatorTests {} } namespace Helpers {}")
+// opens and/or closes outside the target's brace depth, so it's excluded.
+// Nested block-scoped namespaces (e.g. "namespace MyLib { namespace Tests {
+// ... } }") are still collected in order and joined, since each contributes
+// its own segment to the fully qualified name.
+//
+// Brace depth is tracked by counting every "{"/"}" byte in the file, without
+// understanding comments or string literals, which mirrors the level of
+// fragility already accepted by namespaceDeclarationPattern itself.
+func enclosingNamespaceSegments(content []byte, upTo int) []string {
+	type frame struct {
+		depth   int
+		segment string
+	}
+
+	var stack []frame
+	depth := 0
+	pos := 0
+
+	popClosed := func() {
+		for len(stack) > 0 && depth <= stack[len(stack)-1].depth {
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	for _, m := range namespaceDeclarationPattern.FindAllSubmatchIndex(content, -1) {
+		start, end := m[0], m[1]
+		if start >= upTo {
+			break
+		}
+
+		depth += braceDelta(content[pos:start])
+		popClosed()
+
+		// A block-scoped namespace ("namespace X {") closes when depth drops
+		// back to its pre-block depth, so record that depth. A file-scoped
+		// namespace ("namespace X;") has no closing brace and applies for
+		// the rest of the file, so use a depth no valid brace nesting can
+		// ever drop back to, keeping it on the stack permanently.
+		frameDepth := depth
+		if content[end-1] == '{' {
+			depth++
+		} else {
+			frameDepth = -1
+		}
+		stack = append(stack, frame{depth: frameDepth, segment: string(content[m[2]:m[3]])})
+		pos = end
+	}
+
+	depth += braceDelta(content[pos:upTo])
+	popClosed()
+
+	segments := make([]string, len(stack))
+	for i, f := range stack {
+		segments[i] = f.segment
+	}
+	return segments
+}
+
+// braceDelta counts the net change in brace depth across b.
+func braceDelta(b []byte) int {
+	delta := 0
+	for _, c := range b {
+		switch c {
+		case '{':
+			delta++
+		case '}':
+			delta--
+		}
+	}
+	return delta
 }
 
 // Run executes dotnet test with a --filter expression built from the test cases.

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -171,6 +171,11 @@ func TestNUnit_NamespacedClassNameForFile(t *testing.T) {
 			content: "namespace Helpers\n{\n    public class SomeHelper {}\n}\n\nnamespace MyLib.Tests\n{\n    public class CalculatorTests {}\n}\n",
 			want:    "MyLib.Tests.CalculatorTests",
 		},
+		{
+			name:    "UTF-8 BOM before a namespace on the first line",
+			content: "\xEF\xBB\xBFnamespace MyLib.Tests;\n\npublic class CalculatorTests {}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -156,6 +156,11 @@ func TestNUnit_NamespacedClassNameForFile(t *testing.T) {
 			content: "// namespace NotTheRealNamespace;\nnamespace MyLib.Tests;\n\npublic class CalculatorTests {}\n",
 			want:    "MyLib.Tests.CalculatorTests",
 		},
+		{
+			name:    "nested block-scoped namespaces",
+			content: "using NUnit.Framework;\n\nnamespace MyLib\n{\n    namespace Tests\n    {\n        public class CalculatorTests {}\n    }\n}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -228,6 +228,14 @@ func TestNUnit_BuildTestFilter(t *testing.T) {
 			classNames: []string{"CalculatorTests", "StringUtilsTests"},
 			want:       "FullyQualifiedName~.CalculatorTests|FullyQualifiedName~.StringUtilsTests",
 		},
+		{
+			classNames: []string{"MyLib.Tests.CalculatorTests"},
+			want:       "FullyQualifiedName~MyLib.Tests.CalculatorTests",
+		},
+		{
+			classNames: []string{"MyLib.Tests.CalculatorTests", "StringUtilsTests"},
+			want:       "FullyQualifiedName~MyLib.Tests.CalculatorTests|FullyQualifiedName~.StringUtilsTests",
+		},
 	}
 
 	for _, c := range cases {
@@ -275,8 +283,8 @@ func TestNUnit_CommandNameAndArgs_Selector(t *testing.T) {
 	})
 
 	testCases := []plan.TestCase{
-		{Format: plan.TestCaseFormatSelector, Value: "CalculatorTests"},
-		{Format: plan.TestCaseFormatSelector, Value: "StringUtilsTests"},
+		{Format: plan.TestCaseFormatSelector, Value: "MyLib.Tests.CalculatorTests"},
+		{Format: plan.TestCaseFormatSelector, Value: "MyLib.Tests.StringUtilsTests"},
 	}
 
 	gotName, gotArgs, err := nunit.CommandNameAndArgs(testCases, false)
@@ -289,7 +297,7 @@ func TestNUnit_CommandNameAndArgs_Selector(t *testing.T) {
 		"test",
 		"--no-build",
 		"--filter",
-		"FullyQualifiedName~.CalculatorTests|FullyQualifiedName~.StringUtilsTests",
+		"FullyQualifiedName~MyLib.Tests.CalculatorTests|FullyQualifiedName~MyLib.Tests.StringUtilsTests",
 		"--logger",
 		"junit;LogFilePath=test-results.xml",
 	}

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -1,6 +1,9 @@
 package runner
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
@@ -64,6 +67,116 @@ func TestNUnit_GetFiles(t *testing.T) {
 	}
 }
 
+func TestNUnit_GetSelectors(t *testing.T) {
+	changeCwd(t, "./testdata/nunit")
+
+	nunit := NewNUnit(RunnerConfig{
+		TestFilePattern: "tests/**/*Tests.cs",
+	})
+
+	got, err := nunit.GetSelectors()
+	if err != nil {
+		t.Errorf("NUnit.GetSelectors() error = %v", err)
+	}
+
+	want := []string{"MyLib.Tests.CalculatorTests", "MyLib.Tests.SimpleStackTests", "MyLib.Tests.StringUtilsTests"}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("NUnit.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
+// TestNUnit_GetSelectors_SameFilenameDifferentNamespace guards against the
+// collision extractClassNames has: two files with the same filename but
+// different namespaces used to collapse into a single, ambiguous class name.
+// GetSelectors should keep them distinct by qualifying each with its
+// namespace.
+func TestNUnit_GetSelectors_SameFilenameDifferentNamespace(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestFile := func(t *testing.T, subdir, namespace string) {
+		t.Helper()
+		fullDir := filepath.Join(dir, "tests", subdir)
+		if err := os.MkdirAll(fullDir, 0o755); err != nil {
+			t.Fatalf("os.MkdirAll() error = %v", err)
+		}
+		content := "namespace " + namespace + ";\n\npublic class CalculatorTests {}\n"
+		if err := os.WriteFile(filepath.Join(fullDir, "CalculatorTests.cs"), []byte(content), 0o644); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+	}
+
+	writeTestFile(t, "MyLib.Tests", "MyLib.Tests")
+	writeTestFile(t, "OtherLib.Tests", "OtherLib.Tests")
+
+	changeCwd(t, dir)
+
+	nunit := NewNUnit(RunnerConfig{
+		TestFilePattern: "tests/**/*Tests.cs",
+	})
+
+	got, err := nunit.GetSelectors()
+	if err != nil {
+		t.Errorf("NUnit.GetSelectors() error = %v", err)
+	}
+
+	want := []string{"MyLib.Tests.CalculatorTests", "OtherLib.Tests.CalculatorTests"}
+
+	sort.Strings(got)
+	sort.Strings(want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("NUnit.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestNUnit_NamespacedClassNameForFile(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "block-scoped namespace",
+			content: "using NUnit.Framework;\n\nnamespace MyLib.Tests\n{\n    public class CalculatorTests {}\n}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
+		{
+			name:    "file-scoped namespace",
+			content: "using NUnit.Framework;\n\nnamespace MyLib.Tests;\n\npublic class CalculatorTests {}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
+		{
+			name:    "no namespace declared",
+			content: "public class CalculatorTests {}\n",
+			want:    "CalculatorTests",
+		},
+		{
+			name:    "commented out namespace line is ignored",
+			content: "// namespace NotTheRealNamespace;\nnamespace MyLib.Tests;\n\npublic class CalculatorTests {}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := dir + "/CalculatorTests.cs"
+			if err := os.WriteFile(path, []byte(c.content), 0o644); err != nil {
+				t.Fatalf("os.WriteFile() error = %v", err)
+			}
+
+			got, err := namespacedClassNameForFile(path)
+			if err != nil {
+				t.Errorf("namespacedClassNameForFile() error = %v", err)
+			}
+			if got != c.want {
+				t.Errorf("namespacedClassNameForFile() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestNUnit_GetExamples(t *testing.T) {
 	nunit := NewNUnit(RunnerConfig{})
 	_, err := nunit.GetExamples([]string{"tests/MyLib.Tests/CalculatorTests.cs"})
@@ -77,6 +190,21 @@ func TestNUnit_ExtractClassNames(t *testing.T) {
 		{Path: "tests/MyLib.Tests/CalculatorTests.cs"},
 		{Path: "tests/MyLib.Tests/StringUtilsTests.cs"},
 		{Path: "tests/MyLib.Tests/CalculatorTests.cs"}, // duplicate
+	}
+
+	got := extractClassNames(testCases)
+	want := []string{"CalculatorTests", "StringUtilsTests"}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("extractClassNames() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestNUnit_ExtractClassNames_Selector(t *testing.T) {
+	testCases := []plan.TestCase{
+		{Format: plan.TestCaseFormatSelector, Value: "CalculatorTests"},
+		{Format: plan.TestCaseFormatSelector, Value: "StringUtilsTests"},
+		{Format: plan.TestCaseFormatSelector, Value: "CalculatorTests"}, // duplicate
 	}
 
 	got := extractClassNames(testCases)
@@ -118,6 +246,40 @@ func TestNUnit_CommandNameAndArgs(t *testing.T) {
 	classNames := []plan.TestCase{{Path: "CalculatorTests"}, {Path: "StringUtilsTests"}}
 
 	gotName, gotArgs, err := nunit.CommandNameAndArgs(classNames, false)
+	if err != nil {
+		t.Errorf("commandNameAndArgs() error = %v", err)
+	}
+
+	wantName := "dotnet"
+	wantArgs := []string{
+		"test",
+		"--no-build",
+		"--filter",
+		"FullyQualifiedName~.CalculatorTests|FullyQualifiedName~.StringUtilsTests",
+		"--logger",
+		"junit;LogFilePath=test-results.xml",
+	}
+
+	if gotName != wantName {
+		t.Errorf("commandNameAndArgs() name = %v, want %v", gotName, wantName)
+	}
+
+	if diff := cmp.Diff(gotArgs, wantArgs); diff != "" {
+		t.Errorf("commandNameAndArgs() args diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestNUnit_CommandNameAndArgs_Selector(t *testing.T) {
+	nunit := NewNUnit(RunnerConfig{
+		ResultPath: "test-results.xml",
+	})
+
+	testCases := []plan.TestCase{
+		{Format: plan.TestCaseFormatSelector, Value: "CalculatorTests"},
+		{Format: plan.TestCaseFormatSelector, Value: "StringUtilsTests"},
+	}
+
+	gotName, gotArgs, err := nunit.CommandNameAndArgs(testCases, false)
 	if err != nil {
 		t.Errorf("commandNameAndArgs() error = %v", err)
 	}

--- a/internal/runner/nunit_test.go
+++ b/internal/runner/nunit_test.go
@@ -161,6 +161,16 @@ func TestNUnit_NamespacedClassNameForFile(t *testing.T) {
 			content: "using NUnit.Framework;\n\nnamespace MyLib\n{\n    namespace Tests\n    {\n        public class CalculatorTests {}\n    }\n}\n",
 			want:    "MyLib.Tests.CalculatorTests",
 		},
+		{
+			name:    "sibling namespace after the target class is ignored",
+			content: "namespace MyLib.Tests\n{\n    public class CalculatorTests {}\n}\n\nnamespace Helpers\n{\n    public class SomeHelper {}\n}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
+		{
+			name:    "sibling namespace before the target class is ignored",
+			content: "namespace Helpers\n{\n    public class SomeHelper {}\n}\n\nnamespace MyLib.Tests\n{\n    public class CalculatorTests {}\n}\n",
+			want:    "MyLib.Tests.CalculatorTests",
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -48,6 +48,7 @@ func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 		cypress.Name(),
 		pytest.Name(),
 		cucumber.Name(),
+		nunit.Name(),
 	}
 
 	for _, runner := range runners {

--- a/internal/runner/testdata/nunit/tests/MyLib.Tests/CalculatorTests.cs
+++ b/internal/runner/testdata/nunit/tests/MyLib.Tests/CalculatorTests.cs
@@ -1,1 +1,13 @@
-// Test fixture placeholder for bktec test splitting discovery.
+using NUnit.Framework;
+
+namespace MyLib.Tests
+{
+    public class CalculatorTests
+    {
+        [Test]
+        public void AddTwoNumbers()
+        {
+            Assert.That(1 + 1, Is.EqualTo(2));
+        }
+    }
+}

--- a/internal/runner/testdata/nunit/tests/MyLib.Tests/SimpleStackTests.cs
+++ b/internal/runner/testdata/nunit/tests/MyLib.Tests/SimpleStackTests.cs
@@ -1,1 +1,13 @@
-// Test fixture placeholder for bktec test splitting discovery.
+using NUnit.Framework;
+
+namespace MyLib.Tests
+{
+    public class SimpleStackTests
+    {
+        [Test]
+        public void PushAndPop()
+        {
+            Assert.Pass();
+        }
+    }
+}

--- a/internal/runner/testdata/nunit/tests/MyLib.Tests/StringUtilsTests.cs
+++ b/internal/runner/testdata/nunit/tests/MyLib.Tests/StringUtilsTests.cs
@@ -1,1 +1,12 @@
-// Test fixture placeholder for bktec test splitting discovery.
+using NUnit.Framework;
+
+namespace MyLib.Tests;
+
+public class StringUtilsTests
+{
+    [Test]
+    public void ReverseString()
+    {
+        Assert.That("ab".Length, Is.EqualTo(2));
+    }
+}


### PR DESCRIPTION
### Description

This PR adds selector based splitting for `nunit`, following on from TE-6222 which added it for `jest`, `playwright`, `cypress`, `cucumber`, and `pytest` (with `rspec` done separately).

The ticket suggested using bare class names based on the filename, which is what bktec already does today for file based splitting. But that would break things:

- Bare class names risk collisions: two files with the same name in different namespaces would collapse into one ambiguous selector.
- TE-6303 (ta-ingestion) tags `test.selector.primary` from JUnit's `classname` attribute, which NUnit always writes as the full namespace-qualified name. Bare class names would never match that, so historical duration data could never join up with bktec's selectors.

So instead, `GetSelectors` reads each file's `namespace` declaration and combines it with the filename-derived class name.

I also looked at `dotnet test --list-tests` to get the real namespace-qualified name instead of parsing the file. I ruled it out because it doesn't reliably print fully-qualified names by default, you need non-default NUnit adapter settings to get that, and even then the separator doesn't match JUnit's dotted classname format.

### Context

- [TE-6302](https://linear.app/buildkite/issue/TE-6302/support-selector-based-splitting-for-nunit)
- Part of [TE-6222](https://linear.app/buildkite/issue/TE-6222/support-other-runners-for-selector-splitting-in-bktec)
- Related to [TE-6303](https://linear.app/buildkite/issue/TE-6303/ta-ingestion-attribute-nunit-classname-as-testselectorprimary) (ta-ingestion), which needs to tag `test.selector.primary` using the same namespace-qualified value
- Left a comment on the ticket with the full reasoning for the approach change

### Changes

- Added `GetSelectors` to the NUnit runner, deriving namespace-qualified class names from each file's `namespace` declaration
- Added `SplitBySelector: true` to NUnit's supported features
- Updated `CommandNameAndArgs`/`buildTestFilter` to branch per test case (mirroring `gotest`'s `packageFromTestCase`): use `tc.Value` directly for selector-format test cases, fall back to the existing file-path-based class name extraction otherwise
- Updated `docs/nunit.md` to document that selectors are namespace-qualified

### Testing

- Added unit tests for `GetSelectors`, the namespace parsing helper (block-scoped and file-scoped syntax, no namespace, commented-out namespace lines), and the selector-format branch in `CommandNameAndArgs`
- Added a test with two files sharing a filename but different namespaces to confirm they no longer collapse into one selector
- Replaced the placeholder `.cs` test fixtures with real NUnit code so the namespace parsing is actually exercised