### PR TITLE
Unify file and selector target processing

### DIFF
--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -12,6 +12,18 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/runner"
 )
 
+type requestMode uint8
+
+const (
+	requestByFile requestMode = iota
+	requestBySelector
+)
+
+type requestTarget struct {
+	value string
+	file  api.TestPlanFile
+}
+
 // createRequestParam generates the parameters needed for a test plan request.
 //
 // For the Rspec, Cucumber, Pytest, and Playwright runners, it fetches test files through the Test Engine API
@@ -25,14 +37,12 @@ import (
 // Currently only the Pytest runner supports tag filtering.
 func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []string, client api.Client, runner runner.TestRunner) (api.TestPlanParams, error) {
 	selectorSplitting := shouldUseSelectorSplitting(cfg, runner)
-
-	var testParams api.TestPlanParamsTest
-	var err error
+	mode := requestByFile
 	if selectorSplitting {
-		testParams, err = selectorTestParams(ctx, cfg, client, testTargets, runner)
-	} else {
-		testParams, err = fileTestParams(ctx, cfg, client, testTargets, runner)
+		mode = requestBySelector
 	}
+
+	testParams, err := requestTestParams(ctx, cfg, client, newRequestTargets(testTargets, runner.LocationPrefix()), runner, mode)
 	if err != nil {
 		return api.TestPlanParams{}, err
 	}
@@ -55,62 +65,46 @@ func createRequestParam(ctx context.Context, cfg *config.Config, testTargets []s
 	return params, nil
 }
 
-func fileTestParams(ctx context.Context, cfg *config.Config, client api.Client, testTargets []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := make([]api.TestPlanFile, 0, len(testTargets))
-
-	for _, file := range testTargets {
-		testFiles = append(testFiles, api.TestPlanFile{
-			Path: prefixPath(file, runner.LocationPrefix()),
+func newRequestTargets(values []string, prefix string) []requestTarget {
+	targets := make([]requestTarget, 0, len(values))
+	for _, value := range values {
+		targets = append(targets, requestTarget{
+			value: value,
+			file:  api.TestPlanFile{Path: prefixPath(value, prefix)},
 		})
 	}
+	return targets
+}
 
-	// Short circuit here if the runner doesn't support split by example
-	if !runner.SupportedFeatures().SplitByExample {
-		return api.TestPlanParamsTest{Files: testFiles}, nil
+func requestTestParams(ctx context.Context, cfg *config.Config, client api.Client, targets []requestTarget, runner runner.TestRunner, mode requestMode) (api.TestPlanParamsTest, error) {
+	features := runner.SupportedFeatures()
+	if !features.SplitByExample {
+		return encodeRequestTargets(targets, mode), nil
 	}
 
-	if cfg.SplitByExample {
+	if mode == requestByFile && cfg.SplitByExample {
 		debug.Println("Splitting by example")
 	}
 
 	// If tag filtering is enabled, we must split all files to allow to enable filtering.
 	// Tag filtering is currently only supported for pytest.
 	if cfg.TagFilters != "" && runner.Name() == "pytest" {
-		return splitAllFiles(testFiles, runner)
+		return expandAllTargets(targets, runner)
 	}
 
-	// The SplitByExample flag indicates whether to split slow files into examples.
-	// Regardless of the flag's state, the API will still return other test files that need to
-	// be split by example, such as those containing skipped tests.
-	// Therefore, we must fetch and split files even when SplitByExample is disabled.
-	return filterAndSplitFiles(ctx, cfg, client, testFiles, runner)
+	if mode == requestBySelector && !shouldFilterAndSplitSelectorFiles(cfg, runner) {
+		return encodeRequestTargets(targets, mode), nil
+	}
+
+	label := "files"
+	if mode == requestBySelector {
+		label = "selector-backed files"
+	}
+	return filterAndExpandTargets(ctx, cfg, client, targets, runner, mode, label)
 }
 
 func shouldUseSelectorSplitting(cfg *config.Config, runner runner.TestRunner) bool {
 	return cfg.SelectorSplitting && runner.SupportedFeatures().SplitBySelector
-}
-
-// selectorTestParams builds the Tests payload for selector-capable runners.
-//
-// When tag filters are set, every file is expanded into tag-filtered examples so that
-// nothing goes out as a raw selector, which would run all of the file's tests and
-// ignore the tag filter. Tag filtering is currently only supported for pytest.
-//
-// Otherwise, slow or skipped files are expanded into examples and the rest are sent as
-// raw selectors, or everything is sent as raw selectors when the runner doesn't need
-// filtered files.
-func selectorTestParams(ctx context.Context, cfg *config.Config, client api.Client, testTargets []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	if cfg.TagFilters != "" && runner.Name() == "pytest" {
-		return splitAllSelectorFiles(testTargets, runner)
-	}
-
-	if shouldFilterAndSplitSelectorFiles(cfg, runner) {
-		return filterAndSplitSelectorFiles(ctx, cfg, client, testTargets, runner)
-	}
-
-	return api.TestPlanParamsTest{
-		Selectors: selectorParamsFromValues(testTargets),
-	}, nil
 }
 
 func shouldFilterAndSplitSelectorFiles(cfg *config.Config, runner runner.TestRunner) bool {
@@ -139,6 +133,22 @@ func exampleParamsFromTestCases(testCases []plan.TestCase) []api.TestPlanExample
 		})
 	}
 	return examples
+}
+
+func encodeRequestTargets(targets []requestTarget, mode requestMode) api.TestPlanParamsTest {
+	if mode == requestBySelector {
+		values := make([]string, 0, len(targets))
+		for _, target := range targets {
+			values = append(values, target.value)
+		}
+		return api.TestPlanParamsTest{Selectors: selectorParamsFromValues(values)}
+	}
+
+	files := make([]api.TestPlanFile, 0, len(targets))
+	for _, target := range targets {
+		files = append(files, target.file)
+	}
+	return api.TestPlanParamsTest{Files: files}
 }
 
 // buildSelectionParams returns the selection payload sent to the Test Engine
@@ -198,12 +208,12 @@ func getExamplesWithPrefix(filePaths []string, runner runner.TestRunner) ([]plan
 	return examples, nil
 }
 
-// Splits all the test files into examples to support tag filtering.
-func splitAllFiles(files []api.TestPlanFile, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	debug.Printf("Splitting all %d files", len(files))
-	filePaths := make([]string, 0, len(files))
-	for _, file := range files {
-		filePaths = append(filePaths, file.Path)
+// expandAllTargets splits every target into examples to support tag filtering.
+func expandAllTargets(targets []requestTarget, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
+	debug.Printf("Splitting all %d files", len(targets))
+	filePaths := make([]string, 0, len(targets))
+	for _, target := range targets {
+		filePaths = append(filePaths, target.file.Path)
 	}
 
 	examples, err := getExamplesWithPrefix(filePaths, runner)
@@ -218,78 +228,33 @@ func splitAllFiles(files []api.TestPlanFile, runner runner.TestRunner) (api.Test
 	}, nil
 }
 
-// splitAllSelectorFiles expands every selector-backed file into examples to support tag filtering.
-// Selector-capable runners send file targets as raw selectors by default, which would ignore tag
-// filters, so all files are expanded into tag-filtered examples instead.
-func splitAllSelectorFiles(selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := make([]api.TestPlanFile, 0, len(selectors))
-	for _, selector := range selectors {
-		testFiles = append(testFiles, api.TestPlanFile{Path: prefixPath(selector, runner.LocationPrefix())})
+// filterAndExpandTargets filters targets through the Test Engine API, expands filtered targets
+// into examples, and encodes the remaining targets according to the request mode.
+func filterAndExpandTargets(ctx context.Context, cfg *config.Config, client api.Client, targets []requestTarget, runner runner.TestRunner, mode requestMode, label string) (api.TestPlanParamsTest, error) {
+	files := make([]api.TestPlanFile, 0, len(targets))
+	for _, target := range targets {
+		files = append(files, target.file)
 	}
 
-	return splitAllFiles(testFiles, runner)
-}
-
-// filterAndSplitSelectorFiles filters selector-backed file targets through the Test Engine API and splits
-// filtered files into examples. It returns examples for the filtered files and selectors for the remaining files.
-func filterAndSplitSelectorFiles(ctx context.Context, cfg *config.Config, client api.Client, selectors []string, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	testFiles := make([]api.TestPlanFile, 0, len(selectors))
-	for _, selector := range selectors {
-		testFiles = append(testFiles, api.TestPlanFile{Path: prefixPath(selector, runner.LocationPrefix())})
-	}
-
-	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, testFiles, runner, "selector-backed files")
+	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, files, runner, label)
 	if err != nil {
 		return api.TestPlanParamsTest{}, err
 	}
 
 	if len(filteredFilesMap) == 0 {
-		return api.TestPlanParamsTest{
-			Selectors: selectorParamsFromValues(selectors),
-		}, nil
+		return encodeRequestTargets(targets, mode), nil
 	}
 
-	remainingSelectors := make([]string, 0, len(testFiles)-len(filteredFilesMap))
-	for i, file := range testFiles {
-		if _, ok := filteredFilesMap[file.Path]; !ok {
-			remainingSelectors = append(remainingSelectors, selectors[i])
+	remainingTargets := make([]requestTarget, 0, len(targets)-len(filteredFilesMap))
+	for _, target := range targets {
+		if _, ok := filteredFilesMap[target.file.Path]; !ok {
+			remainingTargets = append(remainingTargets, target)
 		}
 	}
 
-	return api.TestPlanParamsTest{
-		Examples:  examples,
-		Selectors: selectorParamsFromValues(remainingSelectors),
-	}, nil
-}
-
-// filterAndSplitFiles filters the test files through the Test Engine API and splits the filtered files into examples.
-// It returns the test plan parameters with the examples from the filtered files and the remaining files that are not filtered.
-// An error is returned if there is a failure in any of the process.
-func filterAndSplitFiles(ctx context.Context, cfg *config.Config, client api.Client, allTestFiles []api.TestPlanFile, runner runner.TestRunner) (api.TestPlanParamsTest, error) {
-	examples, filteredFilesMap, err := filterAndExpandFiles(ctx, cfg, client, allTestFiles, runner, "files")
-	if err != nil {
-		return api.TestPlanParamsTest{}, err
-	}
-
-	// If no files are filtered, return all the files.
-	if len(filteredFilesMap) == 0 {
-		return api.TestPlanParamsTest{
-			Files: allTestFiles,
-		}, nil
-	}
-
-	// Get the remaining files that are not filtered.
-	remainingFiles := make([]api.TestPlanFile, 0, len(allTestFiles)-len(filteredFilesMap))
-	for _, file := range allTestFiles {
-		if _, ok := filteredFilesMap[file.Path]; !ok {
-			remainingFiles = append(remainingFiles, file)
-		}
-	}
-
-	return api.TestPlanParamsTest{
-		Examples: examples,
-		Files:    remainingFiles,
-	}, nil
+	params := encodeRequestTargets(remainingTargets, mode)
+	params.Examples = examples
+	return params, nil
 }
 
 func filterAndExpandFiles(ctx context.Context, cfg *config.Config, client api.Client, files []api.TestPlanFile, runner runner.TestRunner, label string) ([]api.TestPlanExample, map[string]bool, error) {

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -724,6 +724,141 @@ func TestShouldFilterAndSplitSelectorFiles(t *testing.T) {
 	}
 }
 
+func TestEncodeRequestTargets(t *testing.T) {
+	targets := newRequestTargets([]string{"first_test", "second_test"}, "project")
+	tests := []struct {
+		name string
+		mode requestMode
+		want api.TestPlanParamsTest
+	}{
+		{
+			name: "files use prefixed paths",
+			mode: requestByFile,
+			want: api.TestPlanParamsTest{
+				Files: []api.TestPlanFile{{Path: "project/first_test"}, {Path: "project/second_test"}},
+			},
+		},
+		{
+			name: "selectors use original values",
+			mode: requestBySelector,
+			want: api.TestPlanParamsTest{
+				Selectors: []api.TestPlanParamsSelector{{Value: "first_test"}, {Value: "second_test"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := cmp.Diff(encodeRequestTargets(targets, test.mode), test.want); diff != "" {
+				t.Errorf("encodeRequestTargets() diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFilterAndExpandTargets(t *testing.T) {
+	var gotFilterParams api.FilterTestsParams
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotFilterParams); err != nil {
+			t.Fatalf("decoding filter_tests request: %v", err)
+		}
+		fmt.Fprint(w, `{"tests":[{"path":"project/middle_test","reason":"slow file"}]}`)
+	}))
+	defer svr.Close()
+
+	client := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL})
+	targets := newRequestTargets([]string{"first_test", "middle_test", "third_test"}, "project")
+	var exampleFiles []string
+	testRunner := metadataTestRunner{
+		name:           "playwright",
+		locationPrefix: "project",
+		exampleFiles:   &exampleFiles,
+		examples: []plan.TestCase{
+			{
+				Format:     plan.TestCaseFormatExample,
+				Identifier: "middle_test::example",
+				Name:       "example",
+				Path:       "middle_test::example",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		mode requestMode
+		want api.TestPlanParamsTest
+	}{
+		{
+			name: "file mode preserves prefixed files",
+			mode: requestByFile,
+			want: api.TestPlanParamsTest{
+				Files: []api.TestPlanFile{{Path: "project/first_test"}, {Path: "project/third_test"}},
+			},
+		},
+		{
+			name: "selector mode preserves raw selector values",
+			mode: requestBySelector,
+			want: api.TestPlanParamsTest{
+				Selectors: []api.TestPlanParamsSelector{{Value: "first_test"}, {Value: "third_test"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testRunner.examples[0].Path = "middle_test::example"
+			got, err := filterAndExpandTargets(context.Background(), &config.Config{}, *client, targets, testRunner, test.mode, "targets")
+			if err != nil {
+				t.Fatalf("filterAndExpandTargets() error = %v", err)
+			}
+
+			test.want.Examples = []api.TestPlanExample{
+				{
+					Format:     plan.TestCaseFormatExample,
+					Identifier: "middle_test::example",
+					Name:       "example",
+					Path:       "project/middle_test::example",
+				},
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("filterAndExpandTargets() diff (-got +want):\n%s", diff)
+			}
+
+			wantFilterFiles := []api.TestPlanFile{{Path: "project/first_test"}, {Path: "project/middle_test"}, {Path: "project/third_test"}}
+			if diff := cmp.Diff(gotFilterParams.Files, wantFilterFiles); diff != "" {
+				t.Errorf("filter_tests files diff (-got +want):\n%s", diff)
+			}
+			if diff := cmp.Diff(exampleFiles, []string{"middle_test"}); diff != "" {
+				t.Errorf("GetExamples() files diff (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateRequestParams_PlaywrightFileModeAlwaysFilters(t *testing.T) {
+	filterRequestCount := 0
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filterRequestCount++
+		fmt.Fprint(w, `{"tests":[]}`)
+	}))
+	defer svr.Close()
+
+	cfg := config.Config{
+		SuiteSlug:      "my-suite",
+		TestRunner:     "playwright",
+		SplitByExample: false,
+	}
+	client := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL})
+
+	_, err := createRequestParam(context.Background(), &cfg, []string{"first.spec.js"}, *client, runner.NewPlaywright(runner.RunnerConfig{}))
+	if err != nil {
+		t.Fatalf("createRequestParam() error = %v", err)
+	}
+	if filterRequestCount != 1 {
+		t.Errorf("filter request count = %d, want 1", filterRequestCount)
+	}
+}
+
 func TestCreateRequestParams_SelectorSplittingExpandsSlowFilesForSplitByExampleRunners(t *testing.T) {
 	for _, testRunner := range []string{"playwright", "pytest"} {
 		t.Run(testRunner, func(t *testing.T) {
@@ -986,6 +1121,7 @@ func TestCreateRequestParams_WithSelectionAndMetadata_SplitAllFilesBranch(t *tes
 type metadataTestRunner struct {
 	name              string
 	examples          []plan.TestCase
+	exampleFiles      *[]string
 	locationPrefix    string
 	supportedFeatures runner.SupportedFeatures
 }
@@ -1005,6 +1141,9 @@ func (r metadataTestRunner) Name() string {
 }
 
 func (r metadataTestRunner) GetExamples(files []string) ([]plan.TestCase, error) {
+	if r.exampleFiles != nil {
+		*r.exampleFiles = append((*r.exampleFiles)[:0], files...)
+	}
 	return r.examples, nil
 }
 


### PR DESCRIPTION
### Description

Replace the parallel file and selector request transformations with one target-processing pipeline while preserving existing request behaviour.

This is the third reviewable increment of TE-6249 and is stacked on #608. Each target retains both its original runnable value and its prefixed file representation, allowing filtering and example expansion to be shared before the remaining targets are encoded for the active mode.

### Context

- [TE-6249](https://linear.app/buildkite/issue/TE-6249/tidy-up-split-by-file-vs-split-by-selector-code-paths)
- Stacked on [#608](https://github.com/buildkite/test-engine-client/pull/608)
- Follows [#607](https://github.com/buildkite/test-engine-client/pull/607)

### Changes

- Add an internal request target representation containing the raw target and prefixed file path.
- Unify file and selector filtering, example expansion, ordering, and final request encoding.
- Remove the duplicated file/selector splitting helper pairs.
- Preserve raw selector values, prefixed file paths, pytest tag filtering, skipped-test expansion, and file-mode filtering behaviour.
- Add focused coverage for mode encoding, filtered-target ordering, prefix round trips, and Playwright file-mode filtering.

### Testing

- Targeted `internal/command` request construction tests
- `go test ./internal/api ./internal/plan`
- `go vet ./internal/command ./internal/api ./internal/plan`