### PR TITLE
[TE-6371] Support selector splitting for Vitest

### DIFF
--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -48,6 +48,7 @@ func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 		cypress.Name(),
 		pytest.Name(),
 		cucumber.Name(),
+		vitest.Name(),
 	}
 
 	for _, runner := range runners {

--- a/internal/runner/vitest.go
+++ b/internal/runner/vitest.go
@@ -49,6 +49,7 @@ func (v Vitest) SupportedFeatures() SupportedFeatures {
 		AutoRetry:       true,
 		Mute:            true,
 		Skip:            false,
+		SplitBySelector: true,
 	}
 }
 
@@ -75,6 +76,10 @@ func (v Vitest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func (v Vitest) GetSelectors() ([]string, error) {
+	return v.GetFiles()
 }
 
 func (v Vitest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {

--- a/internal/runner/vitest_test.go
+++ b/internal/runner/vitest_test.go
@@ -72,6 +72,25 @@ func TestVitestGetFiles(t *testing.T) {
 	}
 }
 
+func TestVitestGetSelectors(t *testing.T) {
+	changeCwd(t, "./testdata/vitest")
+	vitest := NewVitest(RunnerConfig{})
+
+	gotFiles, err := vitest.GetFiles()
+	if err != nil {
+		t.Errorf("Vitest.GetFiles() error = %v", err)
+	}
+
+	gotSelectors, err := vitest.GetSelectors()
+	if err != nil {
+		t.Errorf("Vitest.GetSelectors() error = %v", err)
+	}
+
+	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
+		t.Errorf("Vitest.GetSelectors() diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestVitestCommandNameAndArgs_WithInterpolationPlaceholder(t *testing.T) {
 	testCases := []plan.TestCase{{Path: "src/user.spec.ts"}, {Path: "src/billing.spec.ts"}}
 	testCommand := "vitest run {{testExamples}} --reporter=json --outputFile {{resultPath}}"


### PR DESCRIPTION
Vitest was recently added as a runner, but it was missing selector-based splitting support that other runners like Jest, Cypress, and RSpec already have.

For Vitest, selectors are just file paths (same as Jest and Playwright), so `GetSelectors` delegates to the existing `GetFiles` method. I also marked `SplitBySelector: true` in `SupportedFeatures` and added a test following the same pattern as the other runners.