### PR TITLE
Introduce focused test plan API request types

### DIFF
--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -10,9 +10,21 @@ import (
 )
 
 type TestPlanParamsTest struct {
-	Files     []plan.TestCase          `json:"files,omitempty"`
-	Examples  []plan.TestCase          `json:"examples,omitempty"`
+	Files     []TestPlanFile           `json:"files,omitempty"`
+	Examples  []TestPlanExample        `json:"examples,omitempty"`
 	Selectors []TestPlanParamsSelector `json:"selectors,omitempty"`
+}
+
+type TestPlanFile struct {
+	Path string `json:"path"`
+}
+
+type TestPlanExample struct {
+	Format     plan.TestCaseFormat `json:"format,omitempty"`
+	Identifier string              `json:"identifier,omitempty"`
+	Name       string              `json:"name,omitempty"`
+	Path       string              `json:"path"`
+	Scope      string              `json:"scope,omitempty"`
 }
 
 type TestPlanParamsSelector struct {

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -29,7 +29,7 @@ func TestCreateTestPlan(t *testing.T) {
 			"git_diff": "line1\nline2",
 		},
 		Tests: TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []TestPlanFile{
 				{Path: "sky_spec.rb"},
 			},
 		},
@@ -161,11 +161,12 @@ func TestCreateTestPlan_SplitByExample(t *testing.T) {
 			"source": "cli",
 		},
 		Tests: TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []TestPlanFile{
 				{Path: "sky_spec.rb"},
 			},
