### PR TITLE
Focus test runner discovery interfaces

### DIFF
--- a/internal/command/files.go
+++ b/internal/command/files.go
@@ -5,17 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
-
-	"github.com/buildkite/test-engine-client/v2/internal/runner"
 )
-
-func getTestFiles(fileList string, testRunner runner.TestRunner) ([]string, error) {
-	if fileList != "" {
-		return getRowsFromFile(fileList)
-	} else {
-		return testRunner.GetFiles()
-	}
-}
 
 // getRowsFromFile reads a text file and returns each non-empty, trimmed line as
 // a row. It's used for any newline-delimited list, such as test files or selectors.

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -175,8 +175,8 @@ func buildSelectionParams(strategy string, params map[string]string) *api.Select
 	}
 }
 
-func getExamplesWithPrefix(filePaths []string, runner runner.TestRunner) ([]plan.TestCase, error) {
-	prefix := runner.LocationPrefix()
+func getExamplesWithPrefix(filePaths []string, testRunner runner.TestRunner) ([]plan.TestCase, error) {
+	prefix := testRunner.LocationPrefix()
 	trimmedPaths := make([]string, len(filePaths))
 
 	// runner.GetExamples will call the test runner with the file paths.
@@ -190,7 +190,12 @@ func getExamplesWithPrefix(filePaths []string, runner runner.TestRunner) ([]plan
 		trimmedPaths[i] = path
 	}
 
-	examples, err := runner.GetExamples(trimmedPaths)
+	discoverer, ok := testRunner.(runner.ExampleDiscoverer)
+	if !ok {
+		return nil, fmt.Errorf("runner %q advertises split by example but does not implement example discovery", testRunner.Name())
+	}
+
+	examples, err := discoverer.GetExamples(trimmedPaths)
 	if err != nil {
 		return nil, fmt.Errorf("get examples: %w", err)
 	}

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -1147,14 +1147,6 @@ func (r metadataTestRunner) GetExamples(files []string) ([]plan.TestCase, error)
 	return r.examples, nil
 }
 
-func (r metadataTestRunner) GetFiles() ([]string, error) {
-	return nil, nil
-}
-
-func (r metadataTestRunner) GetSelectors() ([]string, error) {
-	return nil, nil
-}
-
 func (r metadataTestRunner) LocationPrefix() string {
 	return r.locationPrefix
 }
@@ -1182,6 +1174,22 @@ func (r metadataTestRunner) CommandNameAndArgs(testCases []plan.TestCase, retry 
 	}
 
 	return "metadata-test-runner", paths, nil
+}
+
+type mismatchedExampleRunner struct {
+	runner.Jest
+}
+
+func (m mismatchedExampleRunner) SupportedFeatures() runner.SupportedFeatures {
+	return runner.SupportedFeatures{SplitByExample: true}
+}
+
+func TestGetExamplesWithPrefix_RequiresExampleDiscoverer(t *testing.T) {
+	_, err := getExamplesWithPrefix([]string{"example.spec.js"}, mismatchedExampleRunner{})
+	want := `runner "Jest" advertises split by example but does not implement example discovery`
+	if err == nil || err.Error() != want {
+		t.Errorf("getExamplesWithPrefix() error = %v, want %q", err, want)
+	}
 }
 
 func TestCreateRequestParams_FilterTestsError(t *testing.T) {

--- a/internal/command/test_target.go
+++ b/internal/command/test_target.go
@@ -5,14 +5,16 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/runner"
 )
 
