### PR TITLE
[TE-6304] Fall back to test file collection for custom runner when --selector-file isn't set

### DIFF
--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/v2/internal/debug"
@@ -76,8 +77,12 @@ func (r Custom) GetFiles() ([]string, error) {
 	return files, nil
 }
 
+// GetSelectors falls back to file-pattern discovery, since the custom runner
+// has no way to discover selectors on its own without a selector file
+// (in which case bktec reads selectors from the file directly, without calling this).
 func (r Custom) GetSelectors() ([]string, error) {
-	return nil, fmt.Errorf("use `--selector-file` or `BUILDKITE_TEST_ENGINE_SELECTOR_FILE` to provide the list of selectors")
+	fmt.Fprintln(os.Stderr, "Buildkite Test Engine Client: --selector-file (or BUILDKITE_TEST_ENGINE_SELECTOR_FILE) is not set for the custom runner. Falling back to test files collection.")
+	return r.GetFiles()
 }
 
 func (r Custom) GetExamples(files []string) ([]plan.TestCase, error) {

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -97,6 +97,33 @@ func TestCustom_GetFiles(t *testing.T) {
 	}
 }
 
+func TestCustom_GetSelectors_FallsBackToFilePatternMatching(t *testing.T) {
+	changeCwd(t, "./testdata/custom")
+	custom, err := NewCustom(RunnerConfig{
+		TestCommand:     "bats {{testExamples}}",
+		TestFilePattern: "tests/*.bats",
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to create Custom runner: %v", err)
+	}
+
+	got, err := custom.GetSelectors()
+	if err != nil {
+		t.Errorf("Custom.GetSelectors() error = %v", err)
+	}
+
+	want := []string{
+		"tests/failed_test.bats",
+		"tests/flaky_test.bats",
+		"tests/happy_test.bats",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Custom.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestCustom_CommandNameAndArgs(t *testing.T) {
 	testCases := []plan.TestCase{{Path: "tests/test_a.sh"}, {Path: "tests/test_b.sh"}}
 


### PR DESCRIPTION
### Description

We want selector based splitting to become the default way of splitting tests eventually, but custom runners can't discover selectors on their own, so today they require `--selector-file` and error out if it's missing. That would break existing customers who haven't set up a selector file yet once we turn selector splitting on more broadly.

This PR makes the custom runner fall back to its normal file-pattern collection (via `--test-file-pattern`) when selector splitting is enabled but `--selector-file` isn't set, instead of erroring out. It also prints a stderr notice so customers who meant to use selector splitting know they're missing `--selector-file`, since ideally they'd still provide it.

### Context

https://linear.app/buildkite/issue/TE-6304

### Testing

Added a unit test (`TestCustom_GetSelectors_FallsBackToFilePatternMatching`) confirming `GetSelectors()` returns the same files as `GetFiles()` when no selector file is configured. Ran the full test suite locally, all passing.