### PR TITLE
[TE-6379] Auto-collect git metadata during bktec run for ordered selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## Unreleased
+- Automatically collect git commit metadata on `bktec run` when `--selection-strategy` is set, matching `bktec plan`. Ordered selection can run straight from `bktec run` without a separate `plan` step. Preview; gated behind `BKTEC_PREVIEW_SELECTION`.
 - Add first-class support for the [Vitest](./docs/vitest.md) test runner (`BUILDKITE_TEST_ENGINE_TEST_RUNNER=vitest`), including test splitting by file, automatic retries, and muting. Vitest's JSON reporter is Jest-compatible, so results are parsed with the shared Jest report parser.
 - **Breaking:** Remove the `pytest-pants` runner. It had zero real usage over the last 3 months. Use the `custom` runner instead, which now supports selector-based test splitting (see `--selector-splitting` in 2.9.0).
 - **Breaking:** Remove the `nunit` runner. It saw almost no real usage, and had known issues splitting tests by file (result path handling, and class name collisions across namespaces).

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -28,6 +28,10 @@ _  /_/ /  ,<  / /_ /  __/ /__
 /_.___//_/|_| \__/ \___/\___/
 `
 
+// newGitRunner constructs the git runner used for metadata auto-collection.
+// Overridable in tests to inject a deterministic fake.
+var newGitRunner = func() git.GitRunner { return &git.ExecGitRunner{} }
+
 func Run(ctx context.Context, cfg *config.Config, testListFilename string) error {
 	printStartUpMessage()
 
@@ -447,7 +451,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	// Auto-collect git metadata when selection is active, mirroring `bktec plan`.
 	// Only relevant on the cache-miss path, since a cached plan is reused as-is.
 	if cfg.SelectionStrategy != "" {
-		autoCollectGitMetadata(ctx, cfg, &git.ExecGitRunner{})
+		autoCollectGitMetadata(ctx, cfg, newGitRunner())
 	}
 
 	// If the cache is empty, create a new plan.

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/api"
 	"github.com/buildkite/test-engine-client/v2/internal/config"
 	"github.com/buildkite/test-engine-client/v2/internal/debug"
+	"github.com/buildkite/test-engine-client/v2/internal/git"
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/buildkite/test-engine-client/v2/internal/runner"
 	"github.com/buildkite/test-engine-client/v2/internal/version"
@@ -442,6 +443,13 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	}
 
 	debug.Println("No test plan found, creating a new plan")
+
+	// Auto-collect git metadata when selection is active, mirroring `bktec plan`.
+	// Only relevant on the cache-miss path, since a cached plan is reused as-is.
+	if cfg.SelectionStrategy != "" {
+		autoCollectGitMetadata(ctx, cfg, &git.ExecGitRunner{})
+	}
+
 	// If the cache is empty, create a new plan.
 	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -449,7 +449,6 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	debug.Println("No test plan found, creating a new plan")
 
 	// Auto-collect git metadata when selection is active, mirroring `bktec plan`.
-	// Only relevant on the cache-miss path, since a cached plan is reused as-is.
 	if cfg.SelectionStrategy != "" {
 		autoCollectGitMetadata(ctx, cfg, newGitRunner())
 	}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -11,12 +11,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/buildkite/test-engine-client/v2/internal/api"
 	"github.com/buildkite/test-engine-client/v2/internal/config"
+	"github.com/buildkite/test-engine-client/v2/internal/git"
 	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/buildkite/test-engine-client/v2/internal/runner"
 	"github.com/buildkite/test-engine-client/v2/internal/version"
@@ -467,21 +467,62 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 	}
 }
 
+// withGitRunner overrides the package git-runner seam for the duration of a
+// test and restores it on cleanup.
+func withGitRunner(t *testing.T, r git.GitRunner) {
+	t.Helper()
+	prev := newGitRunner
+	newGitRunner = func() git.GitRunner { return r }
+	t.Cleanup(func() { newGitRunner = prev })
+}
+
+// captureRequestBody serves a cache-miss on GET and records the POST body used
+// to create the plan, returning the server and a getter for the captured body.
+func captureRequestBody(t *testing.T) (*httptest.Server, func() []byte) {
+	t.Helper()
+	var body []byte
+	response := `{"tasks": {"0": {"node_number": 0, "tests": [{"path": "apple", "format": "file"}]}}}`
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message": "Not Found"}`)
+			return
+		}
+		body, _ = io.ReadAll(r.Body)
+		fmt.Fprint(w, response)
+	}))
+	t.Cleanup(svr.Close)
+	return svr, func() []byte { return body }
+}
+
+func requestMetadata(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	if len(body) == 0 {
+		return nil
+	}
+	var params map[string]any
+	if err := json.Unmarshal(body, &params); err != nil {
+		t.Fatalf("failed to unmarshal request body: %v", err)
+	}
+	metadata, _ := params["metadata"].(map[string]any)
+	return metadata
+}
+
 func TestFetchOrCreateTestPlan_CollectsGitMetadataWhenSelectionActive(t *testing.T) {
 	files := []string{"apple"}
 	testRunner := runner.Rspec{}
 
-	response := `{"tasks": {"0": {"node_number": 0, "tests": [{"path": "apple", "format": "file"}]}}}`
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Cache miss on GET so plan creation (and metadata auto-collection) runs.
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"message": "Not Found"}`)
-		} else {
-			fmt.Fprint(w, response)
-		}
-	}))
-	defer svr.Close()
+	svr, getBody := captureRequestBody(t)
+
+	// Deterministic git responses: a repo that resolves its default branch and
+	// reports a current branch, so collection produces at least one metadata key
+	// regardless of the host checkout state.
+	withGitRunner(t, &git.FakeGitRunner{Responses: map[string]string{
+		"rev-parse --git-dir":                          ".git\n",
+		"symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
+		"merge-base origin/main HEAD":                   "abc123\n",
+		"branch --show-current":                         "my-feature\n",
+	}})
 
 	ctx := context.Background()
 	cfg := config.Config{
@@ -489,25 +530,18 @@ func TestFetchOrCreateTestPlan_CollectsGitMetadataWhenSelectionActive(t *testing
 		Parallelism:       10,
 		Identifier:        "identifier",
 		ServerBaseURL:     svr.URL,
+		Remote:            "origin",
 		SelectionStrategy: "least-reliable",
 	}
 	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
-
-	getStderr := captureStderr(t)
 
 	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
 		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
 	}
 
-	stderrOutput := getStderr()
-
-	// Auto-collection should have been entered. Outside a git repo it warns and
-	// skips; inside a git checkout it resolves the base branch. Either proves the
-	// gate was passed.
-	if !strings.Contains(stderrOutput, "Not a git repository") &&
-		!strings.Contains(stderrOutput, "auto-detected base branch") &&
-		!strings.Contains(stderrOutput, "Could not resolve base branch") {
-		t.Errorf("expected git metadata auto-collection to run when SelectionStrategy is set, stderr: %s", stderrOutput)
+	metadata := requestMetadata(t, getBody())
+	if metadata["branch"] != "my-feature" {
+		t.Errorf("expected collected git metadata in request body, got metadata = %v", metadata)
 	}
 }
 
@@ -515,16 +549,10 @@ func TestFetchOrCreateTestPlan_NoGitMetadataWithoutSelection(t *testing.T) {
 	files := []string{"apple"}
 	testRunner := runner.Rspec{}
 
-	response := `{"tasks": {"0": {"node_number": 0, "tests": [{"path": "apple", "format": "file"}]}}}`
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"message": "Not Found"}`)
-		} else {
-			fmt.Fprint(w, response)
-		}
-	}))
-	defer svr.Close()
+	svr, getBody := captureRequestBody(t)
+
+	// The runner must never be consulted when no selection strategy is set.
+	withGitRunner(t, &failingGitRunner{t: t})
 
 	ctx := context.Background()
 	cfg := config.Config{
@@ -536,20 +564,28 @@ func TestFetchOrCreateTestPlan_NoGitMetadataWithoutSelection(t *testing.T) {
 	}
 	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
 
-	getStderr := captureStderr(t)
-
 	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
 		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
 	}
 
