### PR TITLE
Document selector-based splitting and unhide the flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Splitting quality depends on the timing data available for the suite. First runs
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | Split tests by file[^1] | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | [Split slow files by individual test example](https://github.com/buildkite/test-engine-client/blob/main/docs/rspec.md#split-slow-files-by-individual-test-example) | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| [Selector-based test splitting](https://github.com/buildkite/test-engine-client/blob/main/README.md#selector-based-test-splitting) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Filter test files | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Filter tests by tag | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Automatically retry failed test | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
@@ -217,6 +218,40 @@ generate a plan it returns an empty plan, which is emitted as-is (a warning is
 printed to stderr). Only when the server cannot be reached at all does `bktec`
 fall back to a minimal locally-generated plan; this carries the identifier and
 parallelism but no tasks (it is not a computed split), and is noted on stderr.
+
+### Selector-based test splitting
+
+By default, `bktec` discovers tests as files (or Go packages for gotest) and requests a plan by sending those files to Test Engine. Selector-based splitting changes what `bktec` sends: instead of file paths, it sends runner-specific **selectors**, the values Test Engine looks up when computing a split for the current job. For every runner except gotest, the selector is the same file path file-based splitting already discovers, so enabling it doesn't change which tests run where, only how that path is reported and matched. gotest is the exception: its selector is a Go package import path from `go list`, and enabling selector splitting replaces the current even-count package split with duration-aware splitting, so Go users may see a different (and better balanced) split once historical timing data is available.
+
+> [!NOTE]
+> You don't need to enable this. It's opt-in, off by default, and for every runner except gotest it doesn't change how your tests are split, only how that split is reported internally. The one exception is gotest: enabling it turns on duration-aware package splitting, instead of the current even-count package split.
+
+Enable it with `--selector-splitting` (or `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true`):
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
+This is supported for RSpec, Jest, Vitest, Cypress, Playwright, pytest, gotest, Cucumber, and the custom runner.
+
+By default, `bktec` still discovers selectors itself: the same file discovery used for file-based splitting for every runner except gotest (which uses `go list` output) and custom (which falls back to its normal file-pattern collection). You can instead provide a fixed list of selectors with `--selector-file` (or `BUILDKITE_TEST_ENGINE_SELECTOR_FILE`), a path to a newline-delimited file of selector values:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+export BUILDKITE_TEST_ENGINE_SELECTOR_FILE=selectors.txt
+```
+
+`--selector-file` requires `--selector-splitting` to also be enabled; `bktec` exits with a configuration error otherwise.
+
+#### How selectors are matched
+
+When Test Engine computes a plan, it matches the selectors bktec sends against historical executions tagged with `test.selector.primary`. That tag is attributed automatically when results are uploaded via bktec's built-in upload, or via the Ruby, JavaScript, or Python collector at the minimum version noted in the [runner guides](#runner-guides).
+
+If an execution has no `test.selector.primary` (for example an older collector, or the custom runner), nothing breaks: Test Engine falls back to the file name for matching, and for the file-based runners the selector is the file path anyway, so the fallback keeps their history matching. If you upload with a collector, we recommend updating to the minimum version noted in the runner guides so selectors are attributed directly. The fallback strips a configured location prefix on a best-effort basis, so updating matters most if you use a location prefix.
+
+The custom runner is the main case that needs attention, since its selector might not be a file path. See the [custom runner guide](./docs/custom-test-runner.md#selector-based-test-splitting).
+
+A future bktec release will make selector-based splitting the default. Existing bktec versions will keep working with file-based splitting unchanged. See the [runner guides](#runner-guides) for runner-specific selector details.
 
 ### Preview: Test Selection
 

--- a/cli.go
+++ b/cli.go
@@ -356,7 +356,6 @@ var selectorSplittingFlag = &cli.BoolFlag{
 	Value:       false,
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING"),
 	Destination: &cfg.SelectorSplitting,
-	Hidden:      true,
 }
 
 var failOnNoTestsFlag = &cli.BoolFlag{

--- a/cli.go
+++ b/cli.go
@@ -351,7 +351,7 @@ var splitByExampleFlag = &cli.BoolFlag{
 var selectorSplittingFlag = &cli.BoolFlag{
 	Name:        "selector-splitting",
 	Category:    "TEST RUNNER",
-	Usage:       "Enable experimental selector-based test splitting for supported non-file runners",
+	Usage:       "Enable experimental selector-based test splitting",
 	Value:       false,
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING"),
 	Destination: &cfg.SelectorSplitting,

--- a/cli.go
+++ b/cli.go
@@ -289,7 +289,6 @@ var selectorsFlag = &cli.StringFlag{
 	Usage:       "Path to a file containing a list of selectors to run (one per line). Must be used alongside `selector-splitting`",
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_SELECTOR_FILE"),
 	Destination: &cfg.SelectorListPath,
-	Hidden:      true,
 }
 
 var tagFiltersFlag = &cli.StringFlag{

--- a/docs/cucumber.md
+++ b/docs/cucumber.md
@@ -56,3 +56,16 @@ export BUILDKITE_TEST_ENGINE_RETRY_CMD="bundle exec cucumber {{testExamples}} --
 
 ## Split by example
 Splitting slow files by individual scenario is supported for Cucumber. When bktec identifies slow files, it can request a plan that splits these files into individual scenarios. The `{{testExamples}}` placeholder in your test command will then be populated with specific `file:line` identifiers for each scenario to be run.
+
+## Selector-based test splitting
+
+Cucumber supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same feature file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [Ruby test collector](https://buildkite.com/docs/test-engine/test-collection/ruby-collectors), we recommend updating to `buildkite-test_collector` v2.14.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a location prefix (`--location-prefix` / `BUILDKITE_TEST_ENGINE_LOCATION_PREFIX`), since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```

--- a/docs/custom-test-runner.md
+++ b/docs/custom-test-runner.md
@@ -27,6 +27,25 @@ You can exclude specific files or directories that match a certain pattern using
 export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=tests/api
 ```
 
+## Selector-based test splitting
+
+The custom runner supports [selector-based test splitting](../README.md#selector-based-test-splitting). Unlike the other runners, the custom runner has no built-in way to discover selectors on its own, since it doesn't know your test framework's file conventions. Enable it and provide a list of selectors with `--selector-file` (or `BUILDKITE_TEST_ENGINE_SELECTOR_FILE`), a path to a newline-delimited file of selector values:
+
+```sh
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER=custom
+export BUILDKITE_TEST_ENGINE_TEST_CMD="bin/test {{testExamples}}"
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+export BUILDKITE_TEST_ENGINE_SELECTOR_FILE=selectors.txt
+bktec run
+```
+
+The values in `selectors.txt` are passed straight through to `{{testExamples}}`, one per assigned test case, the same way file paths are for file-based splitting.
+
+If `--selector-splitting` is enabled but `--selector-file` isn't set, the custom runner falls back to its normal file-pattern collection (`BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`), the same discovery it uses without selector splitting. In this fallback mode, `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` is still required.
+
+> [!IMPORTANT]
+> The custom runner is a special case for [selector matching](../README.md#how-selectors-are-matched): `bktec` has no way to know what your test command considers a "selector", so it doesn't automatically attribute `test.selector.primary` for custom runner executions. When that tag is missing, Test Engine falls back to the file name for selector matching, so splitting behaves the same as file-based splitting. If your selectors aren't file paths and you want accurate selector history, set `test.selector.primary` yourself as an execution-level [custom tag](https://buildkite.com/docs/pipelines/configure/tests/test-suites/tags#custom-tags) (for example, in the [Test Engine JSON](#test-engine-json-example) result your runner outputs).
+
 ## Muting test results
 If you have [Test state and quarantine](https://buildkite.com/docs/test-engine/test-suites/test-state-and-quarantine#lifecycle-states-mute-recommended) enabled in your Buildkite Test Suite, you can configure bktec to mute test results. When this is configured, failure from muted tests will not cause the build to fail.
 

--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -40,3 +40,16 @@ export BUILDKITE_TEST_ENGINE_TEST_FILE_EXCLUDE_PATTERN=cypress/e2e
 
 > [!TIP]
 > This option accepts the pattern syntax supported by the [zzglob](https://github.com/DrJosh9000/zzglob?tab=readme-ov-file#pattern-syntax) library.
+
+## Selector-based test splitting
+
+Cypress supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [JavaScript test collector](https://buildkite.com/docs/test-engine/test-collection/javascript-collectors), we recommend updating to `buildkite-test-collector` v1.10.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a location prefix, since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```

--- a/docs/gotest.md
+++ b/docs/gotest.md
@@ -67,6 +67,18 @@ export BUILDKITE_TEST_ENGINE_TEST_CMD="go test -json {{packages}}"
 > [!IMPORTANT]
 > Go JSONL output contains both test-level events and package-level events. `bktec` still runs and retries Go tests by package, but reports individual tests when Go includes a test name in the JSON event stream.
 
+## Selector-based test splitting
+
+go test supports [selector-based test splitting](../README.md#selector-based-test-splitting). Without selector splitting, `bktec` splits packages evenly by count. With it enabled, the selector for gotest is the Go package import path, and Test Engine can use historical package duration data to balance packages across nodes instead of just splitting by count.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
+If `--selector-splitting` is enabled but `--selector-file` isn't set, `bktec` still discovers packages itself using `go list`, the same discovery used without selector splitting; only the split strategy changes. You can also provide a fixed list of package import paths with `--selector-file` (or `BUILDKITE_TEST_ENGINE_SELECTOR_FILE`) instead of relying on `go list` discovery.
+
 ## Filter packages
 
 Support for filtering specific packages is planned for a future release. Please let us know if this is a feature you need sooner.

--- a/docs/jest.md
+++ b/docs/jest.md
@@ -59,6 +59,19 @@ Or using the environment variable:
 export BUILDKITE_TEST_ENGINE_LOCATION_PREFIX=my/prefix/
 ```
 
+## Selector-based test splitting
+
+Jest supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [JavaScript test collector](https://buildkite.com/docs/test-engine/test-collection/javascript-collectors), we recommend updating to `buildkite-test-collector` v1.10.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a [location prefix](#location-prefix), since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
 ## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the following command:
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -69,6 +69,19 @@ Or using the environment variable:
 export BUILDKITE_TEST_ENGINE_LOCATION_PREFIX=my/prefix/
 ```
 
+## Selector-based test splitting
+
+Playwright supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [JavaScript test collector](https://buildkite.com/docs/test-engine/test-collection/javascript-collectors), we recommend updating to `buildkite-test-collector` v1.10.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a [location prefix](#location-prefix), since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
 ## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
 

--- a/docs/pytest.md
+++ b/docs/pytest.md
@@ -85,6 +85,19 @@ bktec run
 > [!NOTE]
 > `execution_tag` is a custom marker added by Buildkite Test Collector for pytest. You can add multiple tags to a test, however the tag filters only support single `key:value` pairs.
 
+## Selector-based test splitting
+
+pytest supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with [Buildkite Test Collector for pytest](https://buildkite.com/docs/test-engine/python-collectors#pytest-collector), we recommend updating to `buildkite-test-collector` v1.6.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a location prefix, since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
 ## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using either the default test command or the command specified in `BUILDKITE_TEST_ENGINE_TEST_CMD`.
 

--- a/docs/rspec.md
+++ b/docs/rspec.md
@@ -85,6 +85,19 @@ To enable automatic retry, set the following environment variable:
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=2
 ```
 
+## Selector-based test splitting
+
+RSpec supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [Ruby test collector](https://buildkite.com/docs/test-engine/test-collection/ruby-collectors), we recommend updating to `buildkite-test_collector` v2.14.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a [location prefix](#location-prefix), since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
 ## Split slow files by individual test example
 By default, bktec splits your test suite into batches of test files. In some scenarios, e.g. if your test suite has a few test files that take a very long time to run, you may want to split slow test files into individual test examples for execution. To enable this, you can set the `BUILDKITE_TEST_ENGINE_SPLIT_BY_EXAMPLE` environment variable to `true`. This setting enables bktec to dynamically split slow test files across multiple partitions based on their duration and the number of parallelism.
 

--- a/docs/vitest.md
+++ b/docs/vitest.md
@@ -49,6 +49,19 @@ If you have configured the [Buildkite test collector](https://buildkite.com/docs
 export BUILDKITE_TEST_ENGINE_LOCATION_PREFIX=my/prefix/
 ```
 
+## Selector-based test splitting
+
+Vitest supports [selector-based test splitting](../README.md#selector-based-test-splitting). It doesn't change how your tests are split: the selector sent to Test Engine is the same test file path that file-based splitting already discovers using `BUILDKITE_TEST_ENGINE_TEST_FILE_PATTERN` / `_EXCLUDE_PATTERN`, so file discovery and the `{{testExamples}}` command placeholder work the same way.
+
+> [!NOTE]
+> If you upload results with the [JavaScript test collector](https://buildkite.com/docs/test-engine/test-collection/javascript-collectors), we recommend updating to `buildkite-test-collector` v1.10.0 or later so selectors are attributed directly. If you do not, nothing breaks: Test Engine [falls back to the file path](../README.md#how-selectors-are-matched) when a selector is not attributed, which keeps file-based matching working. Updating matters most if you use a [location prefix](#location-prefix), since the fallback only handles the prefix on a best-effort basis.
+
+To enable it:
+
+```sh
+export BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true
+```
+
 ## Automatically retry failed tests
 You can configure bktec to automatically retry failed tests using the `BUILDKITE_TEST_ENGINE_RETRY_COUNT` environment variable. When this variable is set to a number greater than `0`, bktec will retry each failed test up to the specified number of times, using the following command:
 

--- a/util/supported_features/main.go
+++ b/util/supported_features/main.go
@@ -77,6 +77,12 @@ func main() {
 
 	printRow(
 		runners,
+		"[Selector-based test splitting](https://github.com/buildkite/test-engine-client/blob/main/README.md#selector-based-test-splitting)",
+		func(r runner.TestRunner) bool { return r.SupportedFeatures().SplitBySelector },
+	)
+
+	printRow(
+		runners,
 		"Filter test files",
 		func(r runner.TestRunner) bool { return r.SupportedFeatures().FilterTestFiles },
 	)


### PR DESCRIPTION
### Description

We're moving from file-based splitting to selector-based splitting, and this release makes selector-based splitting a public opt-in (still off by default). Until now `--selector-splitting` and `--selector-file` were hidden flags with no docs. This PR unhides both flags and documents how selector-based splitting works across every supported runner.

For most runners nothing changes about how tests are split. The selector is the same file path file-based splitting already discovers, so it only changes how that path is reported to Test Engine. gotest is the exception: its selector is the Go package import path, so enabling it turns on duration-aware package splitting instead of the current even-count split.

The docs also cover how selectors are matched (`test.selector.primary`, with a fallback to the file name when it is not attributed), the custom runner behaviour (no automatic selector attribution, so it falls back to file-pattern collection and to the file name for matching), and the collector versions we recommend for accurate attribution.

### Context

- [TE-6310](https://linear.app/buildkite/issue/TE-6310)
- Parent: [TE-6207](https://linear.app/buildkite/issue/TE-6207) (docs for new splitting features)
- Rollout plan: [TE-6362](https://linear.app/buildkite/issue/TE-6362)

### Changes

- Unhide the `--selector-splitting` and `--selector-file` CLI flags so they show in `--help`.
- Add a "Selector-based test splitting" section to the README covering how it works, how to enable it, how selectors are matched, and the collector-version recommendation.
- Add a selector-based splitting section to each runner guide, including the custom runner fallback and gotest's package-based duration splitting.
- Add a selector-based splitting row to the supported-features table (and its generator).

### Testing

Docs and flag visibility only. Ran `go build ./...` and regenerated the supported-features table with `go run util/supported_features/main.go`.