### PR TITLE
Default bktec parallelism to one

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ bktec uses the following Buildkite Pipeline provided environment variables.
 | `BUILDKITE_BUILD_ID` | The UUID of the Buildkite build. bktec uses this UUID along with `BUILDKITE_STEP_ID` to uniquely identify the test plan. |
 | `BUILDKITE_JOB_ID` | The UUID of the job in Buildkite build. |
 | `BUILDKITE_ORGANIZATION_SLUG` | The slug of your Buildkite organization. |
-| `BUILDKITE_PARALLEL_JOB` | The index number of a parallel job created from a Buildkite parallel build step. <br>Make sure you configure `parallelism` in your pipeline definition.  You can read more about Buildkite parallel build step on this [page](https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-and-parallelism).|
-| `BUILDKITE_PARALLEL_JOB_COUNT` | The total number of parallel jobs created from a Buildkite parallel build step. <br>Make sure you configure `parallelism` in your pipeline definition.  You can read more about Buildkite parallel build step on this [page](https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-and-parallelism). |
+| `BUILDKITE_PARALLEL_JOB` | The index number of a parallel job created from a Buildkite parallel build step. Defaults to `0` when the command step does not set `parallelism`. |
+| `BUILDKITE_PARALLEL_JOB_COUNT` | The total number of parallel jobs created from a Buildkite parallel build step. Defaults to `1`; configure `parallelism` in your pipeline definition to split tests across multiple jobs. You can read more about Buildkite parallel build steps on this [page](https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-and-parallelism). |
 | `BUILDKITE_STEP_ID` | The UUID of the step group in Buildkite build. bktec uses this UUID along with `BUILDKITE_BUILD_ID` to uniquely identify the test plan. |
 
 > [!IMPORTANT]

--- a/cli.go
+++ b/cli.go
@@ -147,6 +147,7 @@ var parallelismFlag = &cli.IntFlag{
 	Name:        "parallelism",
 	Category:    "BUILD ENVIRONMENT",
 	Usage:       "Run the specified number of bktec processes in parallel",
+	Value:       1,
 	Sources:     cli.EnvVars("BUILDKITE_PARALLEL_JOB_COUNT"),
 	Destination: &cfg.Parallelism,
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -65,6 +66,42 @@ func TestCollectGitMetadataFlagIsGatedByPreviewEnv(t *testing.T) {
 func TestPlanCommandIncludesParallelismFlag(t *testing.T) {
 	if !hasFlag(planCommandFlags(), "parallelism") {
 		t.Fatalf("planCommandFlags() missing --parallelism flag; BUILDKITE_PARALLEL_JOB_COUNT will not be bound to cfg.Parallelism for `bktec plan`, breaking split-by-example slow-file detection")
+	}
+}
+
+func TestRunCommandDefaultsParallelismToOne(t *testing.T) {
+	cfg = config.New()
+	t.Cleanup(func() { cfg = config.New() })
+
+	parallelism, wasSet := os.LookupEnv("BUILDKITE_PARALLEL_JOB_COUNT")
+	if err := os.Unsetenv("BUILDKITE_PARALLEL_JOB_COUNT"); err != nil {
+		t.Fatalf("os.Unsetenv(BUILDKITE_PARALLEL_JOB_COUNT) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv("BUILDKITE_PARALLEL_JOB_COUNT", parallelism)
+		} else {
+			_ = os.Unsetenv("BUILDKITE_PARALLEL_JOB_COUNT")
+		}
+	})
+
+	cmd := &cli.Command{
+		Name: "bktec",
+		Commands: []*cli.Command{
+			{
+				Name:   "run",
+				Action: func(ctx context.Context, cmd *cli.Command) error { return nil },
+				Flags:  runCommandFlags(),
+			},
+		},
+	}
+
+	if err := cmd.Run(context.Background(), []string{"bktec", "run"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Parallelism != 1 {
+		t.Errorf("cfg.Parallelism = %d, want 1", cfg.Parallelism)
 	}
 }
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -236,9 +236,8 @@ func makePipelineUploadCommand(template string) *exec.Cmd {
 }
 
 // fallbackParallelism resolves the fallback plan's parallelism like bktec run
-// does: prefer --max-parallelism, else the static BUILDKITE_PARALLEL_JOB_COUNT.
-// Without this an unset --max-parallelism yields parallelism 0, so the fallback
-// runs nothing. Still 0 off-agent, where BUILDKITE_PARALLEL_JOB_COUNT is unset.
+// does: prefer --max-parallelism, else the static parallelism, which defaults
+// to 1 when BUILDKITE_PARALLEL_JOB_COUNT is unset.
 func fallbackParallelism(cfg *config.Config) int {
 	if cfg.MaxParallelism > 0 {
 		return cfg.MaxParallelism


### PR DESCRIPTION
### Description

Default bktec to serial execution when Buildkite does not provide parallel-job environment variables, matching Buildkite's command-step behavior.

### Context

- Investigation: https://ampcode.com/threads/T-019fa5ba-fe24-7309-a1e6-197062d9451b
- The independent invalid-configuration error improvement was split into #614.

### Changes

- Default static parallelism to 1 while preserving explicit flag and environment values.
- Document serial execution as the default.

### Testing

- `go test .`
- `go test ./internal/config`
- `go test ./internal/command` was attempted but cannot complete locally because pytest does not recognize the repository's `--tag-filters` option.

### Deployment

Low risk; no migration. Pipelines that omit `parallelism` begin running serially instead of failing validation.

### Rollback

Revert `f42ee8f` to restore required parallelism.

### Related

- #614