-func getTestTargets(cfg *config.Config, runner runner.TestRunner, testFileList string) ([]string, error) {
-	if shouldUseSelectorSplitting(cfg, runner) {
+func getTestTargets(cfg *config.Config, testRunner runner.TestRunnerWithTargetDiscovery, testFileList string) ([]string, error) {
+	if shouldUseSelectorSplitting(cfg, testRunner) {
 		if cfg.SelectorListPath != "" {
 			return getRowsFromFile(cfg.SelectorListPath)
-		} else {
-			return runner.GetSelectors()
 		}
+		return testRunner.DiscoverTestTargets()
 	}
 
-	return getTestFiles(testFileList, runner)
+	if testFileList != "" {
+		return getRowsFromFile(testFileList)
+	}
+	return testRunner.DiscoverTestTargets()
 }

--- a/internal/command/test_target_test.go
+++ b/internal/command/test_target_test.go
@@ -1,0 +1,107 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/test-engine-client/v2/internal/config"
+	"github.com/buildkite/test-engine-client/v2/internal/runner"
+	"github.com/google/go-cmp/cmp"
+)
+
+type targetDiscoveryTestRunner struct {
+	runner.Jest
+	targets         []string
+	discoveryCalls  int
+	selectorSupport bool
+}
+
+func (r *targetDiscoveryTestRunner) DiscoverTestTargets() ([]string, error) {
+	r.discoveryCalls++
+	return r.targets, nil
+}
+
+func (r *targetDiscoveryTestRunner) SupportedFeatures() runner.SupportedFeatures {
+	return runner.SupportedFeatures{SplitBySelector: r.selectorSupport}
+}
+
+func TestGetTestTargets(t *testing.T) {
+	tempDir := t.TempDir()
+	selectorList := filepath.Join(tempDir, "selectors.txt")
+	testFileList := filepath.Join(tempDir, "files.txt")
+	if err := os.WriteFile(selectorList, []byte("selector-a\nselector-b\n"), 0o600); err != nil {
+		t.Fatalf("write selector list: %v", err)
+	}
+	if err := os.WriteFile(testFileList, []byte("file-a\nfile-b\n"), 0o600); err != nil {
+		t.Fatalf("write test file list: %v", err)
+	}
+
+	tests := []struct {
+		name              string
+		selectorSplitting bool
+		selectorSupport   bool
+		selectorListPath  string
+		testFileList      string
+		want              []string
+		wantDiscoveries   int
+	}{
+		{
+			name:              "selector mode uses selector list",
+			selectorSplitting: true,
+			selectorSupport:   true,
+			selectorListPath:  selectorList,
+			testFileList:      testFileList,
+			want:              []string{"selector-a", "selector-b"},
+		},
+		{
+			name:              "selector mode discovers targets when selector list is absent",
+			selectorSplitting: true,
+			selectorSupport:   true,
+			testFileList:      testFileList,
+			want:              []string{"discovered-a", "discovered-b"},
+			wantDiscoveries:   1,
+		},
+		{
+			name:              "unsupported selector mode retains file list precedence",
+			selectorSplitting: true,
+			selectorListPath:  selectorList,
+			testFileList:      testFileList,
+			want:              []string{"file-a", "file-b"},
+		},
+		{
+			name:         "file mode uses test file list",
+			testFileList: testFileList,
+			want:         []string{"file-a", "file-b"},
+		},
+		{
+			name:            "file mode discovers targets when test file list is absent",
+			want:            []string{"discovered-a", "discovered-b"},
+			wantDiscoveries: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testRunner := &targetDiscoveryTestRunner{
+				targets:         []string{"discovered-a", "discovered-b"},
+				selectorSupport: test.selectorSupport,
+			}
+			cfg := config.Config{
+				SelectorSplitting: test.selectorSplitting,
+				SelectorListPath:  test.selectorListPath,
+			}
+
+			got, err := getTestTargets(&cfg, testRunner, test.testFileList)
+			if err != nil {
+				t.Fatalf("getTestTargets() error = %v", err)
+			}
+			if diff := cmp.Diff(got, test.want); diff != "" {
+				t.Errorf("getTestTargets() diff (-got +want):\n%s", diff)
+			}
+			if testRunner.discoveryCalls != test.wantDiscoveries {
+				t.Errorf("DiscoverTestTargets() calls = %d, want %d", testRunner.discoveryCalls, test.wantDiscoveries)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ type Config struct {
 	UploadToken string `json:"-"`
 	// SelectorSplitting enables selector-based splitting for supported runners.
 	SelectorSplitting bool `json:"-"`
-	// File path containing the list of selectors to run. If not set, `bktec` will rely on each runner implementation of `GetSelectors`
+	// File path containing the list of selectors to run. If not set, `bktec` will rely on each runner implementation of `DiscoverTestTargets`.
 	SelectorListPath string `json:"-"`
 	// SplitByExample is the flag to enable split the test by example.
 	SplitByExample bool   `json:"-"`

--- a/internal/runner/cucumber.go
+++ b/internal/runner/cucumber.go
@@ -65,8 +65,8 @@ func (c Cucumber) ResultFormat() string {
 	return "cucumber-json"
 }
 
-// GetFiles returns the list of feature files based on include / exclude pattern.
-func (c Cucumber) GetFiles() ([]string, error) {
+// DiscoverTestTargets returns feature files based on include / exclude pattern.
+func (c Cucumber) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", c.TestFilePattern, "exclude pattern:", c.TestFileExcludePattern)
 	files, err := discoverTestFiles(c.TestFilePattern, c.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -80,10 +80,6 @@ func (c Cucumber) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (c Cucumber) GetSelectors() ([]string, error) {
-	return c.GetFiles()
 }
 
 // Run executes the Cucumber command and records results.

--- a/internal/runner/cucumber_test.go
+++ b/internal/runner/cucumber_test.go
@@ -127,14 +127,14 @@ func TestCucumberRun_TestFailed(t *testing.T) {
 	}
 }
 
-func TestCucumberGetFiles(t *testing.T) {
+func TestCucumberDiscoverTestTargets(t *testing.T) {
 	cucumber := NewCucumber(RunnerConfig{
 		TestFilePattern: "testdata/cucumber/features/**/*.feature",
 	})
 
-	got, err := cucumber.GetFiles()
+	got, err := cucumber.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Cucumber.GetFiles() error = %v", err)
+		t.Errorf("Cucumber.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -148,30 +148,7 @@ func TestCucumberGetFiles(t *testing.T) {
 	sort.Strings(want)
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Cucumber.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestCucumberGetSelectors(t *testing.T) {
-	cucumber := NewCucumber(RunnerConfig{
-		TestFilePattern: "testdata/cucumber/features/**/*.feature",
-	})
-
-	gotFiles, err := cucumber.GetFiles()
-	if err != nil {
-		t.Errorf("Cucumber.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := cucumber.GetSelectors()
-	if err != nil {
-		t.Errorf("Cucumber.GetSelectors() error = %v", err)
-	}
-
-	sort.Strings(gotFiles)
-	sort.Strings(gotSelectors)
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Cucumber.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Cucumber.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/custom.go
+++ b/internal/runner/custom.go
@@ -60,8 +60,12 @@ func (r Custom) ResultFormat() string {
 	return "json"
 }
 
-// GetFiles returns an array of file names using the discovery pattern.
-func (r Custom) GetFiles() ([]string, error) {
+// DiscoverTestTargets returns file names using the discovery pattern. Custom
+// selector splitting without a selector list falls back to file discovery.
+func (r Custom) DiscoverTestTargets() ([]string, error) {
+	if r.SelectorSplitting {
+		fmt.Fprintln(os.Stderr, "Buildkite Test Engine Client: --selector-file (or BUILDKITE_TEST_ENGINE_SELECTOR_FILE) is not set for the custom runner. Falling back to test files collection.")
+	}
 	debug.Println("Discovering test files with include pattern:", r.TestFilePattern, "exclude pattern:", r.TestFileExcludePattern)
 	files, err := discoverTestFiles(r.TestFilePattern, r.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -75,18 +79,6 @@ func (r Custom) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-// GetSelectors falls back to file-pattern discovery, since the custom runner
-// has no way to discover selectors on its own without a selector file
-// (in which case bktec reads selectors from the file directly, without calling this).
-func (r Custom) GetSelectors() ([]string, error) {
-	fmt.Fprintln(os.Stderr, "Buildkite Test Engine Client: --selector-file (or BUILDKITE_TEST_ENGINE_SELECTOR_FILE) is not set for the custom runner. Falling back to test files collection.")
-	return r.GetFiles()
-}
-
-func (r Custom) GetExamples(files []string) ([]plan.TestCase, error) {
-	return nil, fmt.Errorf("not supported for custom runner")
 }
 
 func (r Custom) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {

--- a/internal/runner/custom_test.go
+++ b/internal/runner/custom_test.go
@@ -54,23 +54,7 @@ func TestCustom_NewCustom_SelectorListWithoutTestFilePattern(t *testing.T) {
 	}
 }
 
-func TestCustom_GetExamples(t *testing.T) {
-	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "bin/test",
-		TestFilePattern: "tests/**/test_*.sh",
-	})
-
-	if err != nil {
-		t.Fatalf("Failed to create Custom runner: %v", err)
-	}
-
-	_, err = custom.GetExamples([]string{"tests/test_a.sh", "tests/test_b.sh"})
-	if err == nil || err.Error() != "not supported for custom runner" {
-		t.Errorf("GetExamples() error = %v, want %q", err, "not supported for custom runner")
-	}
-}
-
-func TestCustom_GetFiles(t *testing.T) {
+func TestCustom_DiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
 		TestCommand:     "bats {{testExamples}}",
@@ -81,9 +65,9 @@ func TestCustom_GetFiles(t *testing.T) {
 		t.Fatalf("Failed to create Custom runner: %v", err)
 	}
 
-	got, err := custom.GetFiles()
+	got, err := custom.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Custom.GetFiles() error = %v", err)
+		t.Errorf("Custom.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -93,24 +77,25 @@ func TestCustom_GetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Custom.GetFiles() diff (-got +want):\n%s", diff)
+		t.Errorf("Custom.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 
-func TestCustom_GetSelectors_FallsBackToFilePatternMatching(t *testing.T) {
+func TestCustom_DiscoverTestTargets_SelectorSplittingFallsBackToFilePatternMatching(t *testing.T) {
 	changeCwd(t, "./testdata/custom")
 	custom, err := NewCustom(RunnerConfig{
-		TestCommand:     "bats {{testExamples}}",
-		TestFilePattern: "tests/*.bats",
+		TestCommand:       "bats {{testExamples}}",
+		TestFilePattern:   "tests/*.bats",
+		SelectorSplitting: true,
 	})
 
 	if err != nil {
 		t.Fatalf("Failed to create Custom runner: %v", err)
 	}
 
-	got, err := custom.GetSelectors()
+	got, err := custom.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Custom.GetSelectors() error = %v", err)
+		t.Errorf("Custom.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -120,7 +105,7 @@ func TestCustom_GetSelectors_FallsBackToFilePatternMatching(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Custom.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Custom.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/cypress.go
+++ b/internal/runner/cypress.go
@@ -60,7 +60,7 @@ func (c Cypress) Run(result *RunResult, testCases []plan.TestCase, retry bool) e
 	return err
 }
 
-func (c Cypress) GetFiles() ([]string, error) {
+func (c Cypress) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", c.TestFilePattern, "exclude pattern:", c.TestFileExcludePattern)
 	files, err := discoverTestFiles(c.TestFilePattern, c.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -74,14 +74,6 @@ func (c Cypress) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (c Cypress) GetSelectors() ([]string, error) {
-	return c.GetFiles()
-}
-
-func (c Cypress) GetExamples(files []string) ([]plan.TestCase, error) {
-	return nil, fmt.Errorf("not supported in Cypress")
 }
 
 func (c Cypress) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {

--- a/internal/runner/cypress_test.go
+++ b/internal/runner/cypress_test.go
@@ -97,12 +97,12 @@ func TestCypressRun_SignaledError(t *testing.T) {
 	}
 }
 
-func TestCypressGetFiles(t *testing.T) {
+func TestCypressDiscoverTestTargets(t *testing.T) {
 	cypress := NewCypress(RunnerConfig{})
 
-	got, err := cypress.GetFiles()
+	got, err := cypress.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Cypress.GetFiles() error = %v", err)
+		t.Errorf("Cypress.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -112,25 +112,7 @@ func TestCypressGetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Cypress.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestCypressGetSelectors(t *testing.T) {
-	cypress := NewCypress(RunnerConfig{})
-
-	gotFiles, err := cypress.GetFiles()
-	if err != nil {
-		t.Errorf("Cypress.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := cypress.GetSelectors()
-	if err != nil {
-		t.Errorf("Cypress.GetSelectors() error = %v", err)
-	}
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Cypress.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Cypress.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -6,7 +6,7 @@ import (
 	"github.com/buildkite/test-engine-client/v2/internal/config"
 )
 
-func DetectRunner(cfg *config.Config) (TestRunner, error) {
+func DetectRunner(cfg *config.Config) (TestRunnerWithTargetDiscovery, error) {
 	runnerConfig := RunnerConfig{
 		TestRunner: cfg.TestRunner,
 

--- a/internal/runner/gotest.go
+++ b/internal/runner/gotest.go
@@ -78,10 +78,6 @@ func commandProducesGoJSONL(command string) bool {
 	return isGoTestJSONCommand(args) || goJSONLFileArg(args) != ""
 }
 
-func (g GoTest) GetExamples(files []string) ([]plan.TestCase, error) {
-	return nil, fmt.Errorf("not supported in go test")
-}
-
 // Run executes the configured command for the specified packages.
 func (g GoTest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
 	cmd, err := buildCommand(g, testCases, retry)
@@ -308,8 +304,8 @@ func isBuildFailure(test JUnitXMLTestCase) bool {
 		strings.Contains(test.Failure.Content, "[build failed]")
 }
 
-// GetSelectors discovers the Go packages that contain tests and returns their
-// import paths to be used as selectors for selector based splitting.
+// DiscoverTestTargets discovers the Go packages that contain tests and returns
+// their import paths to be used as discovery targets.
 //
 // "File" does not exist as a first level concept in Go projects, so a package
 // import path is the smallest unit we can split on. The returned import paths
@@ -319,7 +315,7 @@ func isBuildFailure(test JUnitXMLTestCase) bool {
 // test files (_test.go). Packages with zero tests would otherwise be sent to the
 // test plan API as split units that run no tests, taking up a bin packing slot
 // for nothing.
-func (g GoTest) GetSelectors() ([]string, error) {
+func (g GoTest) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering Go packages with tests using `go list`")
 	cmd := exec.Command("go", "list", "-f", "{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}", "./...")
 	output, err := cmd.Output()
@@ -343,19 +339,6 @@ func (g GoTest) GetSelectors() ([]string, error) {
 		return nil, fmt.Errorf("no Go packages with tests found using `go list`")
 	}
 	return validPackages, nil
-}
-
-// GetFiles is the fallback used when selector based splitting is disabled, which
-// is the default behavior. Because "file" does not exist as a first level concept
-// in Go projects, there is nothing file-like to discover, so we reuse the same
-// package discovery as GetSelectors and return package import paths instead.
-//
-// The implication is that server side smart test splitting will never work for
-// these targets, since the API treats them as file paths. It almost always falls
-// back to simple splitting. We are migrating Go splitting over to GetSelectors so
-// the API can split by selector properly.
-func (g GoTest) GetFiles() ([]string, error) {
-	return g.GetSelectors()
 }
 
 func (g GoTest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error) {

--- a/internal/runner/gotest_test.go
+++ b/internal/runner/gotest_test.go
@@ -367,14 +367,14 @@ func TestGotestCommandKeepsGotestsumJUnitCommand(t *testing.T) {
 	}, args)
 }
 
-func TestGotestGetSelectors(t *testing.T) {
+func TestGotestDiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/go")
 
 	gotest := NewGoTest(RunnerConfig{})
 
-	got, err := gotest.GetSelectors()
+	got, err := gotest.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Gotest.GetSelectors() error = %v", err)
+		t.Errorf("Gotest.DiscoverTestTargets() error = %v", err)
 	}
 
 	// example.com/hello/notest has source files but no tests, so it must be
@@ -387,33 +387,7 @@ func TestGotestGetSelectors(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Gotest.GetSelectors() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestGotestGetFiles(t *testing.T) {
-	changeCwd(t, "./testdata/go")
-
-	gotest := NewGoTest(RunnerConfig{})
-
-	// When selector based splitting is disabled, GetFiles falls back to the same
-	// package discovery as GetSelectors because Go has no file-level concept.
-	got, err := gotest.GetFiles()
-	if err != nil {
-		t.Errorf("Gotest.GetFiles() error = %v", err)
-	}
-
-	// example.com/hello/notest has source files but no tests, so it must be
-	// excluded from the discovered packages.
-	want := []string{
-		"example.com/hello",
-		"example.com/hello/bad",
-		"example.com/hello/broken",
-		"example.com/hello/testmain",
-	}
-
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Gotest.GetFiles() diff (-got +want):\n%s", diff)
+		t.Errorf("Gotest.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/jest.go
+++ b/internal/runner/jest.go
@@ -57,8 +57,8 @@ func (j Jest) ResultFormat() string {
 	return "jest-json"
 }
 
-// GetFiles returns an array of file names using the discovery pattern.
-func (j Jest) GetFiles() ([]string, error) {
+// DiscoverTestTargets returns file names using the discovery pattern.
+func (j Jest) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", j.TestFilePattern, "exclude pattern:", j.TestFileExcludePattern)
 	files, err := discoverTestFiles(j.TestFilePattern, j.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -72,10 +72,6 @@ func (j Jest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (j Jest) GetSelectors() ([]string, error) {
-	return j.GetFiles()
 }
 
 func (j Jest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
@@ -236,8 +232,4 @@ func (j Jest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string,
 	words = slices.Replace(words, outputIdx, outputIdx+1, j.ResultPath)
 
 	return words[0], words[1:], nil
-}
-
-func (j Jest) GetExamples(files []string) ([]plan.TestCase, error) {
-	return nil, fmt.Errorf("not supported in Jest")
 }

--- a/internal/runner/jest_test.go
+++ b/internal/runner/jest_test.go
@@ -603,13 +603,13 @@ func TestJestRetryCommandNameAndArgs_WithTestExamplesPlaceholder(t *testing.T) {
 	}
 }
 
-func TestJestGetFiles(t *testing.T) {
+func TestJestDiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/jest")
 	jest := NewJest(RunnerConfig{})
 
-	got, err := jest.GetFiles()
+	got, err := jest.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Jest.GetFiles() error = %v", err)
+		t.Errorf("Jest.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -621,25 +621,6 @@ func TestJestGetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Jest.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestJestGetSelectors(t *testing.T) {
-	changeCwd(t, "./testdata/jest")
-	jest := NewJest(RunnerConfig{})
-
-	gotFiles, err := jest.GetFiles()
-	if err != nil {
-		t.Errorf("Jest.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := jest.GetSelectors()
-	if err != nil {
-		t.Errorf("Jest.GetSelectors() error = %v", err)
-	}
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Jest.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Jest.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }

--- a/internal/runner/playwright.go
+++ b/internal/runner/playwright.go
@@ -166,7 +166,7 @@ func (p Playwright) parseReport(path string) (PlaywrightReport, error) {
 	return report, nil
 }
 
-func (p Playwright) GetFiles() ([]string, error) {
+func (p Playwright) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", p.TestFilePattern, "exclude pattern:", p.TestFileExcludePattern)
 	files, err := discoverTestFiles(p.TestFilePattern, p.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -180,10 +180,6 @@ func (p Playwright) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (p Playwright) GetSelectors() ([]string, error) {
-	return p.GetFiles()
 }
 
 // GetExamples returns an array of test examples within the given files.

--- a/internal/runner/playwright_test.go
+++ b/internal/runner/playwright_test.go
@@ -243,13 +243,13 @@ func TestPlaywrightCommandNameAndArgs_WithoutPlaceholder(t *testing.T) {
 	}
 }
 
-func TestPlaywrightGetFiles(t *testing.T) {
+func TestPlaywrightDiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/playwright")
 	playwright := NewPlaywright(RunnerConfig{})
 
-	got, err := playwright.GetFiles()
+	got, err := playwright.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Playwright.GetFiles() error = %v", err)
+		t.Errorf("Playwright.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -260,26 +260,7 @@ func TestPlaywrightGetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Playwright.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestPlaywrightGetSelectors(t *testing.T) {
-	changeCwd(t, "./testdata/playwright")
-	playwright := NewPlaywright(RunnerConfig{})
-
-	gotFiles, err := playwright.GetFiles()
-	if err != nil {
-		t.Errorf("Playwright.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := playwright.GetSelectors()
-	if err != nil {
-		t.Errorf("Playwright.GetSelectors() error = %v", err)
-	}
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Playwright.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Playwright.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/pytest.go
+++ b/internal/runner/pytest.go
@@ -261,7 +261,7 @@ func pytestNodeIDFromJUnit(classname, name string) (path string) {
 	return
 }
 
-func (p Pytest) GetFiles() ([]string, error) {
+func (p Pytest) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", p.TestFilePattern, "exclude pattern:", p.TestFileExcludePattern)
 	files, err := discoverTestFiles(p.TestFilePattern, p.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -275,10 +275,6 @@ func (p Pytest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (p Pytest) GetSelectors() ([]string, error) {
-	return p.GetFiles()
 }
 
 // GetExamples returns an array of test examples within the given files.

--- a/internal/runner/pytest_test.go
+++ b/internal/runner/pytest_test.go
@@ -475,14 +475,14 @@ func TestPytestRun_CommandFailed(t *testing.T) {
 	assert.ErrorAs(t, err, &exitError)
 }
 
-func TestPytestGetFiles(t *testing.T) {
+func TestPytestDiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/pytest")
 
 	pytest := NewPytest(RunnerConfig{})
 
-	got, err := pytest.GetFiles()
+	got, err := pytest.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Pytest.GetFiles() error = %v", err)
+		t.Errorf("Pytest.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -492,27 +492,7 @@ func TestPytestGetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Pytest.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestPytestGetSelectors(t *testing.T) {
-	changeCwd(t, "./testdata/pytest")
-
-	pytest := NewPytest(RunnerConfig{})
-
-	gotFiles, err := pytest.GetFiles()
-	if err != nil {
-		t.Errorf("Pytest.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := pytest.GetSelectors()
-	if err != nil {
-		t.Errorf("Pytest.GetSelectors() error = %v", err)
-	}
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Pytest.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Pytest.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -676,7 +656,7 @@ func TestPytestGetExamples_TagFilter(t *testing.T) {
 		},
 	)
 
-	files, _ := pytest.GetFiles()
+	files, _ := pytest.DiscoverTestTargets()
 
 	got, err := pytest.GetExamples(files)
 	if err != nil {

--- a/internal/runner/rspec.go
+++ b/internal/runner/rspec.go
@@ -63,8 +63,8 @@ func (r Rspec) ResultFormat() string {
 	return "rspec-json"
 }
 
-// GetFiles returns an array of file names using the discovery pattern.
-func (r Rspec) GetFiles() ([]string, error) {
+// DiscoverTestTargets returns file names using the discovery pattern.
+func (r Rspec) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", r.TestFilePattern, "exclude pattern:", r.TestFileExcludePattern)
 	files, err := discoverTestFiles(r.TestFilePattern, r.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -78,10 +78,6 @@ func (r Rspec) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (r Rspec) GetSelectors() ([]string, error) {
-	return r.GetFiles()
 }
 
 // Run executes the test command with the given test cases.

--- a/internal/runner/rspec_test.go
+++ b/internal/runner/rspec_test.go
@@ -371,22 +371,20 @@ func TestRspecCommandNameAndArgs_InvalidTestCommand(t *testing.T) {
 	}
 }
 
-func TestRspecGetSelectors(t *testing.T) {
+func TestRspecDiscoverTestTargets(t *testing.T) {
 	rspec := NewRspec(RunnerConfig{
 		TestFilePattern: "testdata/rspec/spec/spells/**/*_spec.rb",
 	})
 
-	got, err := rspec.GetSelectors()
+	got, err := rspec.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Rspec.GetSelectors() error = %v", err)
+		t.Errorf("Rspec.DiscoverTestTargets() error = %v", err)
 	}
 
-	// Selector based splitting for RSpec splits by file, so the selectors are
-	// the discovered test files (the same result as GetFiles).
 	want := []string{"testdata/rspec/spec/spells/expelliarmus_spec.rb"}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Rspec.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Rspec.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -1,7 +1,5 @@
 package runner
 
-import "fmt"
-
 type RunnerConfig struct {
 	TestRunner string
 
@@ -47,11 +45,4 @@ func (rc RunnerConfig) ResultFormat() string {
 // ResultFilePath returns the path to the runner's raw result file.
 func (rc RunnerConfig) ResultFilePath() string {
 	return rc.ResultPath
-}
-
-// GetSelectors returns a "not supported" error by default. Runners that
-// support selector based splitting override this. Every other runner
-// inherits this default until it gains selector support.
-func (rc RunnerConfig) GetSelectors() ([]string, error) {
-	return nil, fmt.Errorf("selector based splitting is not supported for the %s runner", rc.TestRunner)
 }

--- a/internal/runner/supported_features_test.go
+++ b/internal/runner/supported_features_test.go
@@ -59,3 +59,34 @@ func TestSupportedFeatures_SplitBySelectorSupportedRunners(t *testing.T) {
 		}
 	}
 }
+
+func TestSupportedFeatures_SplitByExampleRequiresExampleDiscoverer(t *testing.T) {
+	runnerConfig := RunnerConfig{
+		ResultPath:      "results.json",
+		TestCommand:     "test-command",
+		TestFilePattern: "**/*_test.go",
+	}
+	custom, err := NewCustom(runnerConfig)
+	if err != nil {
+		t.Fatalf("NewCustom() error = %v", err)
+	}
+
+	runners := []TestRunner{
+		custom,
+		NewRspec(runnerConfig),
+		NewJest(runnerConfig),
+		NewPlaywright(runnerConfig),
+		NewCypress(runnerConfig),
+		NewPytest(runnerConfig),
+		NewGoTest(runnerConfig),
+		NewCucumber(runnerConfig),
+		NewVitest(runnerConfig),
+	}
+
+	for _, testRunner := range runners {
+		_, implementsExampleDiscovery := testRunner.(ExampleDiscoverer)
+		if got := testRunner.SupportedFeatures().SplitByExample; got != implementsExampleDiscovery {
+			t.Errorf("%s SplitByExample = %v, implements ExampleDiscoverer = %v", testRunner.Name(), got, implementsExampleDiscovery)
+		}
+	}
+}

--- a/internal/runner/test_runner.go
+++ b/internal/runner/test_runner.go
@@ -4,9 +4,6 @@ import "github.com/buildkite/test-engine-client/v2/internal/plan"
 
 type TestRunner interface {
 	Run(result *RunResult, testCases []plan.TestCase, retry bool) error
-	GetExamples(files []string) ([]plan.TestCase, error)
-	GetFiles() ([]string, error)
-	GetSelectors() ([]string, error)
 	Name() string
 	CommandNameAndArgs(testCases []plan.TestCase, retry bool) (string, []string, error)
 	LocationPrefix() string
@@ -19,3 +16,33 @@ type TestRunner interface {
 	// ResultFilePath returns the path to the runner's raw result file.
 	ResultFilePath() string
 }
+
+type TestTargetDiscoverer interface {
+	DiscoverTestTargets() ([]string, error)
+}
+
+type ExampleDiscoverer interface {
+	GetExamples(files []string) ([]plan.TestCase, error)
+}
+
+type TestRunnerWithTargetDiscovery interface {
+	TestRunner
+	TestTargetDiscoverer
+}
+
+var (
+	_ TestTargetDiscoverer = (*Custom)(nil)
+	_ TestTargetDiscoverer = (*Cucumber)(nil)
+	_ TestTargetDiscoverer = (*Cypress)(nil)
+	_ TestTargetDiscoverer = (*GoTest)(nil)
+	_ TestTargetDiscoverer = (*Jest)(nil)
+	_ TestTargetDiscoverer = (*Playwright)(nil)
+	_ TestTargetDiscoverer = (*Pytest)(nil)
+	_ TestTargetDiscoverer = (*Rspec)(nil)
+	_ TestTargetDiscoverer = (*Vitest)(nil)
+
+	_ ExampleDiscoverer = (*Cucumber)(nil)
+	_ ExampleDiscoverer = (*Playwright)(nil)
+	_ ExampleDiscoverer = (*Pytest)(nil)
+	_ ExampleDiscoverer = (*Rspec)(nil)
+)

--- a/internal/runner/testdata/go/notest/notest.go
+++ b/internal/runner/testdata/go/notest/notest.go
@@ -1,5 +1,5 @@
-// Package notest has source files but no tests. It exists so GetFiles can be
-// verified to exclude packages that contain zero tests.
+// Package notest has source files but no tests. It exists so target discovery
+// can be verified to exclude packages that contain zero tests.
 package notest
 
 // Add returns the sum of two integers.

--- a/internal/runner/vitest.go
+++ b/internal/runner/vitest.go
@@ -61,8 +61,8 @@ func (v Vitest) ResultFormat() string {
 	return "jest-json"
 }
 
-// GetFiles returns an array of file names using the discovery pattern.
-func (v Vitest) GetFiles() ([]string, error) {
+// DiscoverTestTargets returns file names using the discovery pattern.
+func (v Vitest) DiscoverTestTargets() ([]string, error) {
 	debug.Println("Discovering test files with include pattern:", v.TestFilePattern, "exclude pattern:", v.TestFileExcludePattern)
 	files, err := discoverTestFiles(v.TestFilePattern, v.TestFileExcludePattern)
 	debug.Println("Discovered", len(files), "files")
@@ -76,10 +76,6 @@ func (v Vitest) GetFiles() ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (v Vitest) GetSelectors() ([]string, error) {
-	return v.GetFiles()
 }
 
 func (v Vitest) Run(result *RunResult, testCases []plan.TestCase, retry bool) error {
@@ -214,8 +210,4 @@ func (v Vitest) CommandNameAndArgs(testCases []plan.TestCase, retry bool) (strin
 	words = slices.Replace(words, outputIdx, outputIdx+1, v.ResultPath)
 
 	return words[0], words[1:], nil
-}
-
-func (v Vitest) GetExamples(files []string) ([]plan.TestCase, error) {
-	return nil, fmt.Errorf("not supported in Vitest")
 }

--- a/internal/runner/vitest_test.go
+++ b/internal/runner/vitest_test.go
@@ -52,13 +52,13 @@ func TestNewVitest(t *testing.T) {
 	}
 }
 
-func TestVitestGetFiles(t *testing.T) {
+func TestVitestDiscoverTestTargets(t *testing.T) {
 	changeCwd(t, "./testdata/vitest")
 	vitest := NewVitest(RunnerConfig{})
 
-	got, err := vitest.GetFiles()
+	got, err := vitest.DiscoverTestTargets()
 	if err != nil {
-		t.Errorf("Vitest.GetFiles() error = %v", err)
+		t.Errorf("Vitest.DiscoverTestTargets() error = %v", err)
 	}
 
 	want := []string{
@@ -68,26 +68,7 @@ func TestVitestGetFiles(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Vitest.GetFiles() diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestVitestGetSelectors(t *testing.T) {
-	changeCwd(t, "./testdata/vitest")
-	vitest := NewVitest(RunnerConfig{})
-
-	gotFiles, err := vitest.GetFiles()
-	if err != nil {
-		t.Errorf("Vitest.GetFiles() error = %v", err)
-	}
-
-	gotSelectors, err := vitest.GetSelectors()
-	if err != nil {
-		t.Errorf("Vitest.GetSelectors() error = %v", err)
-	}
-
-	if diff := cmp.Diff(gotSelectors, gotFiles); diff != "" {
-		t.Errorf("Vitest.GetSelectors() diff (-got +want):\n%s", diff)
+		t.Errorf("Vitest.DiscoverTestTargets() diff (-got +want):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
### Description

Replace the duplicated file and selector discovery methods with one target-discovery capability while continuing to support both file and selector splitting. This keeps mode selection and API encoding in the command layer instead of requiring each runner to expose parallel discovery paths.

### Context

[TE-6249: Tidy up split-by-file vs split-by-selector code paths](https://linear.app/buildkite/issue/TE-6249/tidy-up-split-by-file-vs-split-by-selector-code-paths)

### Changes

- replace runner `GetFiles` and `GetSelectors` methods with `DiscoverTestTargets`
- split target and example discovery into focused optional interfaces
- preserve mode-specific file/selector list precedence and fallback behavior
- remove unsupported example-discovery stubs
- add discovery precedence and capability consistency coverage

### Testing

- `go test ./internal/command ./internal/runner -run '^$'`
- focused command and runner discovery tests
- `go vet ./internal/command ./internal/api ./internal/runner ./internal/plan`
- `golangci-lint run` (0 issues)