-	stderrOutput := getStderr()
-
-	if strings.Contains(stderrOutput, "Not a git repository") ||
-		strings.Contains(stderrOutput, "auto-detected base branch") ||
-		strings.Contains(stderrOutput, "skipping metadata auto-collection") ||
-		strings.Contains(stderrOutput, "Could not resolve base branch") {
-		t.Errorf("auto-collection should not run when SelectionStrategy is unset, stderr: %s", stderrOutput)
+	if metadata := requestMetadata(t, getBody()); metadata != nil {
+		t.Errorf("expected no metadata in request when SelectionStrategy is unset, got: %v", metadata)
 	}
+}
+
+// failingGitRunner fails the test if any git command is run.
+type failingGitRunner struct{ t *testing.T }
+
+func (f *failingGitRunner) Output(ctx context.Context, args ...string) (string, error) {
+	f.t.Helper()
+	f.t.Fatalf("git runner unexpectedly invoked with args: %v", args)
+	return "", nil
+}
+
+func (f *failingGitRunner) OutputWithStdin(ctx context.Context, stdin string, args ...string) (string, error) {
+	f.t.Helper()
+	f.t.Fatalf("git runner unexpectedly invoked with args: %v", args)
+	return "", nil
 }
 
 func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -463,6 +464,91 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
