### PR TITLE
Support skipped tests in selector split plans

### DIFF
--- a/internal/command/path.go
+++ b/internal/command/path.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // prefixFilePaths prepends the given prefix to the file paths of the test cases.
@@ -15,6 +16,9 @@ func prefixPath(path string, prefix string) string {
 	// Some test collectors (e.g. Rspec) report file paths with a "./" by default.
 	// Since `filepath.Join` ignore "./", we need to handle this case separately to avoid losing the "./" prefix.
 	if prefix == "./" {
+		if strings.HasPrefix(path, "./") {
+			return path
+		}
 		prefixedPath = prefix + path
 	} else {
 		prefixedPath = filepath.Join(prefix, path)

--- a/internal/command/path_test.go
+++ b/internal/command/path_test.go
@@ -11,6 +11,7 @@ func TestPrefixFilePath(t *testing.T) {
 
 	cases := []struct {
 		prefix   string
+		path     string
 		expected string
 	}{
 		{
@@ -29,10 +30,19 @@ func TestPrefixFilePath(t *testing.T) {
 			prefix:   "./",
 			expected: "./spec/models/user_spec.rb",
 		},
+		{
+			prefix:   "./",
+			path:     "./spec/models/user_spec.rb",
+			expected: "./spec/models/user_spec.rb",
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.prefix, func(t *testing.T) {
+			path := path
+			if c.path != "" {
+				path = c.path
+			}
 			got := prefixPath(path, c.prefix)
 			if diff := cmp.Diff(got, c.expected); diff != "" {
 				t.Errorf("prefixPath() diff (-got +want):\n%s", diff)

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -25,12 +25,28 @@ import (
 // Currently only the Pytest runner supports tag filtering.
 func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	if shouldUseSelectorSplitting(cfg, runner) {
+		if shouldExpandSelectorFilesForSkippedTests(runner) {
+			testParams, err := filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
+			if err != nil {
+				return api.TestPlanParams{}, err
+			}
+
+			return api.TestPlanParams{
+				Identifier:     cfg.Identifier,
+				Parallelism:    cfg.Parallelism,
+				MaxParallelism: cfg.MaxParallelism,
+				TargetTime:     cfg.TargetTime.Seconds(),
+				Branch:         cfg.Branch,
+				Selection:      buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams),
+				Metadata:       cfg.Metadata,
+				Runner:         cfg.TestRunner,
+				Tests:          testParams,
+			}, nil
+		}
+
 		// For selector-capable runners, discovered test targets are already runnable
 		// selector values, e.g. Go package import paths, not file paths.
-		selectors := make([]api.TestPlanParamsSelector, 0, len(testTargets))
-		for _, target := range testTargets {
-			selectors = append(selectors, api.TestPlanParamsSelector{Value: target})
-		}
+		selectors := selectorParamsFromValues(testTargets)
 
 		return api.TestPlanParams{
 			Identifier:     cfg.Identifier,
@@ -119,6 +135,19 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 
+func shouldExpandSelectorFilesForSkippedTests(runner runner.TestRunner) bool {
+	features := runner.SupportedFeatures()
+	return features.SplitBySelector && features.SplitByExample && features.FilterTestFiles && features.Skip
+}
+
+func selectorParamsFromValues(values []string) []api.TestPlanParamsSelector {
+	selectors := make([]api.TestPlanParamsSelector, 0, len(values))
+	for _, value := range values {
+		selectors = append(selectors, api.TestPlanParamsSelector{Value: value})
+	}
+	return selectors
+}
+
 // buildSelectionParams returns the selection payload sent to the Test Engine
 // API, or nil when no strategy was requested.
 //
@@ -196,32 +225,87 @@ func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPla
 	}, nil
 }
 
+// filterAndSplitSelectorFiles filters selector-backed file targets through the Test Engine API and splits
+// filtered files into examples. It returns examples for the filtered files and selectors for the remaining files.
+func filterAndSplitSelectorFiles(ctx context.Context, cfg *config.Config, client api.Client, selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+	testFiles := make([]plan.TestCase, 0, len(selectors))
+	for _, selector := range selectors {
+		testFiles = append(testFiles, plan.TestCase{Path: prefixPath(selector, runner.LocationPrefix())})
+	}
+
+	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, testFiles, runner, "selector-backed files")
+	if err != nil {
+		return api.TestPlanParamsTest{}, err
+	}
+
+	if len(filteredFilesMap) == 0 {
+		return api.TestPlanParamsTest{
+			Selectors: selectorParamsFromValues(selectors),
+		}, nil
+	}
+
+	remainingSelectors := make([]string, 0, len(testFiles)-len(filteredFilesMap))
+	for i, file := range testFiles {
+		if _, ok := filteredFilesMap[file.Path]; !ok {
+			remainingSelectors = append(remainingSelectors, selectors[i])
+		}
+	}
+
+	return api.TestPlanParamsTest{
+		Examples:  examples,
+		Selectors: selectorParamsFromValues(remainingSelectors),
+	}, nil
+}
+
 // filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
 // It returns the test plan parameters with the examples from the filtered files and the remaining files that are not filtered.
 // An error is returned if there is a failure in any of the process.
 func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []plan.TestCase, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	// Filter files that need to be split.
-	debug.Printf("Filtering %d files", len(allTestFiles))
-	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
-		Files: allTestFiles,
-		Env:   cfg.EnvPayload(),
-	})
+	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, allTestFiles, runner, "files")
 	if err != nil {
-		return api.TestPlanParamsTest{}, fmt.Errorf("filter tests: %w", err)
+		return api.TestPlanParamsTest{}, err
 	}
 
 	// If no files are filtered, return all the files.
-	if len(filteredFiles) == 0 {
-		debug.Println("No filtered files found")
+	if len(filteredFilesMap) == 0 {
 		return api.TestPlanParamsTest{
 			Files: allTestFiles,
 		}, nil
 	}
 
-	debug.Printf("Filtered %d files", len(filteredFiles))
-	debug.Printf("Getting examples for %d filtered files", len(filteredFiles))
+	// Get the remaining files that are not filtered.
+	remainingFiles := make([]plan.TestCase, 0, len(allTestFiles)-len(filteredFilesMap))
+	for _, file := range allTestFiles {
+		if _, ok := filteredFilesMap[file.Path]; !ok {
+			remainingFiles = append(remainingFiles, file)
+		}
+	}
+
+	return api.TestPlanParamsTest{
+		Examples: examples,
+		Files:    remainingFiles,
+	}, nil
+}
+
+func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Client, files []plan.TestCase, runner runner.TestRunner, label string) ([]plan.TestCase, map[string]bool, error) {
+	debug.Printf("Filtering %d %s", len(files), label)
+	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
+		Files: files,
+		Env:   cfg.EnvPayload(),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("filter tests: %w", err)
+	}
 
 	filteredFilesMap := make(map[string]bool, len(filteredFiles))
+	if len(filteredFiles) == 0 {
+		debug.Printf("No filtered %s found", label)
+		return nil, filteredFilesMap, nil
+	}
+
+	debug.Printf("Filtered %d %s", len(filteredFiles), label)
+	debug.Printf("Getting examples for %d filtered %s", len(filteredFiles), label)
+
 	filteredFilesPath := make([]string, 0, len(filteredFiles))
 	for _, file := range filteredFiles {
 		filteredFilesMap[file.Path] = true
@@ -233,21 +317,9 @@ func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Cli
 	// then re-apply the prefix to the example paths collected by the runner.
 	examples, err := getExamplesWithPrefix(filteredFilesPath, runner)
 	if err != nil {
-		return api.TestPlanParamsTest{}, err
+		return nil, nil, err
 	}
 
-	debug.Printf("Got %d examples within the filtered files", len(examples))
-
-	// Get the remaining files that are not filtered.
-	remainingFiles := make([]plan.TestCase, 0, len(allTestFiles)-len(filteredFiles))
-	for _, file := range allTestFiles {
-		if _, ok := filteredFilesMap[file.Path]; !ok {
-			remainingFiles = append(remainingFiles, file)
-		}
-	}
-
-	return api.TestPlanParamsTest{
-		Examples: examples,
-		Files:    remainingFiles,
-	}, nil
+	debug.Printf("Got %d examples within the filtered %s", len(examples), label)
+	return examples, filteredFilesMap, nil
 }

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -231,6 +232,248 @@ func TestCreateRequestParams_GoTestSelectorSplitting(t *testing.T) {
 	}
 }
 
+func TestCreateRequestParams_RSpecSelectorSplittingExpandsFilteredFiles(t *testing.T) {
+	filterRequestCount := 0
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filterRequestCount++
+		fmt.Fprint(w, `
+{
+	"tests": [
+		{ "path": "testdata/rspec/spec/fruits/banana_spec.rb", "reason": "file contains 1 or more skipped tests" }
+	]
+}`)
+	}))
+	defer svr.Close()
+
+	cfg := config.Config{
+		OrganizationSlug:  "my-org",
+		SuiteSlug:         "my-suite",
+		Identifier:        "identifier",
+		Parallelism:       2,
+		Branch:            "main",
+		TestRunner:        "rspec",
+		SelectorSplitting: true,
+	}
+
+	client := api.NewClient(api.ClientConfig{
+		ServerBaseURL: svr.URL,
+	})
+	selectors := []string{
+		"testdata/rspec/spec/fruits/apple_spec.rb",
+		"testdata/rspec/spec/fruits/banana_spec.rb",
+		"testdata/rspec/spec/fruits/cherry_spec.rb",
+	}
+
+	testRunner := metadataTestRunner{
+		name: "rspec",
+		supportedFeatures: runner.SupportedFeatures{
+			SplitByExample:  true,
+			SplitBySelector: true,
+			FilterTestFiles: true,
+			Skip:            true,
+		},
+		examples: []plan.TestCase{
+			{
+				Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Name:       "is yellow",
+				Path:       "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Scope:      "Banana",
+			},
+		},
+	}
+
+	got, err := createRequestParam(context.Background(), &cfg, selectors, *client, testRunner)
+	if err != nil {
+		t.Errorf("createRequestParam() error = %v", err)
+	}
+
+	if filterRequestCount != 1 {
+		t.Errorf("filter request count = %d, want 1", filterRequestCount)
+	}
+
+	want := api.TestPlanParams{
+		Identifier:  "identifier",
+		Parallelism: 2,
+		Branch:      "main",
+		Runner:      "rspec",
+		Tests: api.TestPlanParamsTest{
+			Examples: []plan.TestCase{
+				{
+					Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Name:       "is yellow",
+					Path:       "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Scope:      "Banana",
+				},
+			},
+			Selectors: []api.TestPlanParamsSelector{
+				{Value: "testdata/rspec/spec/fruits/apple_spec.rb"},
+				{Value: "testdata/rspec/spec/fruits/cherry_spec.rb"},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCreateRequestParams_RSpecSelectorSplittingNoFilteredFiles(t *testing.T) {
+	filterRequestCount := 0
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filterRequestCount++
+		fmt.Fprint(w, `{"tests": []}`)
+	}))
+	defer svr.Close()
+
+	cfg := config.Config{
+		OrganizationSlug:  "my-org",
+		SuiteSlug:         "my-suite",
+		Identifier:        "identifier",
+		Parallelism:       2,
+		Branch:            "main",
+		TestRunner:        "rspec",
+		SelectorSplitting: true,
+	}
+
+	client := api.NewClient(api.ClientConfig{
+		ServerBaseURL: svr.URL,
+	})
+	selectors := []string{
+		"testdata/rspec/spec/fruits/apple_spec.rb",
+		"testdata/rspec/spec/fruits/banana_spec.rb",
+	}
+
+	testRunner := metadataTestRunner{
+		name: "rspec",
+		supportedFeatures: runner.SupportedFeatures{
+			SplitByExample:  true,
+			SplitBySelector: true,
+			FilterTestFiles: true,
+			Skip:            true,
+		},
+	}
+
+	got, err := createRequestParam(context.Background(), &cfg, selectors, *client, testRunner)
+	if err != nil {
+		t.Errorf("createRequestParam() error = %v", err)
+	}
+
+	if filterRequestCount != 1 {
+		t.Errorf("filter request count = %d, want 1", filterRequestCount)
+	}
+
+	want := api.TestPlanParams{
+		Identifier:  "identifier",
+		Parallelism: 2,
+		Branch:      "main",
+		Runner:      "rspec",
+		Tests: api.TestPlanParamsTest{
+			Selectors: []api.TestPlanParamsSelector{
+				{Value: "testdata/rspec/spec/fruits/apple_spec.rb"},
+				{Value: "testdata/rspec/spec/fruits/banana_spec.rb"},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing.T) {
+	var gotFilterParams api.FilterTestsParams
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotFilterParams); err != nil {
+			t.Fatalf("decoding filter_tests request: %v", err)
+		}
+		fmt.Fprint(w, `
+{
+	"tests": [
+		{ "path": "my/project/testdata/rspec/spec/fruits/banana_spec.rb", "reason": "file contains 1 or more skipped tests" }
+	]
+}`)
+	}))
+	defer svr.Close()
+
+	cfg := config.Config{
+		OrganizationSlug:  "my-org",
+		SuiteSlug:         "my-suite",
+		Identifier:        "identifier",
+		Parallelism:       2,
+		Branch:            "main",
+		TestRunner:        "rspec",
+		SelectorSplitting: true,
+		LocationPrefix:    "my/project",
+	}
+
+	client := api.NewClient(api.ClientConfig{
+		ServerBaseURL: svr.URL,
+	})
+	selectors := []string{
+		"testdata/rspec/spec/fruits/apple_spec.rb",
+		"testdata/rspec/spec/fruits/banana_spec.rb",
+		"testdata/rspec/spec/fruits/cherry_spec.rb",
+	}
+
+	testRunner := metadataTestRunner{
+		name:           "rspec",
+		locationPrefix: "my/project",
+		supportedFeatures: runner.SupportedFeatures{
+			SplitByExample:  true,
+			SplitBySelector: true,
+			FilterTestFiles: true,
+			Skip:            true,
+		},
+		examples: []plan.TestCase{
+			{
+				Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Name:       "is yellow",
+				Path:       "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Scope:      "Banana",
+			},
+		},
+	}
+
+	got, err := createRequestParam(context.Background(), &cfg, selectors, *client, testRunner)
+	if err != nil {
+		t.Errorf("createRequestParam() error = %v", err)
+	}
+
+	wantFilterFiles := []plan.TestCase{
+		{Path: "my/project/testdata/rspec/spec/fruits/apple_spec.rb"},
+		{Path: "my/project/testdata/rspec/spec/fruits/banana_spec.rb"},
+		{Path: "my/project/testdata/rspec/spec/fruits/cherry_spec.rb"},
+	}
+	if diff := cmp.Diff(gotFilterParams.Files, wantFilterFiles); diff != "" {
+		t.Errorf("filter_tests files diff (-got +want):\n%s", diff)
+	}
+
+	want := api.TestPlanParams{
+		Identifier:  "identifier",
+		Parallelism: 2,
+		Branch:      "main",
+		Runner:      "rspec",
+		Tests: api.TestPlanParamsTest{
+			Examples: []plan.TestCase{
+				{
+					Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Name:       "is yellow",
+					Path:       "my/project/testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Scope:      "Banana",
+				},
+			},
+			Selectors: []api.TestPlanParamsSelector{
+				{Value: "testdata/rspec/spec/fruits/apple_spec.rb"},
+				{Value: "testdata/rspec/spec/fruits/cherry_spec.rb"},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 	cfg := config.Config{
 		Identifier:  "identifier",
@@ -269,7 +512,55 @@ func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
 	}
 }
+func TestShouldExpandSelectorFilesForSkippedTests(t *testing.T) {
+	custom, err := runner.NewCustom(runner.RunnerConfig{
+		TestCommand:     "echo {{testExamples}}",
+		TestFilePattern: "tests/**/*",
+	})
+	if err != nil {
+		t.Fatalf("NewCustom() error = %v", err)
+	}
 
+	cases := []struct {
+		name       string
+		testRunner runner.TestRunner
+		want       bool
+	}{
+		{
+			name:       "RSpec selector-backed files support skipped-test expansion",
+			testRunner: runner.NewRspec(runner.RunnerConfig{}),
+			want:       true,
+		},
+		{
+			name:       "Cucumber selector-backed files support skipped-test expansion",
+			testRunner: runner.NewCucumber(runner.RunnerConfig{}),
+			want:       true,
+		},
+		{
+			name:       "Go selectors are not file-backed skipped-test runners",
+			testRunner: runner.NewGoTest(runner.RunnerConfig{}),
+			want:       false,
+		},
+		{
+			name:       "custom selectors do not support Test Engine skipped tests",
+			testRunner: custom,
+			want:       false,
+		},
+		{
+			name:       "selector-backed file runners without skip support do not use skipped-test expansion",
+			testRunner: runner.NewJest(runner.RunnerConfig{}),
+			want:       false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldExpandSelectorFilesForSkippedTests(c.testRunner); got != c.want {
+				t.Errorf("shouldExpandSelectorFilesForSkippedTests(%s) = %v, want %v", c.testRunner.Name(), got, c.want)
+			}
+		})
+	}
+}
 func TestCreateRequestParams_SelectorOptInIgnoredForSplitByExampleRunner(t *testing.T) {
 	filterRequestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -457,11 +748,17 @@ func TestCreateRequestParams_WithSelectionAndMetadata_SplitAllFilesBranch(t *tes
 }
 
 type metadataTestRunner struct {
-	name     string
-	examples []plan.TestCase
+	name              string
+	examples          []plan.TestCase
+	locationPrefix    string
+	supportedFeatures runner.SupportedFeatures
 }
 
 func (r metadataTestRunner) SupportedFeatures() runner.SupportedFeatures {
+	if r.supportedFeatures != (runner.SupportedFeatures{}) {
+		return r.supportedFeatures
+	}
+
 	return runner.SupportedFeatures{
 		SplitByExample: true,
 	}
@@ -484,7 +781,7 @@ func (r metadataTestRunner) GetSelectors() ([]string, error) {
 }
 
 func (r metadataTestRunner) LocationPrefix() string {
-	return ""
+	return r.locationPrefix
 }
 
 func (r metadataTestRunner) UploadToken() string {

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -474,6 +474,85 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing
 	}
 }
 
+func TestCreateRequestParams_RSpecSelectorSplittingWithDotLocationPrefix(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `
+{
+	"tests": [
+		{ "path": "./testdata/rspec/spec/fruits/banana_spec.rb", "reason": "file contains 1 or more skipped tests" }
+	]
+}`)
+	}))
+	defer svr.Close()
+
+	cfg := config.Config{
+		OrganizationSlug:  "my-org",
+		SuiteSlug:         "my-suite",
+		Identifier:        "identifier",
+		Parallelism:       2,
+		Branch:            "main",
+		TestRunner:        "rspec",
+		SelectorSplitting: true,
+		LocationPrefix:    "./",
+	}
+
+	client := api.NewClient(api.ClientConfig{
+		ServerBaseURL: svr.URL,
+	})
+	selectors := []string{
+		"testdata/rspec/spec/fruits/apple_spec.rb",
+		"testdata/rspec/spec/fruits/banana_spec.rb",
+	}
+
+	testRunner := metadataTestRunner{
+		name:           "rspec",
+		locationPrefix: "./",
+		supportedFeatures: runner.SupportedFeatures{
+			SplitByExample:  true,
+			SplitBySelector: true,
+			FilterTestFiles: true,
+			Skip:            true,
+		},
+		examples: []plan.TestCase{
+			{
+				Identifier: "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Name:       "is yellow",
+				Path:       "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+				Scope:      "Banana",
+			},
+		},
+	}
+
+	got, err := createRequestParam(context.Background(), &cfg, selectors, *client, testRunner)
+	if err != nil {
+		t.Errorf("createRequestParam() error = %v", err)
+	}
+
+	want := api.TestPlanParams{
+		Identifier:  "identifier",
+		Parallelism: 2,
+		Branch:      "main",
+		Runner:      "rspec",
+		Tests: api.TestPlanParamsTest{
+			Examples: []plan.TestCase{
+				{
+					Identifier: "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Name:       "is yellow",
+					Path:       "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
+					Scope:      "Banana",
+				},
+			},
+			Selectors: []api.TestPlanParamsSelector{
+				{Value: "testdata/rspec/spec/fruits/apple_spec.rb"},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 	cfg := config.Config{
 		Identifier:  "identifier",


### PR DESCRIPTION
### Description

Supports skipped-test handling when selector splitting is enabled for file-backed runners that already support Test Engine skipping.

For RSpec and Cucumber, selector targets are still discovered as file paths. This change filters those selector-backed files through `filter_tests`; files that need skipped-test filtering are expanded into examples, while the remaining files are sent as selectors for normal selector bin-packing.

### Context

Linear: https://linear.app/buildkite/issue/TE-6199/support-skipped-tests-in-selector-split-test-plans

Related server/API change: https://github.com/buildkite/buildkite/pull/30886

### Changes

- Adds a skipped-test selector-splitting path for file-backed runners with selector, example, file-filtering, and skip support.
- Preserves selector-only request params for non-skipped selector runners such as Go/Jest/etc.
- Extracts shared filter-and-expand logic for file and selector-backed-file flows.
- Makes `./` location-prefix application idempotent so real RSpec example paths are not double-prefixed.
- Adds request-param coverage for filtered selector-backed files, no filtered files, location prefixes, and feature gating.

