### PR TITLE
Enable Skip feature for Pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Splitting quality depends on the timing data available for the suite. First runs
 | Filter tests by tag | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Automatically retry failed test | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
 | Mute tests (ignore test failures) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| Skip tests | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Skip tests | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Splitting quality depends on the timing data available for the suite. First runs
 | Filter tests by tag | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Automatically retry failed test | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
 | Mute tests (ignore test failures) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| Skip tests | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| Skip tests | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
 
 ## Installation
 

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -55,7 +55,7 @@ func (p Playwright) SupportedFeatures() SupportedFeatures {
 		FilterTestByTag: false,
 		AutoRetry:       true,
 		Mute:            true,
-		Skip:            false,
+		Skip:            true,
 		SplitBySelector: true,
 	}
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -55,7 +55,13 @@ func (p Playwright) SupportedFeatures() SupportedFeatures {
 		FilterTestByTag: false,
 		AutoRetry:       true,
 		Mute:            true,
-		Skip:            true,
+		// Skip stays disabled for now. The same test can run across multiple
+		// Playwright projects (e.g. Chromium and Firefox) as separate examples
+		// that share the same Path (file:line). The value we hand to Playwright
+		// is just that Path, which is not project-specific, so skipping one
+		// project's example while keeping another's would still rerun both.
+		// Enabling skip needs a project-scoped selector first.
+		Skip:            false,
 		SplitBySelector: true,
 	}
 }

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -311,7 +311,7 @@ func (p Pytest) GetExamples(files []string) ([]plan.TestCase, error) {
 		return nil, fmt.Errorf("pytest collection failed: %w", err)
 	}
 
-	return parsePytestCollectOutput(string(output))
+	return p.parsePytestCollectOutput(string(output))
 }
 
 // parsePytestCollectOutput parses the output of `pytest --collect-only -q`
