### PR TITLE
Surface retried request failures

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -193,7 +194,7 @@ func (c *Client) doWithRetry(
 	// retry loop
 	resp, err := roko.DoFunc(retryContext, r, func(r *roko.Retrier) (*http.Response, error) {
 		if r.AttemptCount() > 0 {
-			debug.Printf("Retrying requests, attempt %d", r.AttemptCount())
+			fmt.Fprintf(os.Stderr, "Buildkite Test Engine Client: Retrying API request (attempt %d)\n", r.AttemptCount()+1)
 		}
 
 		req, err := newRequest(ctx)
@@ -213,8 +214,8 @@ func (c *Client) doWithRetry(
 		// which means there is a network error (e.g. protocol error, timeout),
 		// we should return and retry.
 		if err != nil {
-			debug.Printf("Error sending request: %v", err)
 			lastRetryError = err
+			printRetryError(err)
 			return nil, err
 		}
 
@@ -227,6 +228,7 @@ func (c *Client) doWithRetry(
 			}
 			drainAndCloseBody(resp)
 			lastRetryError = fmt.Errorf("response code: 429")
+			printRetryError(lastRetryError)
 			return resp, lastRetryError
 		}
 
@@ -235,6 +237,7 @@ func (c *Client) doWithRetry(
 		if resp.StatusCode == http.StatusConflict {
 			drainAndCloseBody(resp)
 			lastRetryError = fmt.Errorf("response code: %d", resp.StatusCode)
+			printRetryError(lastRetryError)
 			return resp, lastRetryError
 		}
 
@@ -242,6 +245,7 @@ func (c *Client) doWithRetry(
 		if resp.StatusCode >= 500 {
 			drainAndCloseBody(resp)
 			lastRetryError = fmt.Errorf("response code: %d", resp.StatusCode)
+			printRetryError(lastRetryError)
 			return resp, lastRetryError
 		}
 
@@ -259,6 +263,10 @@ func (c *Client) doWithRetry(
 	}
 
 	return resp, err
+}
+
+func printRetryError(err error) {
+	fmt.Fprintf(os.Stderr, "Buildkite Test Engine Client: API request failed: %v\n", err)
 }
 
 // drainAndCloseBody reads resp.Body to the end and closes it. An HTTP request

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,6 +78,24 @@ var (
 
 var ErrRetryTimeout = errors.New("request retry timeout")
 
+// RetryTimeoutError preserves the last error that caused a request to be
+// retried before the overall retry timeout elapsed.
+type RetryTimeoutError struct {
+	LastError error
+}
+
+func (e *RetryTimeoutError) Error() string {
+	return fmt.Sprintf("%s: %v", ErrRetryTimeout, e.LastError)
+}
+
+func (e *RetryTimeoutError) Is(target error) bool {
+	return target == ErrRetryTimeout
+}
+
+func (e *RetryTimeoutError) Unwrap() error {
+	return e.LastError
+}
+
 type BillingError struct {
 	Message string
 }
@@ -146,8 +164,9 @@ type httpRequest struct {
 // The request is retried when the server returns 429, 409, or 5xx, or when there
 // is a network error. retryTimeout caps the total time spent across all attempts,
 // and perAttemptTimeout caps each individual attempt. After exhausting the retry
-// timeout, the function returns ErrRetryTimeout. newRequest builds a fresh request
-// for each attempt (so a body can be re-sent on retry).
+// timeout, the function returns an error matching ErrRetryTimeout that preserves
+// the last retryable error. newRequest builds a fresh request for each attempt
+// (so a body can be re-sent on retry).
 //
 // On a response that is not retried, doWithRetry returns it with a nil error
 // and the caller is responsible for reading and closing the response body. When
@@ -168,6 +187,8 @@ func (c *Client) doWithRetry(
 	// retries, not while a single attempt is in flight (that's perAttemptTimeout).
 	retryContext, cancelRetryContext := context.WithTimeout(ctx, retryTimeout)
 	defer cancelRetryContext()
+
+	var lastRetryError error
 
 	// retry loop
 	resp, err := roko.DoFunc(retryContext, r, func(r *roko.Retrier) (*http.Response, error) {
@@ -193,6 +214,7 @@ func (c *Client) doWithRetry(
 		// we should return and retry.
 		if err != nil {
 			debug.Printf("Error sending request: %v", err)
+			lastRetryError = err
 			return nil, err
 		}
 
@@ -204,20 +226,23 @@ func (c *Client) doWithRetry(
 				r.SetNextInterval(time.Duration(rateLimitReset) * time.Second)
 			}
 			drainAndCloseBody(resp)
-			return resp, fmt.Errorf("response code: 429")
+			lastRetryError = fmt.Errorf("response code: 429")
+			return resp, lastRetryError
 		}
 
 		// If we get a 409, we aren't the first client to create the plan so return
 		// and retry
 		if resp.StatusCode == http.StatusConflict {
 			drainAndCloseBody(resp)
-			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
+			lastRetryError = fmt.Errorf("response code: %d", resp.StatusCode)
+			return resp, lastRetryError
 		}
 
 		// If we get a 5xx, we should return and retry
 		if resp.StatusCode >= 500 {
 			drainAndCloseBody(resp)
-			return resp, fmt.Errorf("response code: %d", resp.StatusCode)
+			lastRetryError = fmt.Errorf("response code: %d", resp.StatusCode)
+			return resp, lastRetryError
 		}
 
 		// Other than above cases, we stop retrying and let the caller handle the
@@ -227,6 +252,9 @@ func (c *Client) doWithRetry(
 	})
 
 	if errors.Is(err, context.DeadlineExceeded) {
+		if lastRetryError != nil {
+			return resp, &RetryTimeoutError{LastError: lastRetryError}
+		}
 		return resp, ErrRetryTimeout
 	}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -194,7 +194,7 @@ func (c *Client) doWithRetry(
 	// retry loop
 	resp, err := roko.DoFunc(retryContext, r, func(r *roko.Retrier) (*http.Response, error) {
 		if r.AttemptCount() > 0 {
-			fmt.Fprintf(os.Stderr, "Buildkite Test Engine Client: Retrying API request (attempt %d)\n", r.AttemptCount()+1)
+			fmt.Fprintf(os.Stderr, "bktec: Retrying API request (attempt %d)\n", r.AttemptCount()+1)
 		}
 
 		req, err := newRequest(ctx)
@@ -266,7 +266,7 @@ func (c *Client) doWithRetry(
 }
 
 func printRetryError(err error) {
-	fmt.Fprintf(os.Stderr, "Buildkite Test Engine Client: API request failed: %v\n", err)
+	fmt.Fprintf(os.Stderr, "bktec: API request failed: %v\n", err)
 }
 
 // drainAndCloseBody reads resp.Body to the end and closes it. An HTTP request

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -222,27 +222,39 @@ func TestDoJSONWithRetry_Succesful_GET(t *testing.T) {
 
 func TestDoJSONWithRetry_RequestError(t *testing.T) {
 	originalTimeout := retryTimeout
-	retryTimeout = 300 * time.Millisecond
+	originalInitialDelay := initialDelay
+	retryTimeout = 100 * time.Millisecond
+	initialDelay = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
+		initialDelay = originalInitialDelay
 	})
 
-	cfg := ClientConfig{
-		AccessToken:      "asdf1234",
-		OrganizationSlug: "my-org",
-	}
+	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
 
-	c := NewClient(cfg)
+	c := NewClient(ClientConfig{})
 	resp, err := c.doJSONWithRetry(context.Background(), httpRequest{
 		Method: http.MethodGet,
-		URL:    "http://build.kite",
+		URL:    svr.URL,
 	}, nil)
 
-	fmt.Println(resp)
-
-	// it retries the request and returns ErrRetryTimeout with nil response.
+	// It retries the request and returns ErrRetryTimeout with the final TLS
+	// verification error preserved for user-facing diagnostics.
 	if !errors.Is(err, ErrRetryTimeout) {
 		t.Errorf("doJSONWithRetry() error = %v, want %v", err, ErrRetryTimeout)
+	}
+	var timeoutErr *RetryTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("doJSONWithRetry() error type = %T, want *RetryTimeoutError", err)
+	}
+	if !strings.Contains(timeoutErr.LastError.Error(), "certificate signed by unknown authority") {
+		t.Errorf("doJSONWithRetry() last error = %v, want TLS certificate verification failure", timeoutErr.LastError)
+	}
+	if !strings.Contains(err.Error(), "certificate signed by unknown authority") {
+		t.Errorf("doJSONWithRetry() error = %v, want TLS certificate verification failure", err)
 	}
 
 	if resp != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -223,13 +225,14 @@ func TestDoJSONWithRetry_Succesful_GET(t *testing.T) {
 func TestDoJSONWithRetry_RequestError(t *testing.T) {
 	originalTimeout := retryTimeout
 	originalInitialDelay := initialDelay
-	retryTimeout = 100 * time.Millisecond
+	retryTimeout = 1500 * time.Millisecond
 	initialDelay = 1 * time.Millisecond
 	t.Cleanup(func() {
 		retryTimeout = originalTimeout
 		initialDelay = originalInitialDelay
 	})
 
+	getStderr := captureClientStderr(t)
 	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -240,6 +243,7 @@ func TestDoJSONWithRetry_RequestError(t *testing.T) {
 		Method: http.MethodGet,
 		URL:    svr.URL,
 	}, nil)
+	stderr := getStderr()
 
 	// It retries the request and returns ErrRetryTimeout with the final TLS
 	// verification error preserved for user-facing diagnostics.
@@ -255,6 +259,18 @@ func TestDoJSONWithRetry_RequestError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "certificate signed by unknown authority") {
 		t.Errorf("doJSONWithRetry() error = %v, want TLS certificate verification failure", err)
+	}
+
+	failedAttempts := strings.Count(stderr, "Buildkite Test Engine Client: API request failed:")
+	retries := strings.Count(stderr, "Buildkite Test Engine Client: Retrying API request")
+	if failedAttempts < 2 {
+		t.Errorf("failed attempt log count = %d, want at least 2; stderr = %q", failedAttempts, stderr)
+	}
+	if retries != failedAttempts-1 {
+		t.Errorf("retry log count = %d, want %d; stderr = %q", retries, failedAttempts-1, stderr)
+	}
+	if !strings.Contains(stderr, "certificate signed by unknown authority") {
+		t.Errorf("stderr = %q, want TLS certificate verification failure", stderr)
 	}
 
 	if resp != nil {
@@ -584,5 +600,24 @@ func TestDoJSONWithRetry_BillingError(t *testing.T) {
 
 	if billingError := new(BillingError); !errors.As(err, &billingError) {
 		t.Errorf("doJSONWithRetry() error type = %T, want %T", err, BillingError{})
+	}
+}
+
+func captureClientStderr(t *testing.T) func() string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	original := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = original })
+
+	return func() string {
+		_ = w.Close()
+		var output bytes.Buffer
+		_, _ = io.Copy(&output, r)
+		_ = r.Close()
+		return output.String()
 	}
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -261,8 +261,8 @@ func TestDoJSONWithRetry_RequestError(t *testing.T) {
 		t.Errorf("doJSONWithRetry() error = %v, want TLS certificate verification failure", err)
 	}
 
-	failedAttempts := strings.Count(stderr, "Buildkite Test Engine Client: API request failed:")
-	retries := strings.Count(stderr, "Buildkite Test Engine Client: Retrying API request")
+	failedAttempts := strings.Count(stderr, "bktec: API request failed:")
+	retries := strings.Count(stderr, "bktec: Retrying API request")
 	if failedAttempts < 2 {
 		t.Errorf("failed attempt log count = %d, want at least 2; stderr = %q", failedAttempts, stderr)
 	}

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -70,7 +70,12 @@ func fatal(label string, a any) error {
 // or a fatal error with a formatted message for unrecoverable failures.
 func handleError(err error) error {
 	if errors.Is(err, api.ErrRetryTimeout) {
-		printWarn("Timeout", "Test Engine API timed out")
+		var timeoutError *api.RetryTimeoutError
+		if errors.As(err, &timeoutError) {
+			printWarn("Timeout", "Test Engine API timed out", "Last request error: "+timeoutError.LastError.Error())
+		} else {
+			printWarn("Timeout", "Test Engine API timed out")
+		}
 		return nil
 	}
 

--- a/internal/command/errors_test.go
+++ b/internal/command/errors_test.go
@@ -23,6 +23,22 @@ func TestHandleError_RetryTimeout(t *testing.T) {
 	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
 }
 
+func TestHandleError_RetryTimeoutIncludesLastError(t *testing.T) {
+	getStderr := captureStderr(t)
+
+	err := handleError(&api.RetryTimeoutError{
+		LastError: fmt.Errorf("tls: failed to verify certificate: x509: certificate signed by unknown authority"),
+	})
+
+	assert.Nil(t, err)
+
+	stderr := getStderr()
+	assert.Contains(t, stderr, "⚠️ Timeout:")
+	assert.Contains(t, stderr, "Last request error:")
+	assert.Contains(t, stderr, "x509: certificate signed by unknown authority")
+	assert.Contains(t, stderr, "Falling back to non-intelligent splitting")
+}
+
 func TestHandleError_BillingError(t *testing.T) {
 	getStderr := captureStderr(t)
 


### PR DESCRIPTION
### Description

Report API request failures as they happen and preserve the final failure when retries expire. Non-debug output now identifies transport problems such as TLS certificate verification failures on every attempt, announces each retry, and retains the cause in the final timeout summary.

### Context

- Silent failure: https://buildkite.com/pda/pda-test/builds/5
- TLS error visible only with debug logging: https://buildkite.com/pda/pda-test/builds/6

Build 6 changed only bktec debug logging. The retry loop logged each TLS error through `debug.Printf`, then discarded it when the retry deadline elapsed and returned only `ErrRetryTimeout`.

### Changes

- Emit a one-line error for every failed retryable request and announce each subsequent attempt.
- Preserve the final network or retryable HTTP error while retaining `errors.Is(err, ErrRetryTimeout)` compatibility.
- Include the preserved cause in the final plan fallback warning.
- Let existing result-upload error output include the same underlying cause.
- Reproduce the scenario with an untrusted TLS test server and verify failure/retry log counts.

### Testing

- `go test ./internal/api`
- `go test ./internal/api -run '^TestDoJSONWithRetry_RequestError$' -count=3`
- `go test ./internal/command -run 'TestHandleError|TestFetchOrCreateTestPlan'`

### Deployment

Low risk; retry and fallback decisions are unchanged. Only retained error context and user-facing diagnostics change.

### Rollback

Revert `7c447fc` and `a9d77df` to restore debug-only retry details and generic timeout errors.