### PR TITLE
[TE-6298] - stamp organization_uuid and suite_uuid into backfill tarball metadata.json from the presigned response

### DIFF
--- a/internal/api/get_suite.go
+++ b/internal/api/get_suite.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Suite identifies a Test Engine suite and its organization.
+type Suite struct {
+	ID             string `json:"id"`
+	OrganizationID string `json:"organization_id"`
+}
+
+// GetSuite retrieves a suite by slug.
+//
+// Endpoint: GET /v2/analytics/organizations/:org/suites/:suite
+func (c Client) GetSuite(ctx context.Context, suiteSlug string) (Suite, error) {
+	reqURL := fmt.Sprintf(
+		"%s/v2/analytics/organizations/%s/suites/%s",
+		c.ServerBaseURL, url.PathEscape(c.OrganizationSlug), url.PathEscape(suiteSlug))
+
+	var suite Suite
+	_, err := c.doJSONWithRetry(ctx, httpRequest{Method: http.MethodGet, URL: reqURL}, &suite)
+	if err != nil {
+		return Suite{}, fmt.Errorf("getting suite: %w", err)
+	}
+	return suite, nil
+}

--- a/internal/api/get_suite_test.go
+++ b/internal/api/get_suite_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetSuite(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("request method = %q, want %q", r.Method, http.MethodGet)
+		}
+		if r.URL.Path != "/v2/analytics/organizations/my-org/suites/my-suite" {
+			t.Errorf("request path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "22222222-2222-2222-2222-222222222222",
+			"organization_id": "11111111-1111-1111-1111-111111111111"
+		}`))
+	}))
+	defer svr.Close()
+
+	client := NewClient(ClientConfig{
+		OrganizationSlug: "my-org",
+		ServerBaseURL:    svr.URL,
+	})
+
+	got, err := client.GetSuite(t.Context(), "my-suite")
+	if err != nil {
+		t.Fatalf("GetSuite() error = %v", err)
+	}
+	if got.OrganizationID != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("OrganizationID = %q", got.OrganizationID)
+	}
+	if got.ID != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("ID = %q", got.ID)
+	}
+}

--- a/internal/api/presign_upload.go
+++ b/internal/api/presign_upload.go
@@ -11,8 +11,10 @@ import (
 
 // PresignedUploadResponse is the response from the presigned upload endpoint.
 type PresignedUploadResponse struct {
-	URI  string                     `json:"uri"`
-	Form upload.PresignedUploadForm `json:"form"`
+	URI            string                     `json:"uri"`
+	Form           upload.PresignedUploadForm `json:"form"`
+	OrganizationID string                     `json:"organization_id"`
+	SuiteID        string                     `json:"suite_id"`
 }
 
 // PresignUpload requests a presigned S3 upload URL for commit metadata.

--- a/internal/command/backfill_commit_metadata.go
+++ b/internal/command/backfill_commit_metadata.go
@@ -53,8 +53,8 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 
 	// 3. Request the presigned upload URL now (before the git work) so the
 	// suite-scoped auth check fails fast, and reuse the held response at the
-	// upload site below. Skipped when --output is set, because there's no
-	// upload to authorise.
+	// upload site below. With --output, fetch UUIDs with GetSuite instead.
+	var organizationID, suiteID string
 	var presigned api.PresignedUploadResponse
 	if cfg.Output == "" {
 		fmt.Fprintln(os.Stderr, "Requesting presigned upload URL...")
@@ -62,7 +62,19 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 		if err != nil {
 			return fmt.Errorf("presigning upload: %w", err)
 		}
+		organizationID = presigned.OrganizationID
+		suiteID = presigned.SuiteID
 		debug.Println("Held presigned upload URL for use after git work")
+	} else {
+		suite, err := apiClient.GetSuite(ctx, cfg.SuiteSlug)
+		if err != nil {
+			return err
+		}
+		organizationID = suite.OrganizationID
+		suiteID = suite.ID
+	}
+	if organizationID == "" || suiteID == "" {
+		return errors.New("API response missing organization_id or suite_id")
 	}
 
 	// 4. Detect default branch
@@ -173,12 +185,14 @@ func BackfillCommitMetadata(ctx context.Context, cfg *config.Config, runner git.
 	// 11. Package as tar.gz
 	fmt.Fprintln(os.Stderr, "Packaging tarball...")
 	archiveMeta := packaging.ArchiveMetadata{
-		SchemaVersion:    1,
+		SchemaVersion:    2,
 		Tool:             "bktec",
 		ToolVersion:      version.Version,
 		GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
 		OrganizationSlug: cfg.OrganizationSlug,
 		SuiteSlug:        cfg.SuiteSlug,
+		OrganizationUUID: organizationID,
+		SuiteUUID:        suiteID,
 		CommitCount:      len(records),
 		SkippedCommits:   len(missingCommits),
 		Days:             cfg.Days,

--- a/internal/command/backfill_commit_metadata_test.go
+++ b/internal/command/backfill_commit_metadata_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/packaging"
 )
 
+const (
+	testOrganizationUUID = "11111111-1111-1111-1111-111111111111"
+	testSuiteUUID        = "22222222-2222-2222-2222-222222222222"
+)
+
 func getBackfillConfig(serverURL string) *config.Config {
 	cfg := config.New()
 	cfg.AccessToken = "test-token"
@@ -65,13 +70,22 @@ func newFakeGitRunner() *git.FakeGitRunner {
 // endpoint, pointing the form at s3URL.
 func writePresignedUploadJSON(w http.ResponseWriter, s3URL string) {
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"uri": "s3://bucket/test.tar.gz",
+		"uri": fmt.Sprintf("s3://bucket/backfill/org=%s/suite=%s/test.tar.gz", testOrganizationUUID, testSuiteUUID),
 		"form": map[string]interface{}{
 			"method":     "POST",
 			"url":        s3URL,
 			"data":       map[string]string{"key": "test.tar.gz"},
 			"file_input": "file",
 		},
+		"organization_id": testOrganizationUUID,
+		"suite_id":        testSuiteUUID,
+	})
+}
+
+func writeSuiteJSON(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(map[string]string{
+		"id":              testSuiteUUID,
+		"organization_id": testOrganizationUUID,
 	})
 }
 
@@ -81,6 +95,8 @@ func TestBackfillCommitMetadata_HappyPath(t *testing.T) {
 		case "/v2/analytics/organizations/my-org/suites/my-suite/commits":
 			w.Header().Set("Content-Type", "text/plain")
 			w.Write([]byte("abc123\n"))
+		case "/v2/analytics/organizations/my-org/suites/my-suite":
+			writeSuiteJSON(w)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -130,6 +146,20 @@ func TestBackfillCommitMetadata_HappyPath(t *testing.T) {
 	if record.SchemaVersion != 1 {
 		t.Errorf("SchemaVersion: got %d, want 1", record.SchemaVersion)
 	}
+
+	var metadata packaging.ArchiveMetadata
+	if err := json.Unmarshal([]byte(packaging.FindTarEntry(t, files, "/metadata.json")), &metadata); err != nil {
+		t.Fatalf("parsing metadata.json: %v", err)
+	}
+	if metadata.SchemaVersion != 2 {
+		t.Errorf("metadata SchemaVersion: got %d, want 2", metadata.SchemaVersion)
+	}
+	if metadata.OrganizationUUID != testOrganizationUUID {
+		t.Errorf("OrganizationUUID: got %q, want %q", metadata.OrganizationUUID, testOrganizationUUID)
+	}
+	if metadata.SuiteUUID != testSuiteUUID {
+		t.Errorf("SuiteUUID: got %q, want %q", metadata.SuiteUUID, testSuiteUUID)
+	}
 }
 
 func TestBackfillCommitMetadata_SkipDiffs(t *testing.T) {
@@ -138,6 +168,8 @@ func TestBackfillCommitMetadata_SkipDiffs(t *testing.T) {
 		case "/v2/analytics/organizations/my-org/suites/my-suite/commits":
 			w.Header().Set("Content-Type", "text/plain")
 			w.Write([]byte("abc123\n"))
+		case "/v2/analytics/organizations/my-org/suites/my-suite":
+			writeSuiteJSON(w)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -341,6 +373,18 @@ func TestBackfillCommitMetadata_Upload(t *testing.T) {
 	if uploadedFileContent == "" {
 		t.Error("uploaded file content was empty")
 	}
+	uploadedPath := t.TempDir() + "/uploaded.tar.gz"
+	if err := os.WriteFile(uploadedPath, []byte(uploadedFileContent), 0o600); err != nil {
+		t.Fatalf("writing captured upload: %v", err)
+	}
+	uploadedFiles := packaging.ReadTarball(t, uploadedPath)
+	var uploadedMetadata packaging.ArchiveMetadata
+	if err := json.Unmarshal([]byte(packaging.FindTarEntry(t, uploadedFiles, "/metadata.json")), &uploadedMetadata); err != nil {
+		t.Fatalf("parsing uploaded metadata.json: %v", err)
+	}
+	if uploadedMetadata.SchemaVersion != 2 || uploadedMetadata.OrganizationUUID != testOrganizationUUID || uploadedMetadata.SuiteUUID != testSuiteUUID {
+		t.Errorf("uploaded metadata identity/schema = %#v", uploadedMetadata)
+	}
 	// On the happy path the held URL is reused; a second PresignUpload call
 	// would mean the held-response optimisation has regressed.
 	if got := atomic.LoadInt32(&presignHits); got != 1 {
@@ -436,6 +480,43 @@ func TestBackfillCommitMetadata_ReadScopeMissing_FailsAtFetchCommitList(t *testi
 	}
 }
 
+func TestBackfillCommitMetadata_MissingUUID(t *testing.T) {
+	tests := []struct {
+		name   string
+		output bool
+	}{
+		{name: "presigned response missing suite ID"},
+		{name: "suite response missing organization ID", output: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v2/analytics/organizations/my-org/suites/my-suite/commits":
+					_, _ = w.Write([]byte("abc123\n"))
+				case "/v2/analytics/organizations/my-org/suites/my-suite":
+					json.NewEncoder(w).Encode(map[string]string{"id": testSuiteUUID})
+				case "/v2/analytics/organizations/my-org/suites/my-suite/commit-metadata-backfill/presigned-upload":
+					json.NewEncoder(w).Encode(map[string]string{"organization_id": testOrganizationUUID})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer svr.Close()
+
+			cfg := getBackfillConfig(svr.URL)
+			if tt.output {
+				cfg.Output = t.TempDir() + "/output.tar.gz"
+			}
+			err := BackfillCommitMetadata(t.Context(), cfg, nil)
+			if err == nil || !strings.Contains(err.Error(), "missing organization_id or suite_id") {
+				t.Fatalf("BackfillCommitMetadata() error = %v", err)
+			}
+		})
+	}
+}
+
 // TestBackfillCommitMetadata_OutputSkipsPresignPreflight asserts that
 // --output (write-tarball-locally) does not call PresignUpload, so a user
 // who opts out of the upload is not blocked by a missing write_suites scope.
@@ -447,6 +528,8 @@ func TestBackfillCommitMetadata_OutputSkipsPresignPreflight(t *testing.T) {
 		case "/v2/analytics/organizations/my-org/suites/my-suite/commits":
 			w.Header().Set("Content-Type", "text/plain")
 			w.Write([]byte("abc123\n"))
+		case "/v2/analytics/organizations/my-org/suites/my-suite":
+			writeSuiteJSON(w)
 		case "/v2/analytics/organizations/my-org/suites/my-suite/commit-metadata-backfill/presigned-upload":
 			atomic.AddInt32(&presignHits, 1)
 			// If this is called, the test should fail, but respond plausibly

--- a/internal/packaging/tarball.go
+++ b/internal/packaging/tarball.go
@@ -37,6 +37,8 @@ type ArchiveMetadata struct {
 	GeneratedAt      string `json:"generated_at"`
 	OrganizationSlug string `json:"organization_slug"`
 	SuiteSlug        string `json:"suite_slug"`
+	OrganizationUUID string `json:"organization_uuid"`
+	SuiteUUID        string `json:"suite_uuid"`
 	CommitCount      int    `json:"commit_count"`
 	SkippedCommits   int    `json:"skipped_commits"`
 	// Config options used for this export

--- a/internal/packaging/tarball_test.go
+++ b/internal/packaging/tarball_test.go
@@ -48,12 +48,14 @@ func sampleRecords() []CommitRecord {
 
 func sampleMetadata() ArchiveMetadata {
 	return ArchiveMetadata{
-		SchemaVersion:    1,
+		SchemaVersion:    2,
 		Tool:             "bktec",
 		ToolVersion:      "2.3.0",
 		GeneratedAt:      "2026-03-30T12:00:00Z",
 		OrganizationSlug: "my-org",
 		SuiteSlug:        "my-suite",
+		OrganizationUUID: "11111111-1111-1111-1111-111111111111",
+		SuiteUUID:        "22222222-2222-2222-2222-222222222222",
 		CommitCount:      2,
 		SkippedCommits:   1,
 		Days:             90,
@@ -186,6 +188,17 @@ func TestCreateTarball_SchemaVersion(t *testing.T) {
 	}
 	if got["schema_version"] != float64(1) {
 		t.Errorf("schema_version: got %v, want 1", got["schema_version"])
+	}
+
+	metadata := FindTarEntry(t, files, "/metadata.json")
+	for _, want := range []string{
+		`"schema_version": 2`,
+		`"organization_uuid": "11111111-1111-1111-1111-111111111111"`,
+		`"suite_uuid": "22222222-2222-2222-2222-222222222222"`,
+	} {
+		if !strings.Contains(metadata, want) {
+			t.Errorf("metadata.json missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `organization_uuid` and `suite_uuid` to archive metadata and bump the metadata schema version to `2`.
- Reuse UUIDs from the presigned upload response when uploading, and fetch the suite by slug when writing locally with `--output`.
- Add coverage for suite lookup, UUID propagation, missing-UUID handling, and tarball metadata contents.
- For the `--output` path where no presigned url request is made, the GetSuite api is called instead to retrieve the OrganizationUUID and SuiteUUID. This maintains `read_suites` only scope requirement for the `--output` flag in the documentation

## Context
- Linear: [TE-6298](https://linear.app/buildkite/issue/TE-6298/bktec-stamp-organization-uuid-and-suite-uuid-into-backfill-tarball)

## Testing
- Added unit coverage for `GetSuite`, backfill UUID wiring, and tarball metadata serialization.
- Verified the backfill flow preserves UUIDs through both upload and local output paths.