### PR TITLE
Send `target_time` and `max_parallelism` on filter_tests

### DIFF
--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -10,8 +10,10 @@ import (
 )
 
 type FilterTestsParams struct {
-	Files []plan.TestCase   `json:"files"`
-	Env   config.EnvPayload `json:"env"`
+	Files          []plan.TestCase   `json:"files"`
+	Env            config.EnvPayload `json:"env"`
+	MaxParallelism int               `json:"max_parallelism,omitempty"`
+	TargetTime     float64           `json:"target_time,omitempty"`
 }
 
 type FilteredTest struct {

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -25,7 +25,9 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 			{Path: "./dog_spec.rb"},
 			{Path: "./turtle_spec.rb"},
 		},
-		Env: cfg.EnvPayload(),
+		Env:            cfg.EnvPayload(),
+		MaxParallelism: 10,
+		TargetTime:     300,
 	}
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,6 +50,8 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 				{"path": "./dog_spec.rb"},
 				{"path": "./turtle_spec.rb"}
 			],
+			"max_parallelism": 10,
+			"target_time": 300,
 			"env": {
 				"BUILDKITE_BUILD_ID": "",
 				"BUILDKITE_TEST_ENGINE_DEBUG_ENABLED": false,

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -302,8 +302,10 @@ func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Cli
 func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Client, files []plan.TestCase, runner runner.TestRunner, label string) ([]plan.TestCase, map[string]bool, error) {
 	debug.Printf("Filtering %d %s", len(files), label)
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
-		Files: files,
-		Env:   cfg.EnvPayload(),
+		Files:          files,
+		Env:            cfg.EnvPayload(),
+		MaxParallelism: cfg.MaxParallelism,
+		TargetTime:     cfg.TargetTime.Seconds(),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("filter tests: %w", err)

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/buildkite/test-engine-client/v2/internal/api"
 	"github.com/buildkite/test-engine-client/v2/internal/config"
@@ -401,6 +402,8 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing
 		SuiteSlug:         "my-suite",
 		Identifier:        "identifier",
 		Parallelism:       2,
+		MaxParallelism:    10,
+		TargetTime:        5 * time.Minute,
 		Branch:            "main",
 		TestRunner:        "rspec",
 		SelectorSplitting: true,
@@ -449,9 +452,18 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing
 		t.Errorf("filter_tests files diff (-got +want):\n%s", diff)
 	}
 
+	if gotFilterParams.MaxParallelism != 10 {
+		t.Errorf("filter_tests max_parallelism = %d, want 10", gotFilterParams.MaxParallelism)
+	}
+	if gotFilterParams.TargetTime != 300 {
+		t.Errorf("filter_tests target_time = %v, want 300", gotFilterParams.TargetTime)
+	}
+
 	want := api.TestPlanParams{
 		Identifier:     "identifier",
 		Parallelism:    2,
+		MaxParallelism: 10,
+		TargetTime:     300,
 		Branch:         "main",
 		LocationPrefix: "my/project",
 		Runner:         "rspec",


### PR DESCRIPTION
### Description

Right now slow-file filtering runs before the server calculates dynamic parallelism, so the plan job reports a parallelism of 1 and almost nothing gets flagged as slow. The server side of `filter_tests` is being taught to accept top-level `target_time` (numeric seconds) and `max_parallelism` params, and to use them to derive the run's real parallelism for slow file filtering. That server change ships alongside this one.

This PR teaches bktec to include `target_time` and `max_parallelism` in the `filter_tests` request body, using the same values it already sends to the `create` (plan) endpoint. Both are optional on the server, so nothing breaks for older clients.

### Context

- Linear ticket [TE-6423](https://linear.app/buildkite/issue/TE-6423)
- Parent [TE-6422](https://linear.app/buildkite/issue/TE-6422)

### Changes

- Added `target_time` (numeric seconds) and `max_parallelism` (integer) to the `filter_tests` request body, forwarding the same config values already sent to `create`.

### Testing

Covered by unit tests. Extended the `filter_tests` API test to assert the new params appear in the request body, and the request-param test to confirm the config values are forwarded end-to-end.