### PR TITLE
Improve invalid configuration errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func backfillCommitMetadata(ctx context.Context, cmd *cli.Command) error {
 	debug.SetOutput(os.Stderr)
 
 	if err := cfg.ValidateForBackfillCommitMetadata(); err != nil {
-		return fmt.Errorf("bktec backfill-commit-metadata: invalid configuration:\n%w", err)
+		return fmt.Errorf("bktec tools backfill-commit-metadata: invalid configuration:\n%w", err)
 	}
 
 	return command.BackfillCommitMetadata(ctx, &cfg, &git.ExecGitRunner{})

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if err := cfg.ValidateForRun(); err != nil {
-		return fmt.Errorf("invalid configuration...\n%w", err)
+		return fmt.Errorf("bktec run: invalid configuration:\n%w", err)
 	}
 
 	return command.Run(ctx, &cfg, cmd.String("files"))
@@ -48,7 +48,7 @@ func plan(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if err := cfg.ValidateForPlan(); err != nil {
-		return fmt.Errorf("invalid configuration...\n%w", err)
+		return fmt.Errorf("bktec plan: invalid configuration:\n%w", err)
 	}
 
 	switch {
@@ -66,7 +66,7 @@ func backfillCommitMetadata(ctx context.Context, cmd *cli.Command) error {
 	debug.SetOutput(os.Stderr)
 
 	if err := cfg.ValidateForBackfillCommitMetadata(); err != nil {
-		return fmt.Errorf("invalid configuration...\n%w", err)
+		return fmt.Errorf("bktec backfill-commit-metadata: invalid configuration:\n%w", err)
 	}
 
 	return command.BackfillCommitMetadata(ctx, &cfg, &git.ExecGitRunner{})

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,37 @@
 package main
 
 import (
+	"context"
 	"testing"
 
+	"github.com/buildkite/test-engine-client/v2/internal/config"
 	"github.com/google/go-cmp/cmp"
+	"github.com/urfave/cli/v3"
 )
+
+func TestRunInvalidConfigurationError(t *testing.T) {
+	cfg = config.New()
+	t.Cleanup(func() { cfg = config.New() })
+	t.Setenv(previewSelectionEnvVar, "")
+
+	cfg.Identifier = "build/step"
+	cfg.OrganizationSlug = "my-org"
+	cfg.SuiteSlug = "my-suite"
+	cfg.AccessToken = "access-token"
+	cfg.UploadToken = "upload-token"
+	cfg.TestRunner = "vitest"
+	cfg.Parallelism = 1
+
+	err := run(context.Background(), &cli.Command{})
+	if err == nil {
+		t.Fatal("run() error = nil, want invalid configuration error")
+	}
+
+	want := "bktec run: invalid configuration:\nBUILDKITE_TEST_ENGINE_RESULT_PATH must not be blank"
+	if err.Error() != want {
+		t.Errorf("run() error = %q, want %q", err, want)
+	}
+}
 
 func TestParseMetadataEntries_Empty(t *testing.T) {
 	got, err := parseKeyValueEntries([]string{}, "metadata")


### PR DESCRIPTION
### Description

Make validation failures attributable to bktec by naming the subcommand that rejected the configuration and replacing the vague ellipsis with a conventional error heading.

Before:
<img width="641" height="249" alt="image" src="https://github.com/user-attachments/assets/7940aa3a-b105-4cf8-858f-0e2b1f044659" />

After:
{hopefully something better 😅}

### Context

- Split from #613 so the error-message change can be reviewed and shipped independently.

### Changes

- Prefix validation errors with `bktec <subcommand>: invalid configuration:`.
- Cover the `run` error output with a focused regression test.

### Testing

- `go test .`

### Deployment

Low risk; this changes error text only.

### Rollback

Revert both commits in this pull request to restore the previous error text.

### Related

- #613