### PR TITLE
[TE-6386] Support split-by-example with selector splitting

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -25,7 +25,7 @@ import (
 // Currently only the Pytest runner supports tag filtering.
 func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	if shouldUseSelectorSplitting(cfg, runner) {
-		if shouldExpandSelectorFilesForSkippedTests(runner) {
+		if shouldExpandSelectorFiles(cfg, runner) {
 			testParams, err := filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
 			if err != nil {
 				return api.TestPlanParams{}, err
@@ -137,9 +137,9 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 
-func shouldExpandSelectorFilesForSkippedTests(runner runner.TestRunner) bool {
+func shouldExpandSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
 	features := runner.SupportedFeatures()
-	return features.SplitBySelector && features.SplitByExample && features.FilterTestFiles && features.Skip
+	return features.SplitBySelector && features.SplitByExample && features.FilterTestFiles && (features.Skip || cfg.SplitByExample)
 }
 
 func selectorParamsFromValues(values []string) []api.TestPlanParamsSelector {

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -139,9 +139,8 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 
 func shouldFilterAndSplitSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
 	features := runner.SupportedFeatures()
-	canSplitFilteredFiles := features.SplitByExample && features.FilterTestFiles
 	needsFilteredFiles := cfg.SplitByExample || features.Skip
-	return canSplitFilteredFiles && needsFilteredFiles
+	return features.SplitByExample && needsFilteredFiles
 }
 
 func selectorParamsFromValues(values []string) []api.TestPlanParamsSelector {

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -25,7 +25,7 @@ import (
 // Currently only the Pytest runner supports tag filtering.
 func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	if shouldUseSelectorSplitting(cfg, runner) {
-		if shouldExpandSelectorFiles(cfg, runner) {
+		if shouldFilterAndSplitSelectorFiles(cfg, runner) {
 			testParams, err := filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
 			if err != nil {
 				return api.TestPlanParams{}, err
@@ -137,9 +137,11 @@ func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bo
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
 }
 
-func shouldExpandSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
+func shouldFilterAndSplitSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
 	features := runner.SupportedFeatures()
-	return features.SplitBySelector && features.SplitByExample && features.FilterTestFiles && (features.Skip || cfg.SplitByExample)
+	canSplitFilteredFiles := features.SplitByExample && features.FilterTestFiles
+	needsFilteredFiles := cfg.SplitByExample || features.Skip
+	return canSplitFilteredFiles && needsFilteredFiles
 }
 
 func selectorParamsFromValues(values []string) []api.TestPlanParamsSelector {

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -594,7 +594,7 @@ func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
 	}
 }
-func TestShouldExpandSelectorFilesForSkippedTests(t *testing.T) {
+func TestShouldExpandSelectorFiles(t *testing.T) {
 	custom, err := runner.NewCustom(runner.RunnerConfig{
 		TestCommand:     "echo {{testExamples}}",
 		TestFilePattern: "tests/**/*",
@@ -606,6 +606,7 @@ func TestShouldExpandSelectorFilesForSkippedTests(t *testing.T) {
 	cases := []struct {
 		name       string
 		testRunner runner.TestRunner
+		split      bool
 		want       bool
 	}{
 		{
@@ -633,16 +634,113 @@ func TestShouldExpandSelectorFilesForSkippedTests(t *testing.T) {
 			testRunner: runner.NewJest(runner.RunnerConfig{}),
 			want:       false,
 		},
+		{
+			name:       "Playwright selector-backed files support slow-file expansion when split by example is enabled",
+			testRunner: runner.NewPlaywright(runner.RunnerConfig{}),
+			split:      true,
+			want:       true,
+		},
+		{
+			name:       "Playwright selector-backed files do not expand when split by example is disabled",
+			testRunner: runner.NewPlaywright(runner.RunnerConfig{}),
+			want:       false,
+		},
+		{
+			name:       "pytest selector-backed files support slow-file expansion when split by example is enabled",
+			testRunner: runner.Pytest{},
+			split:      true,
+			want:       true,
+		},
+		{
+			name:       "pytest selector-backed files do not expand when split by example is disabled",
+			testRunner: runner.Pytest{},
+			want:       false,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := shouldExpandSelectorFilesForSkippedTests(c.testRunner); got != c.want {
-				t.Errorf("shouldExpandSelectorFilesForSkippedTests(%s) = %v, want %v", c.testRunner.Name(), got, c.want)
+			cfg := config.Config{SplitByExample: c.split}
+			if got := shouldExpandSelectorFiles(&cfg, c.testRunner); got != c.want {
+				t.Errorf("shouldExpandSelectorFiles(%s) = %v, want %v", c.testRunner.Name(), got, c.want)
 			}
 		})
 	}
 }
+
+func TestCreateRequestParams_SelectorSplittingExpandsSlowFilesForSplitByExampleRunners(t *testing.T) {
+	for _, testRunner := range []string{"playwright", "pytest"} {
+		t.Run(testRunner, func(t *testing.T) {
+			filterRequestCount := 0
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				filterRequestCount++
+				fmt.Fprint(w, `
+{
+	"tests": [
+		{ "path": "tests/slow_test", "reason": "slow file" }
+	]
+}`)
+			}))
+			defer svr.Close()
+
+			cfg := config.Config{
+				OrganizationSlug:  "my-org",
+				SuiteSlug:         "my-suite",
+				Identifier:        "identifier",
+				Parallelism:       2,
+				TestRunner:        testRunner,
+				SelectorSplitting: true,
+				SplitByExample:    true,
+			}
+
+			client := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL})
+			selectors := []string{"tests/fast_test", "tests/slow_test"}
+			stubRunner := metadataTestRunner{
+				name: testRunner,
+				supportedFeatures: runner.SupportedFeatures{
+					SplitByExample:  true,
+					SplitBySelector: true,
+					FilterTestFiles: true,
+				},
+				examples: []plan.TestCase{
+					{
+						Identifier: "tests/slow_test::example",
+						Path:       "tests/slow_test::example",
+						Scope:      "tests/slow_test",
+						Name:       "example",
+						Format:     plan.TestCaseFormatExample,
+					},
+				},
+			}
+
+			got, err := createRequestParam(context.Background(), &cfg, selectors, *client, stubRunner)
+			if err != nil {
+				t.Fatalf("createRequestParam() error = %v", err)
+			}
+
+			if filterRequestCount != 1 {
+				t.Errorf("filter request count = %d, want 1", filterRequestCount)
+			}
+
+			want := api.TestPlanParams{
+				Identifier:  "identifier",
+				Parallelism: 2,
+				Runner:      testRunner,
+				Tests: api.TestPlanParamsTest{
+					Examples: stubRunner.examples,
+					Selectors: []api.TestPlanParamsSelector{
+						{Value: "tests/fast_test"},
+					},
+				},
+			}
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCreateRequestParams_SelectorOptInIgnoredForSplitByExampleRunner(t *testing.T) {
 	filterRequestCount := 0
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -594,7 +594,7 @@ func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 		t.Errorf("createRequestParam() diff (-got +want):\n%s", diff)
 	}
 }
-func TestShouldExpandSelectorFiles(t *testing.T) {
+func TestShouldFilterAndSplitSelectorFiles(t *testing.T) {
 	custom, err := runner.NewCustom(runner.RunnerConfig{
 		TestCommand:     "echo {{testExamples}}",
 		TestFilePattern: "tests/**/*",
@@ -661,8 +661,8 @@ func TestShouldExpandSelectorFiles(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			cfg := config.Config{SplitByExample: c.split}
-			if got := shouldExpandSelectorFiles(&cfg, c.testRunner); got != c.want {
-				t.Errorf("shouldExpandSelectorFiles(%s) = %v, want %v", c.testRunner.Name(), got, c.want)
+			if got := shouldFilterAndSplitSelectorFiles(&cfg, c.testRunner); got != c.want {
+				t.Errorf("shouldFilterAndSplitSelectorFiles(%s) = %v, want %v", c.testRunner.Name(), got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

Preserve split-by-example behavior for Playwright and pytest when selector splitting is enabled. Slow files are expanded into individual examples while remaining files continue to be sent as selectors.

RSpec and Cucumber continue to expand selector-backed files for skipped-test handling, and Playwright/pytest continue to send selectors directly when split-by-example is disabled.

### Context

- [TE-6386](https://linear.app/buildkite/issue/TE-6386)
- [PR #599 review comment](https://github.com/buildkite/test-engine-client/pull/599#discussion_r3592253070)

### Changes

- Expand selector-backed files when either skipped-test handling or split-by-example requires it.
- Add Playwright and pytest coverage for enabled and disabled split-by-example behavior.
- Verify slow files become examples while other files remain selectors.

### Testing

- `go test ./internal/command -run 'TestShouldExpandSelectorFiles|TestCreateRequestParams_SelectorSplittingExpandsSlowFilesForSplitByExampleRunners|TestCreateRequestParams_RSpecSelectorSplitting' -count=1`
- `go test ./internal/api ./internal/config`

The full `go test ./internal/command` run also requires the Buildkite pytest collector locally for its existing tag-filter tests; the focused request-path tests pass.