### PR TITLE
Fix rounding in test summary

### DIFF
--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 )
 
@@ -134,23 +135,34 @@ func printFormatBreakdown(w io.Writer, total, known int, noun string, meta *Form
 	}
 
 	unknown := total - known
-	fmt.Fprintf(w, "%s%*d%s (%d%%) estimated from past historical durations\n",
+	fmt.Fprintf(w, "%s%*d%s (%s) estimated from past historical durations\n",
 		indent, width, known, itemNounFor(known), percentOf(known, total))
 	if unknown > 0 {
 		suffix := ""
 		if meta != nil && meta.MedianDuration != nil {
 			suffix = fmt.Sprintf(" — assumed median (%s)", formatDurationMS(*meta.MedianDuration))
 		}
-		fmt.Fprintf(w, "%s%*d%s (%d%%) had no history%s\n",
+		fmt.Fprintf(w, "%s%*d%s (%s) had no history%s\n",
 			indent, width, unknown, itemNounFor(unknown), percentOf(unknown, total), suffix)
 	}
 }
 
-func percentOf(n, total int) int {
+func percentOf(n, total int) string {
 	if total == 0 {
-		return 0
+		return "0%"
 	}
-	return n * 100 / total
+	percent := float64(n) / float64(total) * 100
+	rounded := math.Round(percent*10) / 10
+	if rounded == 0 && n > 0 {
+		return "<0.1%"
+	}
+	if rounded == 100 && n < total {
+		return ">99.9%"
+	}
+	if rounded == math.Trunc(rounded) {
+		return fmt.Sprintf("%.0f%%", rounded)
+	}
+	return fmt.Sprintf("%.1f%%", rounded)
 }
 
 func formatDurationMS(ms float64) string {

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -297,3 +297,27 @@ func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
 		t.Errorf("expected no output for fallback plan, got: %s", buf.String())
 	}
 }
+
+func TestPercentOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		n     int
+		total int
+		want  string
+	}{
+		{name: "zero total", n: 0, total: 0, want: "0%"},
+		{name: "whole percentage", n: 3, total: 5, want: "60%"},
+		{name: "rounds to one decimal", n: 1, total: 3, want: "33.3%"},
+		{name: "small non-zero percentage", n: 1, total: 200, want: "0.5%"},
+		{name: "tiny non-zero percentage", n: 1, total: 10000, want: "<0.1%"},
+		{name: "nearly all but not all", n: 9999, total: 10000, want: ">99.9%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := percentOf(tt.n, tt.total); got != tt.want {
+				t.Errorf("percentOf(%d, %d) = %q, want %q", tt.n, tt.total, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Fixes the test summary percentage display so small non-zero values are no longer shown as `0%`. Percentages now round to one decimal place when needed and use boundary labels for tiny/non-total values (`<0.1%`, `>99.9%`).

### Context

Linear: TE-6276

### Changes

- Format test summary percentages as strings instead of truncated integers.
- Preserve whole-number percentages where possible.
- Add coverage for zero totals, one-decimal rounding, and tiny/nearly-complete percentages.

### Testing

- `go test ./internal/plan`