+	}
+}
+
+func TestFetchOrCreateTestPlan_CollectsGitMetadataWhenSelectionActive(t *testing.T) {
+	files := []string{"apple"}
+	testRunner := runner.Rspec{}
+
+	response := `{"tasks": {"0": {"node_number": 0, "tests": [{"path": "apple", "format": "file"}]}}}`
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Cache miss on GET so plan creation (and metadata auto-collection) runs.
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message": "Not Found"}`)
+		} else {
+			fmt.Fprint(w, response)
+		}
+	}))
+	defer svr.Close()
+
+	ctx := context.Background()
+	cfg := config.Config{
+		NodeIndex:         0,
+		Parallelism:       10,
+		Identifier:        "identifier",
+		ServerBaseURL:     svr.URL,
+		SelectionStrategy: "least-reliable",
+	}
+	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
+
+	getStderr := captureStderr(t)
+
+	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
+		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
+	}
+
+	stderrOutput := getStderr()
+
+	// Auto-collection should have been entered. Outside a git repo it warns and
+	// skips; inside a git checkout it resolves the base branch. Either proves the
+	// gate was passed.
+	if !strings.Contains(stderrOutput, "Not a git repository") &&
+		!strings.Contains(stderrOutput, "auto-detected base branch") &&
+		!strings.Contains(stderrOutput, "Could not resolve base branch") {
+		t.Errorf("expected git metadata auto-collection to run when SelectionStrategy is set, stderr: %s", stderrOutput)
+	}
+}
+
+func TestFetchOrCreateTestPlan_NoGitMetadataWithoutSelection(t *testing.T) {
+	files := []string{"apple"}
+	testRunner := runner.Rspec{}
+
+	response := `{"tasks": {"0": {"node_number": 0, "tests": [{"path": "apple", "format": "file"}]}}}`
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message": "Not Found"}`)
+		} else {
+			fmt.Fprint(w, response)
+		}
+	}))
+	defer svr.Close()
+
+	ctx := context.Background()
+	cfg := config.Config{
+		NodeIndex:     0,
+		Parallelism:   10,
+		Identifier:    "identifier",
+		ServerBaseURL: svr.URL,
+		// SelectionStrategy intentionally unset.
+	}
+	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
+
+	getStderr := captureStderr(t)
+
+	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
+		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
+	}
+
+	stderrOutput := getStderr()
+
+	if strings.Contains(stderrOutput, "Not a git repository") ||
+		strings.Contains(stderrOutput, "auto-detected base branch") ||
+		strings.Contains(stderrOutput, "skipping metadata auto-collection") ||
+		strings.Contains(stderrOutput, "Could not resolve base branch") {
+		t.Errorf("auto-collection should not run when SelectionStrategy is unset, stderr: %s", stderrOutput)
 	}
 }
 

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -518,7 +518,7 @@ func TestFetchOrCreateTestPlan_CollectsGitMetadataWhenSelectionActive(t *testing
 	// reports a current branch, so collection produces at least one metadata key
 	// regardless of the host checkout state.
 	withGitRunner(t, &git.FakeGitRunner{Responses: map[string]string{
-		"rev-parse --git-dir":                          ".git\n",
+		"rev-parse --git-dir":                           ".git\n",
 		"symbolic-ref --short refs/remotes/origin/HEAD": "origin/main\n",
 		"merge-base origin/main HEAD":                   "abc123\n",
 		"branch --show-current":                         "my-feature\n",


### PR DESCRIPTION
### Description

Auto-collect git metadata during `bktec run` (not only `bktec plan`) so selection prediction can be driven straight from the existing `run` command, with no separate `plan` step. `command.Run` accepted the selection flags but never collected the git commit and diff metadata the plan API needs, so selection could previously only be exercised via `plan`.

The intended use is ordered selection: run the full suite but order it so higher-scoring tests run first. This change does not itself force ordering or drop any tests — it makes the selection options usable from `run`. The behaviour of the resulting plan (ordering versus a score cutoff / deselection) is determined by the strategy and params the caller passes to the API, exactly as with `plan`.

`autoCollectGitMetadata` is called on the plan-creation path in `fetchOrCreateTestPlan`, gated on `cfg.SelectionStrategy != ""`, mirroring `command.Plan`. Collection only runs on a plan-cache miss: when the server already has a cached plan for the identifier, `run` reuses it and skips collection.

Trade-off worth noting for the parallel-node case. A typical `run` has many nodes starting at roughly the same time, each independently inferring its test files and calling `FetchTestPlan`. There is no client-side coordination, so whichever nodes miss the cache before the first `CreateTestPlan` populates it will each run the git-metadata collection and submit their own create request; in the worst case (all nodes start together and all miss) every node runs the git commands. This is acceptable because the cost is low — a handful of quick `git` invocations, dominated by the plan API round-trip and the test run itself. The only potential hotspot is the full `git diff base...HEAD` on very large diffs. `runDiffCommands` has a `skipDiffs` mode that omits the full patch, but it is not reachable here yet: the auto-collection path (`collectDiffMetadata`) always passes `skipDiffs=false`, and the `--skip-diffs` flag is currently only registered on the `backfill-commit-metadata` command. Wiring it into the `run`/`plan` auto-collection is left as follow-up.

`--collect-git-metadata` is intentionally left unwired on `run` for now, so the trigger is the selection strategy alone. The behaviour stays behind the `BKTEC_PREVIEW_SELECTION` preview flag that gates the selection flags on both commands.

### Context

[TE-6379](https://linear.app/buildkite/issue/TE-6379/auto-collect-git-metadata-during-bktec-run-for-ordered-selection)

### Changes

Best reviewed commit-by-commit.

- `internal/command/run.go`: call `autoCollectGitMetadata` on the cache-miss path in `fetchOrCreateTestPlan` when a selection strategy is set.
- `internal/command/run_test.go`: cover the collect and no-collect cases, driven by an injectable fake git runner asserting on the `CreateTestPlan` request body.

### Testing

Backed by specs. AI assisted. `go build ./...`, `go vet ./internal/command`, and `go test .  ./internal/command ./internal/config ./internal/api ./internal/git` all pass.
