### PR TITLE
Support tag filters with selector splitting

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -25,29 +25,10 @@ import (
 // Currently only the Pytest runner supports tag filtering.
 func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	if shouldUseSelectorSplitting(cfg, runner) {
-		if shouldFilterAndSplitSelectorFiles(cfg, runner) {
-			testParams, err := filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
-			if err != nil {
-				return api.TestPlanParams{}, err
-			}
-
-			return api.TestPlanParams{
-				Identifier:     cfg.Identifier,
-				Parallelism:    cfg.Parallelism,
-				MaxParallelism: cfg.MaxParallelism,
-				TargetTime:     cfg.TargetTime.Seconds(),
-				Branch:         cfg.Branch,
-				LocationPrefix: cfg.LocationPrefix,
-				Selection:      buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams),
-				Metadata:       cfg.Metadata,
-				Runner:         cfg.TestRunner,
-				Tests:          testParams,
-			}, nil
+		testParams, err := selectorTestParams(ctx, cfg, client, testTargets, runner)
+		if err != nil {
+			return api.TestPlanParams{}, err
 		}
-
-		// For selector-capable runners, discovered test targets are already runnable
-		// selector values, e.g. Go package import paths, not file paths.
-		selectors := selectorParamsFromValues(testTargets)
 
 		return api.TestPlanParams{
 			Identifier:     cfg.Identifier,
@@ -59,9 +40,7 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 			Selection:      buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams),
 			Metadata:       cfg.Metadata,
 			Runner:         cfg.TestRunner,
-			Tests: api.TestPlanParamsTest{
-				Selectors: selectors,
-			},
+			Tests:          testParams,
 		}, nil
 	}
 
@@ -129,12 +108,30 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 }
 
 func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bool {
-	// Pytest tag filters are applied during local example collection.
-	// Selector requests skip that step, so fall back to example splitting.
-	if cfg.TagFilters != "" {
-		return false
-	}
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
+}
+
+// selectorTestParams builds the Tests payload for selector-capable runners.
+//
+// When tag filters are set, every file is expanded into tag-filtered examples so that
+// nothing goes out as a raw selector, which would run all of the file's tests and
+// ignore the tag filter. Tag filtering is currently only supported for pytest.
+//
+// Otherwise, slow or skipped files are expanded into examples and the rest are sent as
+// raw selectors, or everything is sent as raw selectors when the runner doesn't need
+// filtered files.
+func selectorTestParams(ctx context.Context, cfg *config.Config, client api.Client, testTargets []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+	if cfg.TagFilters != "" && runner.Name() == "pytest" {
+		return splitAllSelectorFiles(testTargets, runner)
+	}
+
+	if shouldFilterAndSplitSelectorFiles(cfg, runner) {
+		return filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
+	}
+
+	return api.TestPlanParamsTest{
+		Selectors: selectorParamsFromValues(testTargets),
+	}, nil
 }
 
 func shouldFilterAndSplitSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
@@ -226,6 +223,18 @@ func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPla
 	return api.TestPlanParamsTest{
 		Examples: examples,
 	}, nil
+}
+
+// splitAllSelectorFiles expands every selector-backed file into examples to support tag filtering.
+// Selector-capable runners send file targets as raw selectors by default, which would ignore tag
+// filters, so all files are expanded into tag-filtered examples instead.
+func splitAllSelectorFiles(selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+	testFiles := make([]plan.TestCase, 0, len(selectors))
+	for _, selector := range selectors {
+		testFiles = append(testFiles, plan.TestCase{Path: prefixPath(selector, runner.LocationPrefix())})
+	}
+
+	return splitAllFiles(testFiles, runner)
 }
 
 // filterAndSplitSelectorFiles filters selector-backed file targets through the Test Engine API and splits

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -1148,7 +1148,10 @@ func TestCreateRequestParams_WithTagFilters(t *testing.T) {
 	}
 }
 
-func TestCreateRequestParams_SelectorOptInIgnoredForTagFilters(t *testing.T) {
+// When selector splitting and tag filters are both enabled, every file is expanded into
+// tag-filtered examples so that nothing goes out as a raw selector that would ignore the
+// tag filter.
+func TestCreateRequestParams_SelectorSplittingWithTagFilters(t *testing.T) {
 	cfg := config.Config{
 		OrganizationSlug:  "my-org",
 		SuiteSlug:         "my-suite",


### PR DESCRIPTION
### Description

Today `shouldUseSelectorSplitting` returns false whenever tag filters are set, so a pytest job with both `BUILDKITE_TEST_ENGINE_TAG_FILTERS` and `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING=true` falls back to the file/example path and gets no selector timings.

We can't just drop that guard. In the selector path, `filterAndSplitSelectorFiles` only expands the filtered (slow or skipped) files into examples and sends the rest as raw selectors. Tag filtering is applied during local example collection (`pytest --collect-only --tag-filters`), so any file sent as a raw selector would run all its tests and ignore the tag filter.

So when tag filters are set, the selector path now expands every file into tag-filtered examples so nothing goes out as a raw unfiltered selector, and I removed the tag-filter guard in `shouldUseSelectorSplitting`. Only pytest supports tag filters today.

This builds on the split-by-example-in-selector-mode work from #600.

### Context

[TE-6418](https://linear.app/buildkite/issue/TE-6418)

### Changes

- Removed the tag-filter guard in `shouldUseSelectorSplitting` so selector splitting runs when tag filters are set.
- Added a tag-filter branch to the selector path that expands all files into tag-filtered examples (`splitAllSelectorFiles`), so no file goes out as a raw selector that would ignore the filter.
- Pulled the selector-branch logic into a `selectorTestParams` helper. The two selector returns shared an identical `api.TestPlanParams` envelope, so folding them into the helper collapsed that duplicate envelope into a single return in `createRequestParam`.

### Testing

Covered by unit tests. Renamed the old `SelectorOptInIgnoredForTagFilters` test to `SelectorSplittingWithTagFilters` since the opt-in is no longer ignored, and it asserts every file expands to tag-filtered examples with no raw selectors.