@@ -324,7 +324,7 @@ func (p Pytest) GetExamples(files []string) ([]plan.TestCase, error) {
 //	test_auth.py::test_param[value1]
 //
 //	3 tests collected in 0.05s
-func parsePytestCollectOutput(output string) ([]plan.TestCase, error) {
+func (p Pytest) parsePytestCollectOutput(output string) ([]plan.TestCase, error) {
 	var testCases []plan.TestCase
 
 	for _, line := range strings.Split(output, "\n") {
@@ -336,7 +336,7 @@ func parsePytestCollectOutput(output string) ([]plan.TestCase, error) {
 		}
 
 		// Parse node ID: "file.py::TestClass::test_method" or "file.py::test_func"
-		testCases = append(testCases, mapNodeIDToTestCase(line))
+		testCases = append(testCases, p.mapNodeIDToTestCase(line))
 	}
 
 	return testCases, nil
@@ -346,7 +346,7 @@ func parsePytestCollectOutput(output string) ([]plan.TestCase, error) {
 // Node ID format: file_path::class::method or file_path::function
 // Must match the format used by buildkite-test-collector for pytest.
 // Scope is everything except the final component, Name is the last component.
-func mapNodeIDToTestCase(nodeID string) plan.TestCase {
+func (p Pytest) mapNodeIDToTestCase(nodeID string) plan.TestCase {
 	// Split on the last :: to get scope (everything before) and name (last component)
 	lastIdx := strings.LastIndex(nodeID, "::")
 	scope := ""
@@ -356,6 +356,11 @@ func mapNodeIDToTestCase(nodeID string) plan.TestCase {
 		name = nodeID[lastIdx+2:]
 	}
 
+	// There is difference between the scope reported by test-collector and native JUnit XML.
+	if p.useJUnit {
+		scope = collectorScopeToJunitScope(scope)
+	}
+
 	return plan.TestCase{
 		Identifier: nodeID,
 		Path:       nodeID,
@@ -363,6 +368,23 @@ func mapNodeIDToTestCase(nodeID string) plan.TestCase {
 		Name:       name,
 		Format:     plan.TestCaseFormatExample,
 	}
+}
+
+// collectorScopeToJunitScope converts a pytest scope (from test-collector) to a JUnit scope (from JUnit XML).
+// test-collector reports the scope as the file path (e.g. tests/test_auth.py::TestLogin),
+// while JUnit XML reports the scope as the raw classname (e.g. tests.test_auth.TestLogin).
+// Remove `.py` extension, and replace `::` with `.` from scope.
+// Example:
+//
+//	test_sample.py -> test_sample
+//	tests/test_auth.py::TestLogin -> tests.test_auth.TestLogin
+//	tests/MyTest/test_subtract.py::TestClass -> tests.MyTest.test_subtract.TestClass
+func collectorScopeToJunitScope(scope string) string {
+	classname := strings.Replace(scope, ".py", "", 1)
+	classname = strings.ReplaceAll(classname, "::", ".")
+	classname = strings.ReplaceAll(classname, "/", ".")
+
+	return classname
 }
 
 func (p Pytest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -195,13 +195,14 @@ func (p Pytest) runParseJUnit(result *RunResult) error {
 	}
 
 	for _, test := range tests {
-		scope, path := pytestNodeIDFromJUnit(test.Classname, test.Name)
+		path := pytestNodeIDFromJUnit(test.Classname, test.Name)
 		result.RecordTestResult(plan.TestCase{
 			Identifier: path,
 			Format:     plan.TestCaseFormatExample,
-			Scope:      scope,
-			Name:       test.Name,
-			Path:       path,
+			// JUnit XML ingestion set Scope to the raw classname
+			Scope: test.Classname,
+			Name:  test.Name,
+			Path:  path,
 		}, test.Result)
 	}
 
@@ -219,9 +220,9 @@ func (p Pytest) runParseJUnit(result *RunResult) error {
 //	classname="tests.test_auth.TestLogin",            name="test_success" → scope="tests/test_auth.py::TestLogin",           path="tests/test_auth.py::TestLogin::test_success"
 //	classname="tests.MyTest.test_subtract.TestClass", name="test_positive"→ scope="tests/MyTest/test_subtract.py::TestClass",path="tests/MyTest/test_subtract.py::TestClass::test_positive"
 //	classname="tests.MyTest.test_add",                name="test_add"     → scope="tests/MyTest/test_add.py",                path="tests/MyTest/test_add.py::test_add"
-func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
+func pytestNodeIDFromJUnit(classname, name string) (path string) {
 	if classname == "" {
-		return name, name
+		return name
 	}
 
 	parts := strings.Split(classname, ".")
@@ -252,11 +253,9 @@ func pytestNodeIDFromJUnit(classname, name string) (scope, path string) {
 	classParts := parts[moduleEnd:]
 
 	if len(classParts) == 0 {
-		scope = modulePath
 		path = modulePath + "::" + name
 	} else {
 		classPath := strings.Join(classParts, "::")
-		scope = modulePath + "::" + classPath
 		path = modulePath + "::" + classPath + "::" + name
 	}
 	return

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -105,7 +105,7 @@ func (p Pytest) SupportedFeatures() SupportedFeatures {
 		FilterTestByTag: true,
 		AutoRetry:       true,
 		Mute:            true,
-		Skip:            false,
+		Skip:            true,
 		SplitBySelector: true,
 	}
 }

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -373,15 +373,24 @@ func (p Pytest) mapNodeIDToTestCase(nodeID string) plan.TestCase {
 // collectorScopeToJunitScope converts a pytest scope (from test-collector) to a JUnit scope (from JUnit XML).
 // test-collector reports the scope as the file path (e.g. tests/test_auth.py::TestLogin),
 // while JUnit XML reports the scope as the raw classname (e.g. tests.test_auth.TestLogin).
-// Remove `.py` extension, and replace `::` with `.` from scope.
+// Strip the `.py` extension from the file path, then replace `::` and `/` with `.`.
+// The file path is always the part before the first `::`, so we only trim the suffix on
+// that part. Doing so avoids mangling a directory that happens to end in `.py`.
 // Example:
 //
 //	test_sample.py -> test_sample
 //	tests/test_auth.py::TestLogin -> tests.test_auth.TestLogin
 //	tests/MyTest/test_subtract.py::TestClass -> tests.MyTest.test_subtract.TestClass
+//	tests/test_auth.py::TestOuter::TestInner -> tests.test_auth.TestOuter.TestInner
+//	tests/pkg.py/test_auth.py::TestLogin -> tests.pkg.py.test_auth.TestLogin
 func collectorScopeToJunitScope(scope string) string {
-	classname := strings.Replace(scope, ".py", "", 1)
-	classname = strings.ReplaceAll(classname, "::", ".")
+	path, rest, hasClass := strings.Cut(scope, "::")
+	path = strings.TrimSuffix(path, ".py")
+	if hasClass {
+		path = path + "::" + rest
+	}
+
+	classname := strings.ReplaceAll(path, "::", ".")
 	classname = strings.ReplaceAll(classname, "/", ".")
 
 	return classname

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -789,8 +789,10 @@ func TestParsePytestCollectOutput_JUnit(t *testing.T) {
 test_auth.py::TestLogin::test_success
 test_auth.py::test_param[value1]
 tests/test_another.py::WithClass::test_method
+tests/test_nested.py::TestOuter::TestInner::test_deep
+tests/pkg.py/test_auth.py::TestLogin::test_success
 
-3 tests collected in 0.05s`
+6 tests collected in 0.05s`
 	got, err := pytest.parsePytestCollectOutput(output)
 	if err != nil {
 		t.Fatalf("parsePytestCollectOutput() error = %v", err)
@@ -801,6 +803,10 @@ tests/test_another.py::WithClass::test_method
 		{Identifier: "test_auth.py::TestLogin::test_success", Path: "test_auth.py::TestLogin::test_success", Scope: "test_auth.TestLogin", Name: "test_success", Format: plan.TestCaseFormatExample},
 		{Identifier: "test_auth.py::test_param[value1]", Path: "test_auth.py::test_param[value1]", Scope: "test_auth", Name: "test_param[value1]", Format: plan.TestCaseFormatExample},
 		{Identifier: "tests/test_another.py::WithClass::test_method", Path: "tests/test_another.py::WithClass::test_method", Scope: "tests.test_another.WithClass", Name: "test_method", Format: plan.TestCaseFormatExample},
+		// Nested classes produce more than one `::` in the scope.
+		{Identifier: "tests/test_nested.py::TestOuter::TestInner::test_deep", Path: "tests/test_nested.py::TestOuter::TestInner::test_deep", Scope: "tests.test_nested.TestOuter.TestInner", Name: "test_deep", Format: plan.TestCaseFormatExample},
+		// A directory ending in `.py` must keep its extension; only the file loses it.
+		{Identifier: "tests/pkg.py/test_auth.py::TestLogin::test_success", Path: "tests/pkg.py/test_auth.py::TestLogin::test_success", Scope: "tests.pkg.py.test_auth.TestLogin", Name: "test_success", Format: plan.TestCaseFormatExample},
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -384,7 +384,7 @@ func TestPytestRun_JUnit_TestPassed(t *testing.T) {
 			Identifier: "test_sample.py::test_happy",
 			Name:       "test_happy",
 			Path:       "test_sample.py::test_happy",
-			Scope:      "test_sample.py",
+			Scope:      "test_sample",
 		},
 	}
 	if diff := cmp.Diff(passedTests, wantPassedTests); diff != "" {
@@ -424,7 +424,7 @@ func TestPytestRun_JUnit_TestFailed(t *testing.T) {
 			Identifier: "tests/failed_test.py::test_failed",
 			Name:       "test_failed",
 			Path:       "tests/failed_test.py::test_failed",
-			Scope:      "tests/failed_test.py",
+			Scope:      "tests.failed_test",
 		},
 	}
 
@@ -706,37 +706,31 @@ func TestPytestNodeIDFromJUnit(t *testing.T) {
 		{
 			classname: "test_sample",
 			name:      "test_happy",
-			wantScope: "test_sample.py",
 			wantPath:  "test_sample.py::test_happy",
 		},
 		{
 			classname: "tests.test_sample",
 			name:      "test_happy",
-			wantScope: "tests/test_sample.py",
 			wantPath:  "tests/test_sample.py::test_happy",
 		},
 		{
 			classname: "tests.failed_test",
 			name:      "test_failed",
-			wantScope: "tests/failed_test.py",
 			wantPath:  "tests/failed_test.py::test_failed",
 		},
 		{
 			classname: "test_auth.TestLogin",
 			name:      "test_success",
-			wantScope: "test_auth.py::TestLogin",
 			wantPath:  "test_auth.py::TestLogin::test_success",
 		},
 		{
 			classname: "tests.test_auth.TestLogin",
 			name:      "test_success",
-			wantScope: "tests/test_auth.py::TestLogin",
 			wantPath:  "tests/test_auth.py::TestLogin::test_success",
 		},
 		{
 			classname: "",
 			name:      "test_something",
-			wantScope: "test_something",
 			wantPath:  "test_something",
 		},
 		{
@@ -750,17 +744,13 @@ func TestPytestNodeIDFromJUnit(t *testing.T) {
 			// Uppercase package directory with no class: MyTest is a directory.
 			classname: "tests.MyTest.test_add",
 			name:      "test_add",
-			wantScope: "tests/MyTest/test_add.py",
 			wantPath:  "tests/MyTest/test_add.py::test_add",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.classname+"::"+tt.name, func(t *testing.T) {
-			gotScope, gotPath := pytestNodeIDFromJUnit(tt.classname, tt.name)
-			if gotScope != tt.wantScope {
-				t.Errorf("pytestNodeIDFromJUnit(%q, %q) scope = %q, want %q", tt.classname, tt.name, gotScope, tt.wantScope)
-			}
+			gotPath := pytestNodeIDFromJUnit(tt.classname, tt.name)
 			if gotPath != tt.wantPath {
 				t.Errorf("pytestNodeIDFromJUnit(%q, %q) path = %q, want %q", tt.classname, tt.name, gotPath, tt.wantPath)
 			}

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -765,7 +765,7 @@ test_auth.py::test_param[value1]
 
 3 tests collected in 0.05s`
 
-	pytest := NewPytest(RunnerConfig{})
+	pytest := Pytest{useJUnit: false}
 
 	got, err := pytest.parsePytestCollectOutput(output)
 	if err != nil {

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -765,7 +765,9 @@ test_auth.py::test_param[value1]
 
 3 tests collected in 0.05s`
 
-	got, err := parsePytestCollectOutput(output)
+	pytest := NewPytest(RunnerConfig{})
+
+	got, err := pytest.parsePytestCollectOutput(output)
 	if err != nil {
 		t.Fatalf("parsePytestCollectOutput() error = %v", err)
 	}
@@ -774,6 +776,31 @@ test_auth.py::test_param[value1]
 		{Identifier: "test_sample.py::test_happy", Path: "test_sample.py::test_happy", Scope: "test_sample.py", Name: "test_happy", Format: plan.TestCaseFormatExample},
 		{Identifier: "test_auth.py::TestLogin::test_success", Path: "test_auth.py::TestLogin::test_success", Scope: "test_auth.py::TestLogin", Name: "test_success", Format: plan.TestCaseFormatExample},
 		{Identifier: "test_auth.py::test_param[value1]", Path: "test_auth.py::test_param[value1]", Scope: "test_auth.py", Name: "test_param[value1]", Format: plan.TestCaseFormatExample},
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("parsePytestCollectOutput() diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestParsePytestCollectOutput_JUnit(t *testing.T) {
+	pytest := Pytest{useJUnit: true}
+	output := `test_sample.py::test_happy
+test_auth.py::TestLogin::test_success
+test_auth.py::test_param[value1]
+tests/test_another.py::WithClass::test_method
+
+3 tests collected in 0.05s`
+	got, err := pytest.parsePytestCollectOutput(output)
+	if err != nil {
+		t.Fatalf("parsePytestCollectOutput() error = %v", err)
+	}
+
+	want := []plan.TestCase{
+		{Identifier: "test_sample.py::test_happy", Path: "test_sample.py::test_happy", Scope: "test_sample", Name: "test_happy", Format: plan.TestCaseFormatExample},
+		{Identifier: "test_auth.py::TestLogin::test_success", Path: "test_auth.py::TestLogin::test_success", Scope: "test_auth.TestLogin", Name: "test_success", Format: plan.TestCaseFormatExample},
+		{Identifier: "test_auth.py::test_param[value1]", Path: "test_auth.py::test_param[value1]", Scope: "test_auth", Name: "test_param[value1]", Format: plan.TestCaseFormatExample},
+		{Identifier: "tests/test_another.py::WithClass::test_method", Path: "tests/test_another.py::WithClass::test_method", Scope: "tests.test_another.WithClass", Name: "test_method", Format: plan.TestCaseFormatExample},
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {


### PR DESCRIPTION
### Description

Right now Pytest and Playwright both have `SplitByExample: true` but `Skip: false` in their `SupportedFeatures()`. Skipping tests relies on example-level granularity, which is the same mechanism that split by example uses. So any runner that supports split by example should also support skip. RSpec and Cucumber already follow that pattern.

I originally planned to flip `Skip` to `true` for both Pytest and Playwright. During review we found a complication with Playwright, so this PR only enables skip for Pytest and leaves Playwright for a follow-up.

**Why Playwright is not included**

The same Playwright test can run across multiple projects (for example Chromium and Firefox). Test Engine treats each project run as a separate example with its own scope, but all of them share the same `Path` (`spec.File:spec.Line`). The value we hand to Playwright when we run tests is just that `Path`, which is not project-specific. So if the plan skips only the Chromium example and keeps the Firefox one, we would still invoke Playwright with the shared line selector and rerun the test for every project. Enabling skip safely needs a project-scoped selector first (for example passing `--project`), so Playwright skip is deferred.

**Pytest scope fix**

While enabling skip for Pytest, I hit a scope mismatch that had to be fixed first. Skip works by matching the tests we collect locally (via `GetExamples`) against the results the server has on record. For Pytest those two come from different sources, and they were producing different scopes:

- JUnit XML ingestion records the scope as the raw classname (e.g. `tests.test_auth.TestLogin`).
- Local collection via `pytest --collect-only` was recording the scope as the file path (e.g. `tests/test_auth.py::TestLogin`).

Because the scopes did not match, skip would not line up. So this PR makes local collection derive a JUnit-style scope when we are in JUnit mode, so it matches what ingestion stores. I also dropped the now-unused `scope` return from `pytestNodeIDFromJUnit`.

### Context

[TE-6388](https://linear.app/buildkite/issue/TE-6388/enable-skip-feature-for-pytest-and-playwright)

### Changes

- Set `Skip: true` for Pytest
- Fixed Pytest local collection to derive a JUnit-style scope when running in JUnit mode, so it matches the scope recorded by JUnit XML ingestion
- Kept `Skip: false` for Playwright and added a comment explaining the project-selector limitation

### Testing

Covered by the existing runner unit tests plus a new `TestParsePytestCollectOutput_JUnit` case. The Pytest suite passes locally.