-			Examples: []plan.TestCase{
+			Examples: []TestPlanExample{
 				{
+					Format:     plan.TestCaseFormatExample,
 					Path:       "sea_spec.rb:4",
 					Name:       "is blue",
 					Scope:      "sea",
@@ -185,6 +186,7 @@ func TestCreateTestPlan_SplitByExample(t *testing.T) {
 			"tests": {
 				"files": [{"path": "sky_spec.rb"}],
 				"examples": [{
+					"format": "example",
 					"path": "sea_spec.rb:4",
 					"name": "is blue",
 					"scope": "sea",
@@ -376,7 +378,7 @@ func TestCreateTestPlan_MutedTests(t *testing.T) {
 		Identifier:  "abc123",
 		Parallelism: 3,
 		Tests: TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []TestPlanFile{
 				{Path: "sky_spec.rb"},
 			},
 		},

--- a/internal/api/filter_tests.go
+++ b/internal/api/filter_tests.go
@@ -6,11 +6,10 @@ import (
 	"net/http"
 
 	"github.com/buildkite/test-engine-client/v2/internal/config"
-	"github.com/buildkite/test-engine-client/v2/internal/plan"
 )
 
 type FilterTestsParams struct {
-	Files          []plan.TestCase   `json:"files"`
+	Files          []TestPlanFile    `json:"files"`
 	Env            config.EnvPayload `json:"env"`
 	MaxParallelism int               `json:"max_parallelism,omitempty"`
 	TargetTime     float64           `json:"target_time,omitempty"`

--- a/internal/api/filter_tests_test.go
+++ b/internal/api/filter_tests_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/buildkite/test-engine-client/v2/internal/config"
-	"github.com/buildkite/test-engine-client/v2/internal/plan"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -20,7 +19,7 @@ func TestFilterTests_SlowFiles(t *testing.T) {
 	cfg.SplitByExample = true
 
 	params := FilterTestsParams{
-		Files: []plan.TestCase{
+		Files: []TestPlanFile{
 			{Path: "./cat_spec.rb"},
 			{Path: "./dog_spec.rb"},
 			{Path: "./turtle_spec.rb"},
@@ -115,7 +114,7 @@ func TestFilterTests_InternalServerError(t *testing.T) {
 	})
 
 	_, err := c.FilterTests(context.Background(), "my-suite", FilterTestsParams{
-		Files: []plan.TestCase{},
+		Files: []TestPlanFile{},
 	})
 
 	if !errors.Is(err, ErrRetryTimeout) {

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -56,10 +56,10 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 }
 
 func fileTestParams(ctx context.Context, cfg *config.Config, client api.Client, testTargets []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := []plan.TestCase{}
+	testFiles := make([]api.TestPlanFile, 0, len(testTargets))
 
 	for _, file := range testTargets {
-		testFiles = append(testFiles, plan.TestCase{
+		testFiles = append(testFiles, api.TestPlanFile{
 			Path: prefixPath(file, runner.LocationPrefix()),
 		})
 	}
@@ -127,6 +127,20 @@ func selectorParamsFromValues(values []string) []api.TestPlanParamsSelector {
 	return selectors
 }
 
+func exampleParamsFromTestCases(testCases []plan.TestCase) []api.TestPlanExample {
+	examples := make([]api.TestPlanExample, 0, len(testCases))
+	for _, testCase := range testCases {
+		examples = append(examples, api.TestPlanExample{
+			Format:     testCase.Format,
+			Identifier: testCase.Identifier,
+			Name:       testCase.Name,
+			Path:       testCase.Path,
+			Scope:      testCase.Scope,
+		})
+	}
+	return examples
+}
+
 // buildSelectionParams returns the selection payload sent to the Test Engine
 // API, or nil when no strategy was requested.
 //
@@ -185,7 +199,7 @@ func getExamplesWithPrefix(filePaths []string, runner runner.TestRunner) ([]plan
 }
 
 // Splits all the test files into examples to support tag filtering.
-func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+func splitAllFiles(files []api.TestPlanFile, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
 	debug.Printf("Splitting all %d files", len(files))
 	filePaths := make([]string, 0, len(files))
 	for _, file := range files {
@@ -200,7 +214,7 @@ func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPla
 	debug.Printf("Got %d examples from all files", len(examples))
 
 	return api.TestPlanParamsTest{
-		Examples: examples,
+		Examples: exampleParamsFromTestCases(examples),
 	}, nil
 }
 
@@ -208,9 +222,9 @@ func splitAllFiles(files []plan.TestCase, runner runner.TestRunner) (api.TestPla
 // Selector-capable runners send file targets as raw selectors by default, which would ignore tag
 // filters, so all files are expanded into tag-filtered examples instead.
 func splitAllSelectorFiles(selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := make([]plan.TestCase, 0, len(selectors))
+	testFiles := make([]api.TestPlanFile, 0, len(selectors))
 	for _, selector := range selectors {
-		testFiles = append(testFiles, plan.TestCase{Path: prefixPath(selector, runner.LocationPrefix())})
+		testFiles = append(testFiles, api.TestPlanFile{Path: prefixPath(selector, runner.LocationPrefix())})
 	}
 
 	return splitAllFiles(testFiles, runner)
@@ -219,9 +233,9 @@ func splitAllSelectorFiles(selectors []string, runner runner.TestRunner) (api.Te
 // filterAndSplitSelectorFiles filters selector-backed file targets through the Test Engine API and splits
 // filtered files into examples. It returns examples for the filtered files and selectors for the remaining files.
 func filterAndSplitSelectorFiles(ctx context.Context, cfg *config.Config, client api.Client, selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := make([]plan.TestCase, 0, len(selectors))
+	testFiles := make([]api.TestPlanFile, 0, len(selectors))
 	for _, selector := range selectors {
-		testFiles = append(testFiles, plan.TestCase{Path: prefixPath(selector, runner.LocationPrefix())})
+		testFiles = append(testFiles, api.TestPlanFile{Path: prefixPath(selector, runner.LocationPrefix())})
 	}
 
 	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, testFiles, runner, "selector-backed files")
@@ -251,7 +265,7 @@ func filterAndSplitSelectorFiles(ctx context.Context, cfg *config.Config, client
 // filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
 // It returns the test plan parameters with the examples from the filtered files and the remaining files that are not filtered.
 // An error is returned if there is a failure in any of the process.
-func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []plan.TestCase, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []api.TestPlanFile, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
 	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, allTestFiles, runner, "files")
 	if err != nil {
 		return api.TestPlanParamsTest{}, err
@@ -265,7 +279,7 @@ func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Cli
 	}
 
 	// Get the remaining files that are not filtered.
-	remainingFiles := make([]plan.TestCase, 0, len(allTestFiles)-len(filteredFilesMap))
+	remainingFiles := make([]api.TestPlanFile, 0, len(allTestFiles)-len(filteredFilesMap))
 	for _, file := range allTestFiles {
 		if _, ok := filteredFilesMap[file.Path]; !ok {
 			remainingFiles = append(remainingFiles, file)
@@ -278,7 +292,7 @@ func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Cli
 	}, nil
 }
 
-func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Client, files []plan.TestCase, runner runner.TestRunner, label string) ([]plan.TestCase, map[string]bool, error) {
+func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Client, files []api.TestPlanFile, runner runner.TestRunner, label string) ([]api.TestPlanExample, map[string]bool, error) {
 	debug.Printf("Filtering %d %s", len(files), label)
 	filteredFiles, err := client.FilterTests(ctx, cfg.SuiteSlug, api.FilterTestsParams{
 		Files:          files,
@@ -314,5 +328,5 @@ func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Cl
 	}
 
 	debug.Printf("Got %d examples within the filtered %s", len(examples), label)
-	return examples, filteredFilesMap, nil
+	return exampleParamsFromTestCases(examples), filteredFilesMap, nil
 }

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -67,14 +67,14 @@ func TestCreateRequestParams(t *testing.T) {
 		Branch:      "",
 		Runner:      "rspec",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/cherry_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/dragonfruit_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/elderberry_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/grape_spec.rb"},
 			},
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
 					Name:       "is yellow",
@@ -149,7 +149,7 @@ func TestCreateRequestParams_NonRSpec(t *testing.T) {
 				Branch:      "",
 				Runner:      r.Name(),
 				Tests: api.TestPlanParamsTest{
-					Files: []plan.TestCase{
+					Files: []api.TestPlanFile{
 						{Path: "testdata/fruits/apple.spec.js"},
 						{Path: "testdata/fruits/banana.spec.js"},
 						{Path: "testdata/fruits/cherry.spec.js"},
@@ -343,7 +343,7 @@ func TestCreateRequestParams_RSpecSelectorSplittingExpandsFilteredFiles(t *testi
 		Branch:      "main",
 		Runner:      "rspec",
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
 					Name:       "is yellow",
@@ -487,7 +487,7 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing
 		t.Errorf("createRequestParam() error = %v", err)
 	}
 
-	wantFilterFiles := []plan.TestCase{
+	wantFilterFiles := []api.TestPlanFile{
 		{Path: "my/project/testdata/rspec/spec/fruits/apple_spec.rb"},
 		{Path: "my/project/testdata/rspec/spec/fruits/banana_spec.rb"},
 		{Path: "my/project/testdata/rspec/spec/fruits/cherry_spec.rb"},
@@ -512,7 +512,7 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithLocationPrefix(t *testing
 		LocationPrefix: "my/project",
 		Runner:         "rspec",
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
 					Name:       "is yellow",
@@ -593,7 +593,7 @@ func TestCreateRequestParams_RSpecSelectorSplittingWithDotLocationPrefix(t *test
 		LocationPrefix: "./",
 		Runner:         "rspec",
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
 					Name:       "is yellow",
@@ -639,7 +639,7 @@ func TestCreateRequestParams_GoTestSelectorSplittingOptInOff(t *testing.T) {
 		Branch:      "main",
 		Runner:      "gotest",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "github.com/buildkite/test-engine-client/internal/api"},
 				{Path: "github.com/buildkite/test-engine-client/internal/runner"},
 			},
@@ -783,7 +783,7 @@ func TestCreateRequestParams_SelectorSplittingExpandsSlowFilesForSplitByExampleR
 				Parallelism: 2,
 				Runner:      testRunner,
 				Tests: api.TestPlanParamsTest{
-					Examples: stubRunner.examples,
+					Examples: exampleParamsFromTestCases(stubRunner.examples),
 					Selectors: []api.TestPlanParamsSelector{
 						{Value: "tests/fast_test"},
 					},
@@ -839,7 +839,7 @@ func TestCreateRequestParams_SelectorOptInIgnoredForSplitByExampleRunner(t *test
 		Branch:      "main",
 		Runner:      "rspec",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/banana_spec.rb"},
 			},
@@ -897,7 +897,7 @@ func TestCreateRequestParams_WithSelectionAndMetadata_NonRSpec(t *testing.T) {
 			"source":   "cli",
 		},
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "testdata/fruits/apple.spec.js"},
 				{Path: "testdata/fruits/banana.spec.js"},
 			},
@@ -966,7 +966,7 @@ func TestCreateRequestParams_WithSelectionAndMetadata_SplitAllFilesBranch(t *tes
 			"git_diff": "line1\nline2",
 		},
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "test_sample.py::test_happy",
 					Path:       "test_sample.py::test_happy",
@@ -1126,7 +1126,7 @@ func TestCreateRequestParams_NoFilteredFiles(t *testing.T) {
 		Parallelism: 7,
 		Branch:      "",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/banana_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/cherry_spec.rb"},
@@ -1180,7 +1180,7 @@ func TestCreateRequestParams_WithTagFilters(t *testing.T) {
 		Branch:      "main",
 		Runner:      "pytest",
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Format:     "example",
 					Identifier: "runner/testdata/pytest/test_sample.py::test_happy",
@@ -1245,7 +1245,7 @@ func TestCreateRequestParams_SelectorSplittingWithTagFilters(t *testing.T) {
 		Branch:      "main",
 		Runner:      "pytest",
 		Tests: api.TestPlanParamsTest{
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Format:     "example",
 					Identifier: "runner/testdata/pytest/test_sample.py::test_happy",
@@ -1312,7 +1312,7 @@ func TestCreateRequestParams_WithTagFilters_NonPytest(t *testing.T) {
 		Branch:      "main",
 		Runner:      "rspec",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "testdata/rspec/spec/fruits/banana_spec.rb"},
 			},
@@ -1354,11 +1354,11 @@ func TestCreateRequestParams_WithLocationPrefix(t *testing.T) {
 
 	cases := []struct {
 		prefix    string
-		wantFiles []plan.TestCase
+		wantFiles []api.TestPlanFile
 	}{
 		{
 			prefix: "./",
-			wantFiles: []plan.TestCase{
+			wantFiles: []api.TestPlanFile{
 				{Path: "./testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "./testdata/rspec/spec/fruits/banana_spec.rb"},
 				{Path: "./testdata/rspec/spec/fruits/cherry_spec.rb"},
@@ -1366,7 +1366,7 @@ func TestCreateRequestParams_WithLocationPrefix(t *testing.T) {
 		},
 		{
 			prefix: "monorepo/project-abc",
-			wantFiles: []plan.TestCase{
+			wantFiles: []api.TestPlanFile{
 				{Path: "monorepo/project-abc/testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "monorepo/project-abc/testdata/rspec/spec/fruits/banana_spec.rb"},
 				{Path: "monorepo/project-abc/testdata/rspec/spec/fruits/cherry_spec.rb"},
@@ -1499,11 +1499,11 @@ func TestCreateRequestParams_WithLocationPrefix_SplitByExample(t *testing.T) {
 		Branch:      "",
 		Runner:      "rspec",
 		Tests: api.TestPlanParamsTest{
-			Files: []plan.TestCase{
+			Files: []api.TestPlanFile{
 				{Path: "my/project/testdata/rspec/spec/fruits/apple_spec.rb"},
 				{Path: "my/project/testdata/rspec/spec/fruits/cherry_spec.rb"},
 			},
-			Examples: []plan.TestCase{
+			Examples: []api.TestPlanExample{
 				{
 					Identifier: "./testdata/rspec/spec/fruits/banana_spec.rb[1:1]",
 					Name:       "is yellow",


### PR DESCRIPTION
### Description

Introduce focused request types for test plan files and examples, keeping the API request model separate from the broader response and execution-side `plan.TestCase` model.

This is the second reviewable increment of TE-6249. It preserves mixed payloads (files plus examples or selectors plus examples) and existing wire behaviour while preventing file requests from carrying response-only test case fields.

### Context

- [TE-6249](https://linear.app/buildkite/issue/TE-6249/tidy-up-split-by-file-vs-split-by-selector-code-paths)
- Follows [#607](https://github.com/buildkite/test-engine-client/pull/607)

### Changes

- Add focused `TestPlanFile` and `TestPlanExample` API request types.
- Use `TestPlanFile` for `filter_tests` requests.
- Convert runner-produced `plan.TestCase` examples explicitly at the command/API boundary.
- Update request and serialization tests for the focused types, including example `format`.

### Testing

- `go test ./internal/api`
- Focused request construction coverage: `go test ./internal/command -run 'TestCreateRequestParams_(NoFilteredFiles|WithLocationPrefix|RSpecSelectorSplittingExpandsFilteredFiles)|TestCreateRequestParams$'`
- `go test ./internal/api ./internal/command` was also attempted. The API package passed
