### PR TITLE
[TE-6288] Warn when selector splitting has no historical timings

### DIFF
--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -42,10 +42,10 @@ func printWarn(label, message string, hints ...string) {
 }
 
 // printSplitSummary prints the plan summary and warns when a selector plan had
-// to use only default durations because no timing history was available.
+// to use default durations because no selector timing history was available.
 func printSplitSummary(w io.Writer, testPlan plan.TestPlan) {
 	plan.PrintSplitSummary(w, testPlan)
-	if testPlan.SelectorPlanUsesOnlyDefaultDurations() {
+	if testPlan.HasNoSelectorTimingHistory() {
 		printWarning(
 			w,
 			"Selector splitting used default durations because no historical selector timings were found.",

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -3,9 +3,11 @@ package command
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/buildkite/test-engine-client/v2/internal/api"
+	"github.com/buildkite/test-engine-client/v2/internal/plan"
 )
 
 const fallbackExtra = "⚠️ Falling back to non-intelligent splitting. Your build may take longer than usual."
@@ -25,14 +27,33 @@ func ansi(code string) string {
 	return code
 }
 
+// printWarning prints a warning and optional hints to w.
+func printWarning(w io.Writer, message string, hints ...string) {
+	fmt.Fprintf(w, "%s⚠️ %s%s\n", colorYellow+colorBold, message, colorReset)
+	for _, h := range hints {
+		fmt.Fprintln(w, colorYellow+h+colorReset)
+	}
+}
+
 // printWarn prints a recoverable warning to stderr followed by an optional hint
 // and the fallback notice.
 func printWarn(label, message string, hints ...string) {
-	fmt.Fprintf(os.Stderr, "%s⚠️ %s: %s\n", colorYellow+colorBold, label, message)
-	for _, h := range hints {
-		fmt.Fprintln(os.Stderr, colorYellow+h+colorReset)
+	printWarning(os.Stderr, label+": "+message, append(hints, fallbackExtra)...)
+}
+
+// printSplitSummary prints the plan summary and warns when a selector plan had
+// to use default durations because no selector timing history was available.
+func printSplitSummary(w io.Writer, testPlan plan.TestPlan) {
+	plan.PrintSplitSummary(w, testPlan)
+	if testPlan.HasNoSelectorTimingHistory() {
+		printWarning(
+			w,
+			"Selector splitting used default durations because no historical selector timings were found.",
+			"If these tests have not run before, run them once to record selector timings. Otherwise, update your collector and run them again:",
+			"  Ruby gem: buildkite-test_collector v2.14.0+",
+			"  JavaScript npm package: buildkite-test-collector v1.10.0+",
+		)
 	}
-	fmt.Fprintf(os.Stderr, "%s%s%s\n", colorYellow, fallbackExtra, colorReset)
 }
 
 // fatal formats an unrecoverable error message with red bold styling.

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -42,10 +42,10 @@ func printWarn(label, message string, hints ...string) {
 }
 
 // printSplitSummary prints the plan summary and warns when a selector plan had
-// to use default durations because no selector timing history was available.
+// to use only default durations because no timing history was available.
 func printSplitSummary(w io.Writer, testPlan plan.TestPlan) {
 	plan.PrintSplitSummary(w, testPlan)
-	if testPlan.HasNoSelectorTimingHistory() {
+	if testPlan.SelectorPlanUsesOnlyDefaultDurations() {
 		printWarning(
 			w,
 			"Selector splitting used default durations because no historical selector timings were found.",

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -131,3 +131,27 @@ func TestPrintSplitSummaryWarnsWhenSelectorHistoryIsUnavailable(t *testing.T) {
 	assert.Contains(t, output, "Ruby gem: buildkite-test_collector v2.14.0+")
 	assert.Contains(t, output, "JavaScript npm package: buildkite-test-collector v1.10.0+")
 }
+
+func TestPrintSplitSummaryDoesNotWarnWhenMixedPlanHasExampleHistory(t *testing.T) {
+	median := 500.0
+	testPlan := plan.TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*plan.Task{
+			"0": {NodeNumber: 0, Tests: []plan.TestCase{
+				{Value: "spec/models/user_spec.rb", Format: plan.TestCaseFormatSelector},
+			}},
+			"1": {NodeNumber: 1, Tests: []plan.TestCase{
+				{Path: "spec/models/team_spec.rb[1:1]", Format: plan.TestCaseFormatExample, TimingSampleSize: 3},
+			}},
+		},
+		TimingMetadata: &plan.TimingMetadata{
+			Example:  &plan.FormatTimingMetadata{MedianDuration: &median, DefaultDuration: 1000},
+			Selector: &plan.FormatTimingMetadata{DefaultDuration: 1000},
+		},
+	}
+
+	var buf bytes.Buffer
+	printSplitSummary(&buf, testPlan)
+
+	assert.NotContains(t, buf.String(), "⚠️ Selector splitting used default durations")
+}

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -131,27 +131,3 @@ func TestPrintSplitSummaryWarnsWhenSelectorHistoryIsUnavailable(t *testing.T) {
 	assert.Contains(t, output, "Ruby gem: buildkite-test_collector v2.14.0+")
 	assert.Contains(t, output, "JavaScript npm package: buildkite-test-collector v1.10.0+")
 }
-
-func TestPrintSplitSummaryDoesNotWarnWhenMixedPlanHasExampleHistory(t *testing.T) {
-	median := 500.0
-	testPlan := plan.TestPlan{
-		Parallelism: 2,
-		Tasks: map[string]*plan.Task{
-			"0": {NodeNumber: 0, Tests: []plan.TestCase{
-				{Value: "spec/models/user_spec.rb", Format: plan.TestCaseFormatSelector},
-			}},
-			"1": {NodeNumber: 1, Tests: []plan.TestCase{
-				{Path: "spec/models/team_spec.rb[1:1]", Format: plan.TestCaseFormatExample, TimingSampleSize: 3},
-			}},
-		},
-		TimingMetadata: &plan.TimingMetadata{
-			Example:  &plan.FormatTimingMetadata{MedianDuration: &median, DefaultDuration: 1000},
-			Selector: &plan.FormatTimingMetadata{DefaultDuration: 1000},
-		},
-	}
-
-	var buf bytes.Buffer
-	printSplitSummary(&buf, testPlan)
-
-	assert.NotContains(t, buf.String(), "⚠️ Selector splitting used default durations")
-}

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -1,10 +1,12 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
 	"github.com/buildkite/test-engine-client/v2/internal/api"
+	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,4 +103,31 @@ func TestWarnErrorPlan(t *testing.T) {
 	assert.Contains(t, stderr, "⚠️ Error Plan:")
 	assert.Contains(t, stderr, "Test Engine API failed to generate a plan")
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
+func TestPrintSplitSummaryWarnsWhenSelectorHistoryIsUnavailable(t *testing.T) {
+	testPlan := plan.TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*plan.Task{
+			"0": {NodeNumber: 0, Tests: []plan.TestCase{
+				{Value: "spec/models/user_spec.rb", Format: plan.TestCaseFormatSelector},
+			}},
+			"1": {NodeNumber: 1, Tests: []plan.TestCase{
+				{Value: "spec/models/team_spec.rb", Format: plan.TestCaseFormatSelector},
+			}},
+		},
+		TimingMetadata: &plan.TimingMetadata{
+			Selector: &plan.FormatTimingMetadata{DefaultDuration: 1000},
+		},
+	}
+
+	var buf bytes.Buffer
+	printSplitSummary(&buf, testPlan)
+	output := buf.String()
+
+	assert.Contains(t, output, colorYellow+colorBold+"⚠️ Selector splitting used default durations")
+	assert.Contains(t, output, "If these tests have not run before, run them once to record selector timings")
+	assert.Contains(t, output, "Otherwise, update your collector and run them again")
+	assert.Contains(t, output, "Ruby gem: buildkite-test_collector v2.14.0+")
+	assert.Contains(t, output, "JavaScript npm package: buildkite-test-collector v1.10.0+")
 }

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -80,7 +80,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	}
 
-	plan.PrintSplitSummary(os.Stderr, testPlan)
+	printSplitSummary(os.Stderr, testPlan)
 
 	switch outputFormat {
 
@@ -169,7 +169,7 @@ func planOut(ctx context.Context, cfg *config.Config, testTargets []string, apiC
 	}
 
 	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
-	plan.PrintSplitSummary(os.Stderr, testPlan)
+	printSplitSummary(os.Stderr, testPlan)
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -60,7 +60,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
-	plan.PrintSplitSummary(os.Stdout, testPlan)
+	printSplitSummary(os.Stdout, testPlan)
 
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -54,18 +54,16 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	fmt.Fprintln(w)
 }
 
-// SelectorPlanUsesOnlyDefaultDurations reports whether a multi-node plan with
-// selectors has no historical timings for any of its case formats.
-func (p TestPlan) SelectorPlanUsesOnlyDefaultDurations() bool {
+// HasNoSelectorTimingHistory reports whether a multi-node selector plan used
+// default durations because no historical selector timings were available.
+func (p TestPlan) HasNoSelectorTimingHistory() bool {
 	if p.Fallback || p.Parallelism <= 1 || p.TimingMetadata == nil ||
 		p.TimingMetadata.Selector == nil || p.TimingMetadata.Selector.MedianDuration != nil {
 		return false
 	}
 
-	_, fileKnown := countByFormat(p, TestCaseFormatFile)
-	_, exampleKnown := countByFormat(p, TestCaseFormatExample)
 	selectorTotal, selectorKnown := countByFormat(p, TestCaseFormatSelector)
-	return selectorTotal > 0 && fileKnown+exampleKnown+selectorKnown == 0
+	return selectorTotal > 0 && selectorKnown == 0
 }
 
 // countByFormat returns (total, known) for cases of the given format. The

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -54,16 +54,18 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	fmt.Fprintln(w)
 }
 
-// HasNoSelectorTimingHistory reports whether a multi-node selector plan used
-// default durations because no historical selector timings were available.
-func (p TestPlan) HasNoSelectorTimingHistory() bool {
+// SelectorPlanUsesOnlyDefaultDurations reports whether a multi-node plan with
+// selectors has no historical timings for any of its case formats.
+func (p TestPlan) SelectorPlanUsesOnlyDefaultDurations() bool {
 	if p.Fallback || p.Parallelism <= 1 || p.TimingMetadata == nil ||
 		p.TimingMetadata.Selector == nil || p.TimingMetadata.Selector.MedianDuration != nil {
 		return false
 	}
 
+	_, fileKnown := countByFormat(p, TestCaseFormatFile)
+	_, exampleKnown := countByFormat(p, TestCaseFormatExample)
 	selectorTotal, selectorKnown := countByFormat(p, TestCaseFormatSelector)
-	return selectorTotal > 0 && selectorKnown == 0
+	return selectorTotal > 0 && fileKnown+exampleKnown+selectorKnown == 0
 }
 
 // countByFormat returns (total, known) for cases of the given format. The

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -54,6 +54,18 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	fmt.Fprintln(w)
 }
 
+// HasNoSelectorTimingHistory reports whether a multi-node selector plan used
+// default durations because no historical selector timings were available.
+func (p TestPlan) HasNoSelectorTimingHistory() bool {
+	if p.Fallback || p.Parallelism <= 1 || p.TimingMetadata == nil ||
+		p.TimingMetadata.Selector == nil || p.TimingMetadata.Selector.MedianDuration != nil {
+		return false
+	}
+
+	selectorTotal, selectorKnown := countByFormat(p, TestCaseFormatSelector)
+	return selectorTotal > 0 && selectorKnown == 0
+}
+
 // countByFormat returns (total, known) for cases of the given format. The
 // empty (default) Format value is treated as TestCaseFormatFile.
 func countByFormat(p TestPlan, format TestCaseFormat) (total, known int) {

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -200,7 +200,7 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 	if strings.Contains(got, " files ") || strings.Contains(got, " examples ") {
 		t.Errorf("expected no file/example wording in selector-mode output, got:\n%s", got)
 	}
-	if p.HasNoSelectorTimingHistory() {
+	if p.SelectorPlanUsesOnlyDefaultDurations() {
 		t.Error("expected plan with selector history not to report missing selector timings")
 	}
 }
@@ -232,7 +232,7 @@ func TestPrintSplitSummary_SelectorModeNoHistoryUsesDefaultDuration(t *testing.T
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
 		}
 	}
-	if !p.HasNoSelectorTimingHistory() {
+	if !p.SelectorPlanUsesOnlyDefaultDurations() {
 		t.Error("expected plan to report no selector timing history")
 	}
 }
@@ -255,8 +255,8 @@ func TestPrintSplitSummary_SelectorModeParallelismOneDoesNotWarn(t *testing.T) {
 	if !strings.Contains(got, "1 selector across 1 node") {
 		t.Errorf("output missing count line\nfull output:\n%s", got)
 	}
-	if strings.Contains(got, "update it and run the suite once") {
-		t.Errorf("unexpected collector warning at parallelism 1, got:\n%s", got)
+	if p.SelectorPlanUsesOnlyDefaultDurations() {
+		t.Error("expected single-node plan not to report missing selector timings")
 	}
 }
 
@@ -336,8 +336,8 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "update it and run the suite once") {
-		t.Errorf("unexpected collector warning when selector history exists, got:\n%s", got)
+	if p.SelectorPlanUsesOnlyDefaultDurations() {
+		t.Error("expected mixed plan with history not to report missing selector timings")
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -200,7 +200,7 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 	if strings.Contains(got, " files ") || strings.Contains(got, " examples ") {
 		t.Errorf("expected no file/example wording in selector-mode output, got:\n%s", got)
 	}
-	if p.SelectorPlanUsesOnlyDefaultDurations() {
+	if p.HasNoSelectorTimingHistory() {
 		t.Error("expected plan with selector history not to report missing selector timings")
 	}
 }
@@ -232,7 +232,7 @@ func TestPrintSplitSummary_SelectorModeNoHistoryUsesDefaultDuration(t *testing.T
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
 		}
 	}
-	if !p.SelectorPlanUsesOnlyDefaultDurations() {
+	if !p.HasNoSelectorTimingHistory() {
 		t.Error("expected plan to report no selector timing history")
 	}
 }
@@ -255,8 +255,8 @@ func TestPrintSplitSummary_SelectorModeParallelismOneDoesNotWarn(t *testing.T) {
 	if !strings.Contains(got, "1 selector across 1 node") {
 		t.Errorf("output missing count line\nfull output:\n%s", got)
 	}
-	if p.SelectorPlanUsesOnlyDefaultDurations() {
-		t.Error("expected single-node plan not to report missing selector timings")
+	if strings.Contains(got, "update it and run the suite once") {
+		t.Errorf("unexpected collector warning at parallelism 1, got:\n%s", got)
 	}
 }
 
@@ -336,8 +336,8 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
 		}
 	}
-	if p.SelectorPlanUsesOnlyDefaultDurations() {
-		t.Error("expected mixed plan with history not to report missing selector timings")
+	if strings.Contains(got, "update it and run the suite once") {
+		t.Errorf("unexpected collector warning when selector history exists, got:\n%s", got)
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -200,8 +200,8 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 	if strings.Contains(got, " files ") || strings.Contains(got, " examples ") {
 		t.Errorf("expected no file/example wording in selector-mode output, got:\n%s", got)
 	}
-	if strings.Contains(got, "update it and run the suite once") {
-		t.Errorf("unexpected collector warning when selector history exists, got:\n%s", got)
+	if p.HasNoSelectorTimingHistory() {
+		t.Error("expected plan with selector history not to report missing selector timings")
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -200,6 +200,64 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 	if strings.Contains(got, " files ") || strings.Contains(got, " examples ") {
 		t.Errorf("expected no file/example wording in selector-mode output, got:\n%s", got)
 	}
+	if strings.Contains(got, "update it and run the suite once") {
+		t.Errorf("unexpected collector warning when selector history exists, got:\n%s", got)
+	}
+}
+
+func TestPrintSplitSummary_SelectorModeNoHistoryUsesDefaultDuration(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 2,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Value: "spec/models/user_spec.rb", Format: TestCaseFormatSelector},
+			}},
+			"1": {NodeNumber: 1, Tests: []TestCase{
+				{Value: "spec/models/team_spec.rb", Format: TestCaseFormatSelector},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{
+			Selector: &FormatTimingMetadata{MedianDuration: nil, DefaultDuration: 1000},
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	for _, want := range []string{
+		"2 selectors (100%) had no history and used the default duration (1.0s)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+	if !p.HasNoSelectorTimingHistory() {
+		t.Error("expected plan to report no selector timing history")
+	}
+}
+
+func TestPrintSplitSummary_SelectorModeParallelismOneDoesNotWarn(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{
+				{Value: "spec/models/user_spec.rb", Format: TestCaseFormatSelector},
+			}},
+		},
+		TimingMetadata: &TimingMetadata{},
+	}
+
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	got := buf.String()
+
+	if !strings.Contains(got, "1 selector across 1 node") {
+		t.Errorf("output missing count line\nfull output:\n%s", got)
+	}
+	if strings.Contains(got, "update it and run the suite once") {
+		t.Errorf("unexpected collector warning at parallelism 1, got:\n%s", got)
+	}
 }
 
 func TestPrintSplitSummary_MixedFormats(t *testing.T) {
@@ -277,6 +335,9 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "update it and run the suite once") {
+		t.Errorf("unexpected collector warning when selector history exists, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
### Description

Warn when a multi-node selector split has no historical selector timings and therefore uses default durations. The warning explains how to seed timings for new tests and identifies the minimum Ruby and JavaScript collector versions needed to report selector metadata.

<img width="1055" height="222" alt="Screenshot 2026-07-16 at 9 22 21 AM" src="https://github.com/user-attachments/assets/d8a5897b-2342-4562-985d-0809329805bf" />


### Context

[TE-6288](https://linear.app/buildkite/issue/TE-6288/add-log-output-to-bktec-when-non-intelligent-splitting)

### Changes

- Detect selector plans with no known timing samples and a nil selector median.
- Print guidance for new tests and customers using older Ruby or JavaScript collectors.
- Reuse a writer-aware warning formatter for existing fallback warnings and the new selector warning.
- Emit the warning from `bktec run`, standard `bktec plan`, and `bktec plan --plan-out` summary paths.
- Suppress the warning for single-node, fallback, non-selector, and historically timed plans.

### Testing

- `go test ./internal/plan`
- `go test ./internal/command -run 'Test(PrintSplitSummary|HandleError|WarnErrorPlan)'`
- `git diff --check`

The full `go test ./internal/command` suite was also run. Two existing environment-dependent pytest tests fail locally because the installed collector does not recognize `--tag-filters`; the failures are unrelated to these changes.
