### PR TITLE
Fix request param test for pytest skipped-test expansion

### DIFF
--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -664,9 +664,9 @@ func TestShouldFilterAndSplitSelectorFiles(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "pytest selector-backed files do not expand when split by example is disabled",
+			name:       "pytest selector-backed files support skipped-test expansion",
 			testRunner: runner.Pytest{},
-			want:       false,
+			want:       true,
 		},
 	}
 


### PR DESCRIPTION
### Description

The `pytest selector-backed files do not expand when split by example is disabled` test case started failing on `main`. The test was added expecting pytest selector-backed files to not expand, but the PR that enabled the skip feature for pytest (#601) merged after that test landed. I didn't rebase the skip-enabling PR after the test merged, so the two ended up out of sync.

This PR updates the test case to match the current behaviour: pytest selector-backed files now support skipped-test expansion, so `want` is `true`.

### Testing

Ran the test suite locally to confirm the case passes.