### PR TITLE
Relay test OTLP traces through bktec

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,35 @@ export BUILDKITE_TEST_ENGINE_TAGS="env=production,region=us-east-1"
 
 Test collectors are available for many languages and frameworks. Some collectors also provide richer data collection such as execution-level tagging and span tracing. See the [test collector docs](https://buildkite.com/docs/test-engine/test-collection) for details on what's available for your framework.
 
+### Relay OpenTelemetry traces
+
+For test collectors and OpenTelemetry SDKs that export OTLP/HTTP protobuf
+traces, bktec can receive those traces on loopback and relay them to Buildkite.
+Enable it on `bktec run` with:
+
+```sh
+export BUILDKITE_TESTS_OTLP_RELAY=true
+```
+
+The relay injects the standard `OTEL_EXPORTER_OTLP_TRACES_*` configuration into
+the test process, acknowledges local exports immediately, and retries delivery
+to Buildkite in the background. It obtains and refreshes the upstream credential
+through `buildkite-agent oidc request-token`; `--no-oidc` cannot be used with
+the relay. Exporters authenticate to the relay with a random, per-run local
+credential; existing collector upload credentials are left unchanged.
+
+After the final test attempt, bktec spends at most 10 seconds draining queued
+requests and prints the number of forwarded and dropped requests. Requests over
+900 KiB are rejected synchronously, and a full 64 MiB byte queue returns HTTP
+429 so the SDK can apply backpressure.
+
+The child resource also receives
+`buildkite.otlp.endpoint=<loopback URL>` through
+`OTEL_RESOURCE_ATTRIBUTES`. This is a Buildkite-specific attribute—OpenTelemetry
+does not define a semantic convention for the relay route—and lets stored spans
+show that their SDK exported through bktec without modifying the opaque OTLP
+payload in the relay.
+
 ### Plan identifier
 
 `--plan-identifier` (or `BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER`) sets the

--- a/cli.go
+++ b/cli.go
@@ -188,6 +188,24 @@ var oidcLifetimeFlag = &cli.DurationFlag{
 	Destination: &cfg.OIDCLifetime,
 }
 
+var otlpRelayFlag = &cli.BoolFlag{
+	Name:        "otlp-relay",
+	Category:    "TEST ENGINE",
+	Usage:       "Relay OTLP/HTTP traces from the test process to Buildkite using OIDC authentication",
+	Sources:     cli.EnvVars("BUILDKITE_TESTS_OTLP_RELAY"),
+	Destination: &cfg.OTLPRelay,
+}
+
+var otlpRelayUpstreamEndpointFlag = &cli.StringFlag{
+	Name:        "otlp-relay-upstream-endpoint",
+	Category:    "TEST ENGINE",
+	Usage:       "Upstream OTLP/HTTP traces endpoint",
+	Sources:     cli.EnvVars("BUILDKITE_TESTS_OTLP_RELAY_UPSTREAM_ENDPOINT"),
+	Value:       "https://tests-otlp.buildkite.com/v1/traces",
+	Destination: &cfg.OTLPRelayUpstreamEndpoint,
+	Hidden:      true,
+}
+
 var suiteSlugFlag = &cli.StringFlag{
 	Name:        "suite-slug",
 	Category:    "TEST ENGINE",
@@ -669,6 +687,7 @@ func runCommandFlags() []cli.Flag {
 	}
 	flags = append(flags, buildEnvironmentFlags...)
 	flags = append(flags, testEngineFlags...)
+	flags = append(flags, otlpRelayFlag, otlpRelayUpstreamEndpointFlag)
 	flags = append(flags, runnerEnvironmentFlags...)
 	flags = append(flags, parallelismFlag)
 	flags = append(flags, failOnNoTestsFlag)

--- a/cli_test.go
+++ b/cli_test.go
@@ -69,6 +69,17 @@ func TestPlanCommandIncludesParallelismFlag(t *testing.T) {
 	}
 }
 
+func TestOTLPRelayFlagsAreRunOnly(t *testing.T) {
+	for _, name := range []string{"otlp-relay", "otlp-relay-upstream-endpoint"} {
+		if !hasFlag(runCommandFlags(), name) {
+			t.Errorf("runCommandFlags() missing --%s", name)
+		}
+		if hasFlag(planCommandFlags(), name) {
+			t.Errorf("planCommandFlags() unexpectedly includes --%s", name)
+		}
+	}
+}
+
 func TestRunCommandDefaultsParallelismToOne(t *testing.T) {
 	cfg = config.New()
 	t.Cleanup(func() { cfg = config.New() })
@@ -257,6 +268,8 @@ func TestRunCommandEnvVarsBindToConfig(t *testing.T) {
 	t.Setenv("BUILDKITE_TEST_ENGINE_DEBUG_ENABLED", "true")
 	t.Setenv("BUILDKITE_TEST_ENGINE_OIDC", "false")
 	t.Setenv("BUILDKITE_TEST_ENGINE_OIDC_LIFETIME", "1h")
+	t.Setenv("BUILDKITE_TESTS_OTLP_RELAY", "true")
+	t.Setenv("BUILDKITE_TESTS_OTLP_RELAY_UPSTREAM_ENDPOINT", "https://otlp.example/v1/traces")
 	t.Setenv("BUILDKITE_TEST_ENGINE_TAGS", "env=production,region=us-east-1")
 
 	cmd := &cli.Command{
@@ -311,6 +324,8 @@ func TestRunCommandEnvVarsBindToConfig(t *testing.T) {
 		{"DebugEnabled", cfg.DebugEnabled, true},
 		{"OIDC", cfg.OIDC, false},
 		{"OIDCLifetime", cfg.OIDCLifetime, time.Hour},
+		{"OTLPRelay", cfg.OTLPRelay, true},
+		{"OTLPRelayUpstreamEndpoint", cfg.OTLPRelayUpstreamEndpoint, "https://otlp.example/v1/traces"},
 	}
 
 	for _, c := range checks {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -100,13 +100,13 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 	// execute tests
 	var timeline []api.Timeline
 	runResult, runErr := runTestsWithRetry(ctx, apiClient, cfg, testRunner, &thisNodeTask.Tests, cfg.MaxRetries, testPlan.MutedTests, &timeline, cfg.RetryForMutedTest, cfg.FailOnNoTests)
-	drainRelay()
 
 	// Abort immediately and propagate the error if the process was terminated by a signal,
 	// since the test results may be unreliable and cannot be trusted.
 	if ProcessSignaledError := new(runner.ProcessSignaledError); errors.As(runErr, &ProcessSignaledError) {
 		logSignalAndExit(testRunner.Name(), ProcessSignaledError.Signal)
 	}
+	drainRelay()
 
 	// Retries are now exhausted. If hard (non-muted) failures remain and the
 	// opt-in flag is set, declare an early failure to the Buildkite Agent API so

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/config"
 	"github.com/buildkite/test-engine-client/v3/internal/debug"
 	"github.com/buildkite/test-engine-client/v3/internal/git"
+	"github.com/buildkite/test-engine-client/v3/internal/otlprelay"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
 	"github.com/buildkite/test-engine-client/v3/internal/runner"
 	"github.com/buildkite/test-engine-client/v3/internal/version"
@@ -34,6 +35,28 @@ var newGitRunner = func() git.GitRunner { return &git.ExecGitRunner{} }
 
 func Run(ctx context.Context, cfg *config.Config, testListFilename string) error {
 	printStartUpMessage()
+
+	relay, err := startOTLPRelay(cfg)
+	if err != nil {
+		return err
+	}
+	drainRelay := func() {
+		if relay == nil {
+			return
+		}
+		drainCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		report := relay.Drain(drainCtx)
+		fmt.Printf(
+			"Buildkite Test Engine Client: OTLP relay: %d request(s) forwarded, %d dropped permanently, %d dropped at drain deadline, %d byte(s) dropped\n",
+			report.ForwardedRequests,
+			report.DroppedPermanentRequests,
+			report.DroppedDeadlineRequests,
+			report.DroppedBytes,
+		)
+		relay = nil
+	}
+	defer drainRelay()
 
 	testRunner, err := runner.DetectRunner(cfg)
 	if err != nil {
@@ -77,6 +100,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 	// execute tests
 	var timeline []api.Timeline
 	runResult, runErr := runTestsWithRetry(ctx, apiClient, cfg, testRunner, &thisNodeTask.Tests, cfg.MaxRetries, testPlan.MutedTests, &timeline, cfg.RetryForMutedTest, cfg.FailOnNoTests)
+	drainRelay()
 
 	// Abort immediately and propagate the error if the process was terminated by a signal,
 	// since the test results may be unreliable and cannot be trusted.
@@ -106,6 +130,34 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 	}
 
 	return runErr
+}
+
+func startOTLPRelay(cfg *config.Config) (*otlprelay.Relay, error) {
+	if !cfg.OTLPRelay {
+		return nil, nil
+	}
+
+	runKey := os.Getenv("BUILDKITE_ANALYTICS_KEY")
+	if runKey == "" {
+		runKey = cfg.BuildID
+	}
+	relay, err := otlprelay.New(otlprelay.Config{
+		UpstreamEndpoint: cfg.OTLPRelayUpstreamEndpoint,
+		RunKey:           runKey,
+		TokenLifetime:    cfg.OIDCLifetime,
+		CollectorToken:   cfg.UploadToken,
+		TokenSource:      cfg.RequestOIDCToken,
+		Logf: func(format string, args ...any) {
+			fmt.Printf(format+"\n", args...)
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start OTLP relay: %w", err)
+	}
+
+	cfg.TestProcessEnv = relay.Environment(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
+	fmt.Printf("Buildkite Test Engine Client: OTLP relay listening on %s\n", relay.Endpoint())
+	return relay, nil
 }
 
 func trimTaskLocationPrefix(task *plan.Task, locationPrefix string) error {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +25,68 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestStartOTLPRelayWiresTestEnvironmentAndOIDCForwarding(t *testing.T) {
+	t.Setenv("BUILDKITE_ANALYTICS_KEY", "custom-run-key")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=example")
+
+	received := make(chan *http.Request, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		received <- req.Clone(context.Background())
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		OTLPRelay:                 true,
+		OTLPRelayUpstreamEndpoint: upstream.URL,
+		OIDC:                      true,
+		OIDCLifetime:              time.Hour,
+		BuildkiteAgentCommand:     "../config/mock-buildkite-agent",
+		ServerBaseURL:             "https://api.buildkite.com",
+		OrganizationSlug:          "organization",
+		SuiteSlug:                 "suite",
+		BuildID:                   "build-id",
+	}
+	relay, err := startOTLPRelay(cfg)
+	if err != nil {
+		t.Fatalf("startOTLPRelay() error = %v", err)
+	}
+
+	localToken := cfg.TestProcessEnv["BUILDKITE_TESTS_OTLP_TOKEN"]
+	req, err := http.NewRequest(http.MethodPost, cfg.TestProcessEnv["BUILDKITE_ANALYTICS_OTLP_ENDPOINT"], bytes.NewReader([]byte("protobuf")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", `Token token="`+localToken+`"`)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST local OTLP request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("local OTLP status = %d, want 200", resp.StatusCode)
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if report.ForwardedRequests != 1 {
+		t.Errorf("Drain report = %+v, want one forwarded request", report)
+	}
+
+	upstreamRequest := <-received
+	if got := upstreamRequest.Header.Get("Authorization"); got != `Token token="mocktoken"` {
+		t.Errorf("upstream Authorization = %q, want refreshed OIDC token", got)
+	}
+	if got := upstreamRequest.Header.Get("Buildkite-Tests-Run-Key"); got != "custom-run-key" {
+		t.Errorf("upstream run key = %q, want custom-run-key", got)
+	}
+	if got := cfg.TestProcessEnv["OTEL_RESOURCE_ATTRIBUTES"]; !strings.Contains(got, "buildkite.otlp.endpoint=http://127.0.0.1:") {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q, want relay endpoint", got)
+	}
+}
 
 func TestRunTestsWithRetry(t *testing.T) {
 	testRunner := runner.NewRspec(runner.RunnerConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,10 @@ type Config struct {
 	OIDC bool `json:"-"`
 	// Lifetime of OIDC tokens
 	OIDCLifetime time.Duration `json:"-"`
+	// OTLPRelay enables the local OTLP/HTTP trace relay for the test process.
+	OTLPRelay bool `json:"-"`
+	// OTLPRelayUpstreamEndpoint is the Buildkite OTLP/HTTP traces endpoint.
+	OTLPRelayUpstreamEndpoint string `json:"-"`
 	// OrganizationSlug is the slug of the organization.
 	OrganizationSlug string `json:"-"`
 	// Output is the local file path for the export tarball. If set, skip S3 upload.
@@ -107,6 +111,10 @@ type Config struct {
 	TestFilePattern string `json:"-"`
 	// TestRunner is the name of the runner.
 	TestRunner string `json:"-"`
+	// TestProcessEnv contains trusted environment overrides added only to test
+	// runner subprocesses. It is populated after validation when a local service
+	// such as the OTLP relay starts.
+	TestProcessEnv map[string]string `json:"-"`
 
 	// Set to true if AccessToken was unset and an OIDC token was generated instead
 	accessTokenIsOIDC bool

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -103,6 +104,10 @@ func (c *Config) validate() error {
 // Validation for the `bktec run` command
 func (c *Config) ValidateForRun() error {
 	_ = c.validate()
+
+	if c.OTLPRelay && !c.OIDC {
+		c.errs.appendFieldError("BUILDKITE_TESTS_OTLP_RELAY", "requires OIDC authentication")
+	}
 
 	// result-path is only consumed when running tests (command construction and
 	// report parsing), so it is required here but not for `plan`. Checked as an
@@ -273,6 +278,13 @@ func (c *Config) ValidateForPlan() error {
 }
 
 func (c *Config) generateOIDCToken() (token string, err error) {
+	return c.RequestOIDCToken(context.Background())
+}
+
+// RequestOIDCToken asks the Buildkite agent for a suite-scoped OIDC token.
+// The context lets long-running users, such as the OTLP relay, stop an in-flight
+// agent invocation when their drain deadline expires.
+func (c *Config) RequestOIDCToken(ctx context.Context) (token string, err error) {
 	if !c.OIDC {
 		return "", nil
 	}
@@ -283,7 +295,7 @@ func (c *Config) generateOIDCToken() (token string, err error) {
 	lifetime := strconv.Itoa(int(c.OIDCLifetime.Seconds()))
 	// Skipping a security linter check here. The issue is "G204: Subprocess launched with a potential tainted input or cmd arguments"
 	// Given that running tainted input commands is bktec's raison d'etre this is acceptable.
-	cmd := exec.Command(c.BuildkiteAgentCommand, "oidc", "request-token", "--audience", suiteURL, "--lifetime", lifetime) //nolint:gosec
+	cmd := exec.CommandContext(ctx, c.BuildkiteAgentCommand, "oidc", "request-token", "--audience", suiteURL, "--lifetime", lifetime) //nolint:gosec
 	cmd.Stderr = &errorWriter
 	cmd.Stdout = &tokenWriter
 	cmd.Env = os.Environ()

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -30,6 +30,22 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestConfigValidateForRun_OTLPRelayRequiresOIDC(t *testing.T) {
+	c := createConfig()
+	c.OTLPRelay = true
+	c.OIDC = false
+	c.UploadToken = "upload-token"
+
+	err := c.ValidateForRun()
+	var invalidConfig InvalidConfigError
+	if !errors.As(err, &invalidConfig) {
+		t.Fatalf("ValidateForRun() error = %v, want InvalidConfigError", err)
+	}
+	if _, ok := invalidConfig["BUILDKITE_TESTS_OTLP_RELAY"]; !ok {
+		t.Errorf("ValidateForRun() error = %v, want OTLP relay OIDC error", invalidConfig)
+	}
+}
+
 func TestConfigValidate_CustomRunnerFilePatternWithSelectorList(t *testing.T) {
 	t.Run("requires a file pattern for the custom runner by default", func(t *testing.T) {
 		c := createConfig()

--- a/internal/otlprelay/relay.go
+++ b/internal/otlprelay/relay.go
@@ -1,0 +1,573 @@
+package otlprelay
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultUpstreamEndpoint = "https://tests-otlp.buildkite.com/v1/traces"
+	ResourceAttribute       = "buildkite.otlp.endpoint"
+
+	maxRequestBytes           = 900 * 1024
+	defaultQueueCapacity      = 64 * 1024 * 1024
+	defaultRequestTimeout     = 30 * time.Second
+	defaultInitialBackoff     = 250 * time.Millisecond
+	defaultMaxBackoff         = 5 * time.Second
+	defaultTokenLifetime      = 2 * time.Hour
+	defaultTokenRefreshLeeway = 5 * time.Minute
+)
+
+// Config contains the trusted values that bktec adds when forwarding an OTLP
+// request. The test process supplies only the opaque protobuf body and its
+// content encoding.
+type Config struct {
+	UpstreamEndpoint string
+	RunKey           string
+	QueueCapacity    int
+	TokenLifetime    time.Duration
+	CollectorToken   string
+	TokenSource      func(context.Context) (string, error)
+	HTTPClient       *http.Client
+	Logf             func(string, ...any)
+
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+// Report summarizes requests delivered or dropped by a relay.
+type Report struct {
+	ForwardedRequests        int
+	DroppedPermanentRequests int
+	DroppedDeadlineRequests  int
+	DroppedBytes             int64
+}
+
+type request struct {
+	body            []byte
+	contentEncoding string
+}
+
+type deliveryResult int
+
+const (
+	deliveryForwarded deliveryResult = iota
+	deliveryPermanentFailure
+	deliveryDeadline
+)
+
+// Relay accepts authenticated OTLP/HTTP protobuf requests on loopback and
+// forwards their byte-exact bodies to Buildkite from one background worker.
+type Relay struct {
+	config Config
+
+	endpoint string
+	token    string
+
+	server *http.Server
+	client *http.Client
+
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wake         chan struct{}
+	drainStarted chan struct{}
+	done         chan struct{}
+
+	mu              sync.Mutex
+	queue           []*request
+	queuedBytes     int
+	accepting       bool
+	draining        bool
+	drainDeadline   time.Time
+	drainRetryDelay time.Duration
+	report          Report
+
+	upstreamToken  string
+	tokenRefreshAt time.Time
+}
+
+// New starts a relay on a random 127.0.0.1 TCP port.
+func New(config Config) (*Relay, error) {
+	if config.UpstreamEndpoint == "" {
+		config.UpstreamEndpoint = DefaultUpstreamEndpoint
+	}
+	upstreamURL, err := url.ParseRequestURI(config.UpstreamEndpoint)
+	if err != nil || upstreamURL.Host == "" || (upstreamURL.Scheme != "http" && upstreamURL.Scheme != "https") {
+		return nil, fmt.Errorf("invalid OTLP upstream endpoint %q", config.UpstreamEndpoint)
+	}
+	if !validRunKey(config.RunKey) {
+		return nil, fmt.Errorf("invalid Buildkite test run key")
+	}
+	if config.TokenSource == nil {
+		return nil, fmt.Errorf("OTLP relay token source is required")
+	}
+	if config.QueueCapacity == 0 {
+		config.QueueCapacity = defaultQueueCapacity
+	}
+	if config.QueueCapacity < 1 {
+		return nil, fmt.Errorf("OTLP relay queue capacity must be greater than zero")
+	}
+	if config.TokenLifetime <= 0 {
+		config.TokenLifetime = defaultTokenLifetime
+	}
+	if config.initialBackoff <= 0 {
+		config.initialBackoff = defaultInitialBackoff
+	}
+	if config.maxBackoff <= 0 {
+		config.maxBackoff = defaultMaxBackoff
+	}
+	if config.Logf == nil {
+		config.Logf = func(string, ...any) {}
+	}
+
+	localTokenBytes := make([]byte, 32)
+	if _, err := rand.Read(localTokenBytes); err != nil {
+		return nil, fmt.Errorf("generate OTLP relay token: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("start OTLP relay listener: %w", err)
+	}
+
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{
+			Timeout: defaultRequestTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	relay := &Relay{
+		config:       config,
+		endpoint:     "http://" + listener.Addr().String(),
+		token:        base64.RawURLEncoding.EncodeToString(localTokenBytes),
+		client:       client,
+		ctx:          ctx,
+		cancel:       cancel,
+		wake:         make(chan struct{}, 1),
+		drainStarted: make(chan struct{}),
+		done:         make(chan struct{}),
+		accepting:    true,
+	}
+	if _, err := relay.authorizationToken(); err != nil {
+		cancel()
+		_ = listener.Close()
+		return nil, fmt.Errorf("get initial OTLP relay credential: %w", err)
+	}
+	relay.server = &http.Server{
+		Handler:           relay,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		MaxHeaderBytes:    16 * 1024,
+	}
+
+	go func() {
+		if err := relay.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			relay.config.Logf("Buildkite Test Engine Client: OTLP relay listener stopped: %v", err)
+		}
+	}()
+	go relay.forward()
+
+	return relay, nil
+}
+
+// Endpoint is the credential-free loopback base URL advertised to OTel SDKs.
+func (r *Relay) Endpoint() string {
+	return r.endpoint
+}
+
+// Environment returns the child-process environment needed by standard OTel
+// SDKs and by Buildkite's Ruby test collector. Existing resource attributes
+// are retained.
+func (r *Relay) Environment(resourceAttributes string) map[string]string {
+	traceEndpoint := r.endpoint + "/v1/traces"
+	headers := "authorization=" + url.PathEscape("Bearer "+r.token)
+	relayAttribute := ResourceAttribute + "=" + traceEndpoint
+	if resourceAttributes != "" {
+		relayAttribute = resourceAttributes + "," + relayAttribute
+	}
+
+	return map[string]string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT":        r.endpoint,
+		"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": traceEndpoint,
+		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  headers,
+		"OTEL_RESOURCE_ATTRIBUTES":           relayAttribute,
+		"BUILDKITE_ANALYTICS_OTLP_ENDPOINT":  traceEndpoint,
+		"BUILDKITE_TESTS_OTLP_TOKEN":         r.token,
+	}
+}
+
+func (r *Relay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if !r.authorized(req.Header.Get("Authorization")) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	if req.URL.Path != "/v1/traces" {
+		http.NotFound(w, req)
+		return
+	}
+	if req.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if req.Header.Get("Content-Type") != "application/x-protobuf" {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
+
+	contentEncoding := strings.ToLower(strings.TrimSpace(req.Header.Get("Content-Encoding")))
+	if contentEncoding != "" && contentEncoding != "gzip" {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
+	if req.ContentLength > maxRequestBytes {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxRequestBytes+1))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxRequestBytes {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	if !r.enqueue(&request{body: body, contentEncoding: contentEncoding}) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.WriteHeader(http.StatusOK)
+}
+
+func (r *Relay) authorized(got string) bool {
+	bearer := "Bearer " + r.token
+	collector := `Token token="` + r.token + `"`
+	valid := subtle.ConstantTimeCompare([]byte(got), []byte(bearer)) |
+		subtle.ConstantTimeCompare([]byte(got), []byte(collector))
+	if r.config.CollectorToken != "" {
+		existingCollector := `Token token="` + r.config.CollectorToken + `"`
+		valid |= subtle.ConstantTimeCompare([]byte(got), []byte(existingCollector))
+	}
+	return valid == 1
+}
+
+func (r *Relay) enqueue(req *request) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.accepting || r.queuedBytes+len(req.body) > r.config.QueueCapacity {
+		return false
+	}
+	r.queue = append(r.queue, req)
+	r.queuedBytes += len(req.body)
+	r.signal()
+	return true
+}
+
+func (r *Relay) signal() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Relay) forward() {
+	defer close(r.done)
+
+	for {
+		req, ok := r.nextRequest()
+		if !ok {
+			if r.ctx.Err() != nil {
+				r.dropRemainingAtDeadline()
+			}
+			return
+		}
+
+		result := r.deliver(req)
+		switch result {
+		case deliveryForwarded:
+			r.complete(req, true)
+		case deliveryPermanentFailure:
+			r.complete(req, false)
+		case deliveryDeadline:
+			r.dropRemainingAtDeadline()
+			return
+		}
+	}
+}
+
+func (r *Relay) nextRequest() (*request, bool) {
+	for {
+		r.mu.Lock()
+		if len(r.queue) > 0 {
+			req := r.queue[0]
+			r.mu.Unlock()
+			return req, true
+		}
+		if r.draining {
+			r.mu.Unlock()
+			return nil, false
+		}
+		r.mu.Unlock()
+
+		select {
+		case <-r.wake:
+		case <-r.ctx.Done():
+			return nil, false
+		}
+	}
+}
+
+func (r *Relay) deliver(queued *request) deliveryResult {
+	backoff := r.config.initialBackoff
+	for {
+		token, err := r.authorizationToken()
+		var status int
+		var retryAfter time.Duration
+		var hasRetryAfter bool
+		if err == nil {
+			status, retryAfter, hasRetryAfter, err = r.send(queued, token)
+		}
+
+		if err == nil {
+			switch {
+			case status >= 200 && status < 300:
+				return deliveryForwarded
+			case status != http.StatusRequestTimeout && status != http.StatusTooManyRequests && status < 500:
+				r.config.Logf("Buildkite Test Engine Client: OTLP relay dropped a request after upstream returned HTTP %d", status)
+				return deliveryPermanentFailure
+			}
+		}
+		if r.ctx.Err() != nil {
+			return deliveryDeadline
+		}
+
+		delay := backoff
+		if hasRetryAfter {
+			delay = retryAfter
+		}
+		if !r.waitForRetry(delay) {
+			return deliveryDeadline
+		}
+		backoff = min(backoff*2, r.config.maxBackoff)
+	}
+}
+
+func (r *Relay) waitForRetry(delay time.Duration) bool {
+	for {
+		r.mu.Lock()
+		draining := r.draining
+		r.mu.Unlock()
+
+		timer := time.NewTimer(r.clampRetryDelay(delay))
+		drainStarted := r.drainStarted
+		if draining {
+			drainStarted = nil
+		}
+		select {
+		case <-timer.C:
+			return true
+		case <-drainStarted:
+			timer.Stop()
+		case <-r.ctx.Done():
+			timer.Stop()
+			return false
+		}
+	}
+}
+
+func (r *Relay) send(queued *request, token string) (int, time.Duration, bool, error) {
+	req, err := http.NewRequestWithContext(r.ctx, http.MethodPost, r.config.UpstreamEndpoint, bytes.NewReader(queued.body))
+	if err != nil {
+		return 0, 0, false, err
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if queued.contentEncoding != "" {
+		req.Header.Set("Content-Encoding", queued.contentEncoding)
+	}
+	req.Header.Set("Authorization", `Token token="`+token+`"`)
+	req.Header.Set("Buildkite-Tests-Run-Key", r.config.RunKey)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4*1024))
+	_ = resp.Body.Close()
+
+	retryAfter, hasRetryAfter := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now())
+	return resp.StatusCode, retryAfter, hasRetryAfter, nil
+}
+
+func (r *Relay) authorizationToken() (string, error) {
+	now := time.Now()
+	if r.upstreamToken != "" && now.Before(r.tokenRefreshAt) {
+		return r.upstreamToken, nil
+	}
+
+	token, err := r.config.TokenSource(r.ctx)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(token) == "" {
+		return "", fmt.Errorf("OIDC token source returned an empty token")
+	}
+	r.upstreamToken = strings.TrimSpace(token)
+	r.tokenRefreshAt = tokenRefreshTime(r.upstreamToken, now, r.config.TokenLifetime)
+	return r.upstreamToken, nil
+}
+
+func tokenRefreshTime(token string, now time.Time, fallbackLifetime time.Duration) time.Time {
+	expiresAt := now.Add(fallbackLifetime)
+	parts := strings.Split(token, ".")
+	if len(parts) == 3 {
+		if payload, err := base64.RawURLEncoding.DecodeString(parts[1]); err == nil {
+			var claims struct {
+				ExpiresAt int64 `json:"exp"`
+			}
+			if json.Unmarshal(payload, &claims) == nil && claims.ExpiresAt > 0 {
+				expiresAt = time.Unix(claims.ExpiresAt, 0)
+			}
+		}
+	}
+
+	lifetime := expiresAt.Sub(now)
+	if lifetime <= 0 {
+		return now
+	}
+	leeway := min(defaultTokenRefreshLeeway, lifetime/10)
+	return expiresAt.Add(-leeway)
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second, true
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		return max(retryAt.Sub(now), 0), true
+	}
+	return 0, false
+}
+
+func (r *Relay) clampRetryDelay(delay time.Duration) time.Duration {
+	r.mu.Lock()
+	deadline := r.drainDeadline
+	drainDelay := r.drainRetryDelay
+	r.mu.Unlock()
+	if deadline.IsZero() {
+		return delay
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	return min(drainDelay, remaining)
+}
+
+func (r *Relay) complete(req *request, forwarded bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.queue) == 0 || r.queue[0] != req {
+		return
+	}
+	r.queue[0] = nil
+	r.queue = r.queue[1:]
+	r.queuedBytes -= len(req.body)
+	if forwarded {
+		r.report.ForwardedRequests++
+	} else {
+		r.report.DroppedPermanentRequests++
+		r.report.DroppedBytes += int64(len(req.body))
+	}
+}
+
+func (r *Relay) dropRemainingAtDeadline() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.report.DroppedDeadlineRequests += len(r.queue)
+	r.report.DroppedBytes += int64(r.queuedBytes)
+	r.queue = nil
+	r.queuedBytes = 0
+}
+
+// Drain stops accepting requests and waits for queued requests to be delivered
+// until ctx expires. The deadline always wins over an in-flight request or
+// retry delay.
+func (r *Relay) Drain(ctx context.Context) Report {
+	r.mu.Lock()
+	firstDrain := !r.draining
+	r.draining = true
+	r.accepting = false
+	if deadline, ok := ctx.Deadline(); ok {
+		r.drainDeadline = deadline
+		r.drainRetryDelay = max(time.Until(deadline)/3, time.Nanosecond)
+	}
+	r.mu.Unlock()
+	if firstDrain {
+		close(r.drainStarted)
+	}
+	r.signal()
+
+	if firstDrain {
+		if err := r.server.Shutdown(ctx); err != nil {
+			_ = r.server.Close()
+		}
+	}
+
+	select {
+	case <-r.done:
+	case <-ctx.Done():
+		r.cancel()
+		_ = r.server.Close()
+		<-r.done
+	}
+	r.cancel()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.report
+}
+
+func validRunKey(runKey string) bool {
+	if len(runKey) < 1 || len(runKey) > 255 {
+		return false
+	}
+	for _, char := range []byte(runKey) {
+		if char < '!' || char > '~' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/otlprelay/relay.go
+++ b/internal/otlprelay/relay.go
@@ -25,6 +25,7 @@ const (
 
 	maxRequestBytes           = 900 * 1024
 	defaultQueueCapacity      = 64 * 1024 * 1024
+	queueRequestOverhead      = 1024 // Account for object and slice overhead, even with an empty body.
 	defaultRequestTimeout     = 30 * time.Second
 	defaultInitialBackoff     = 250 * time.Millisecond
 	defaultMaxBackoff         = 5 * time.Second
@@ -89,7 +90,7 @@ type Relay struct {
 
 	mu              sync.Mutex
 	queue           []*request
-	queuedBytes     int
+	queuedSize      int
 	accepting       bool
 	draining        bool
 	drainDeadline   time.Time
@@ -206,8 +207,6 @@ func (r *Relay) Environment(resourceAttributes string) map[string]string {
 	}
 
 	return map[string]string{
-		"OTEL_EXPORTER_OTLP_ENDPOINT":        r.endpoint,
-		"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
 		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": traceEndpoint,
 		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
 		"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  headers,
@@ -282,11 +281,12 @@ func (r *Relay) enqueue(req *request) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if !r.accepting || r.queuedBytes+len(req.body) > r.config.QueueCapacity {
+	size := len(req.body) + queueRequestOverhead
+	if !r.accepting || r.queuedSize+size > r.config.QueueCapacity {
 		return false
 	}
 	r.queue = append(r.queue, req)
-	r.queuedBytes += len(req.body)
+	r.queuedSize += size
 	r.signal()
 	return true
 }
@@ -503,7 +503,7 @@ func (r *Relay) complete(req *request, forwarded bool) {
 	}
 	r.queue[0] = nil
 	r.queue = r.queue[1:]
-	r.queuedBytes -= len(req.body)
+	r.queuedSize -= len(req.body) + queueRequestOverhead
 	if forwarded {
 		r.report.ForwardedRequests++
 	} else {
@@ -517,9 +517,11 @@ func (r *Relay) dropRemainingAtDeadline() {
 	defer r.mu.Unlock()
 
 	r.report.DroppedDeadlineRequests += len(r.queue)
-	r.report.DroppedBytes += int64(r.queuedBytes)
+	for _, req := range r.queue {
+		r.report.DroppedBytes += int64(len(req.body))
+	}
 	r.queue = nil
-	r.queuedBytes = 0
+	r.queuedSize = 0
 }
 
 // Drain stops accepting requests and waits for queued requests to be delivered

--- a/internal/otlprelay/relay_test.go
+++ b/internal/otlprelay/relay_test.go
@@ -1,0 +1,547 @@
+package otlprelay
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRelayForwardsOpaqueGzipRequestWithTrustedHeaders(t *testing.T) {
+	body := []byte("opaque compressed protobuf bytes")
+	type receivedRequest struct {
+		body            []byte
+		authorization   string
+		runKey          string
+		contentType     string
+		contentEncoding string
+	}
+	received := make(chan receivedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotBody, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("read upstream request: %v", err)
+		}
+		received <- receivedRequest{
+			body:            gotBody,
+			authorization:   req.Header.Get("Authorization"),
+			runKey:          req.Header.Get("Buildkite-Tests-Run-Key"),
+			contentType:     req.Header.Get("Content-Type"),
+			contentEncoding: req.Header.Get("Content-Encoding"),
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	var tokenRequests atomic.Int32
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource: func(context.Context) (string, error) {
+			tokenRequests.Add(1)
+			return "oidc-token", nil
+		},
+	})
+
+	resp := postTraces(t, relay, body, "Bearer "+relay.token, "gzip")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /v1/traces status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/x-protobuf" {
+		t.Errorf("response Content-Type = %q, want application/x-protobuf", got)
+	}
+	_ = resp.Body.Close()
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if report != (Report{ForwardedRequests: 1}) {
+		t.Errorf("Drain report = %+v, want one forwarded request", report)
+	}
+
+	got := <-received
+	if !bytes.Equal(got.body, body) {
+		t.Errorf("upstream body = %q, want byte-exact %q", got.body, body)
+	}
+	if got.authorization != `Token token="oidc-token"` {
+		t.Errorf("upstream Authorization = %q", got.authorization)
+	}
+	if got.runKey != "build-id" {
+		t.Errorf("upstream Buildkite-Tests-Run-Key = %q, want build-id", got.runKey)
+	}
+	if got.contentType != "application/x-protobuf" {
+		t.Errorf("upstream Content-Type = %q", got.contentType)
+	}
+	if got.contentEncoding != "gzip" {
+		t.Errorf("upstream Content-Encoding = %q, want gzip", got.contentEncoding)
+	}
+	if got := tokenRequests.Load(); got != 1 {
+		t.Errorf("OIDC token requests = %d, want 1", got)
+	}
+}
+
+func TestRelayFailsToStartWhenInitialOIDCTokenIsUnavailable(t *testing.T) {
+	_, err := New(Config{
+		UpstreamEndpoint: "http://127.0.0.1:1/v1/traces",
+		RunKey:           "build-id",
+		TokenSource: func(context.Context) (string, error) {
+			return "", fmt.Errorf("agent unavailable")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "agent unavailable") {
+		t.Fatalf("New() error = %v, want initial credential error", err)
+	}
+}
+
+func TestRelayAcknowledgesBeforeDeliveryAndReturns429WhenByteQueueIsFull(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	body := []byte("full")
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		QueueCapacity:    len(body),
+		TokenSource:      staticToken("oidc-token"),
+	})
+
+	first := postTraces(t, relay, body, "Bearer "+relay.token, "")
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first POST status = %d, want 200", first.StatusCode)
+	}
+	_ = first.Body.Close()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("upstream delivery did not start")
+	}
+
+	second := postTraces(t, relay, []byte("x"), "Bearer "+relay.token, "")
+	if second.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("second POST status = %d, want 429", second.StatusCode)
+	}
+	_ = second.Body.Close()
+
+	close(release)
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if report.ForwardedRequests != 1 || report.DroppedBytes != 0 {
+		t.Errorf("Drain report = %+v, want one forwarded request and no silent drop", report)
+	}
+}
+
+func TestRelayRetriesRetryableResponses(t *testing.T) {
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	resp := postTraces(t, relay, []byte("request"), `Token token="`+relay.token+`"`, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST status = %d, want 200", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if got := requests.Load(); got != 2 {
+		t.Errorf("upstream requests = %d, want 2", got)
+	}
+	if report != (Report{ForwardedRequests: 1}) {
+		t.Errorf("Drain report = %+v, want one forwarded request", report)
+	}
+}
+
+func TestRelayRefreshesExpiredOIDCTokenWhileRetrying(t *testing.T) {
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requestNumber := requests.Add(1)
+		if requestNumber == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if got := req.Header.Get("Authorization"); got != `Token token="fresh-token"` {
+			t.Errorf("refreshed Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	var tokenRequests atomic.Int32
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource: func(context.Context) (string, error) {
+			if tokenRequests.Add(1) == 1 {
+				payload := base64.RawURLEncoding.EncodeToString([]byte(`{"exp":1}`))
+				return "header." + payload + ".signature", nil
+			}
+			return "fresh-token", nil
+		},
+	})
+	resp := postTraces(t, relay, []byte("request"), "Bearer "+relay.token, "")
+	_ = resp.Body.Close()
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if report != (Report{ForwardedRequests: 1}) {
+		t.Errorf("Drain report = %+v, want one forwarded request", report)
+	}
+	if got := tokenRequests.Load(); got != 2 {
+		t.Errorf("OIDC token requests = %d, want refresh after expiry", got)
+	}
+}
+
+func TestRelayDropsPermanent4xx(t *testing.T) {
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer upstream.Close()
+
+	body := []byte("request")
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	resp := postTraces(t, relay, body, "Bearer "+relay.token, "")
+	_ = resp.Body.Close()
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	if got := requests.Load(); got != 1 {
+		t.Errorf("upstream requests = %d, want no retry", got)
+	}
+	want := Report{DroppedPermanentRequests: 1, DroppedBytes: int64(len(body))}
+	if report != want {
+		t.Errorf("Drain report = %+v, want %+v", report, want)
+	}
+}
+
+func TestRelayDrainDeadlineCancelsDeliveryAndReportsDrops(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+	}))
+	defer upstream.Close()
+
+	body := []byte("request")
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	resp := postTraces(t, relay, body, "Bearer "+relay.token, "")
+	_ = resp.Body.Close()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("upstream delivery did not start")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+	close(release)
+	want := Report{DroppedDeadlineRequests: 1, DroppedBytes: int64(len(body))}
+	if report != want {
+		t.Errorf("Drain report = %+v, want %+v", report, want)
+	}
+}
+
+func TestRelayDrainLimitsRetryAttempts(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	body := []byte("request")
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	resp := postTraces(t, relay, body, "Bearer "+relay.token, "")
+	_ = resp.Body.Close()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("upstream delivery did not start")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+	reportCh := make(chan Report, 1)
+	go func() { reportCh <- relay.Drain(drainCtx) }()
+	for {
+		relay.mu.Lock()
+		draining := relay.draining
+		relay.mu.Unlock()
+		if draining {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	report := <-reportCh
+
+	if got := requests.Load(); got > 4 {
+		t.Errorf("upstream requests during drain = %d, want at most 4", got)
+	}
+	want := Report{DroppedDeadlineRequests: 1, DroppedBytes: int64(len(body))}
+	if report != want {
+		t.Errorf("Drain report = %+v, want %+v", report, want)
+	}
+}
+
+func TestRelayDrainInterruptsExistingRetryDelay(t *testing.T) {
+	var requests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	body := []byte("request")
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: upstream.URL,
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	resp := postTraces(t, relay, body, "Bearer "+relay.token, "")
+	_ = resp.Body.Close()
+	deadline := time.Now().Add(time.Second)
+	for requests.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if requests.Load() == 0 {
+		t.Fatal("upstream delivery did not start")
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+	report := relay.Drain(drainCtx)
+
+	if got := requests.Load(); got < 2 || got > 4 {
+		t.Errorf("upstream requests = %d, want 2 to 4 after interrupting Retry-After", got)
+	}
+	want := Report{DroppedDeadlineRequests: 1, DroppedBytes: int64(len(body))}
+	if report != want {
+		t.Errorf("Drain report = %+v, want %+v", report, want)
+	}
+}
+
+func TestRelayRejectsInvalidLocalRequestsSynchronously(t *testing.T) {
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: "http://127.0.0.1:1/v1/traces",
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		auth        string
+		contentType string
+		encoding    string
+		body        []byte
+		wantStatus  int
+	}{
+		{name: "authorization", method: http.MethodPost, path: "/v1/traces", contentType: "application/x-protobuf", body: []byte("x"), wantStatus: http.StatusUnauthorized},
+		{name: "path", method: http.MethodPost, path: "/v1/metrics", auth: "Bearer " + relay.token, contentType: "application/x-protobuf", body: []byte("x"), wantStatus: http.StatusNotFound},
+		{name: "method", method: http.MethodGet, path: "/v1/traces", auth: "Bearer " + relay.token, contentType: "application/x-protobuf", wantStatus: http.StatusMethodNotAllowed},
+		{name: "content type", method: http.MethodPost, path: "/v1/traces", auth: "Bearer " + relay.token, contentType: "application/json", body: []byte("x"), wantStatus: http.StatusUnsupportedMediaType},
+		{name: "content encoding", method: http.MethodPost, path: "/v1/traces", auth: "Bearer " + relay.token, contentType: "application/x-protobuf", encoding: "br", body: []byte("x"), wantStatus: http.StatusUnsupportedMediaType},
+		{name: "wire size", method: http.MethodPost, path: "/v1/traces", auth: "Bearer " + relay.token, contentType: "application/x-protobuf", body: bytes.Repeat([]byte("x"), maxRequestBytes+1), wantStatus: http.StatusRequestEntityTooLarge},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(test.method, relay.endpoint+test.path, bytes.NewReader(test.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", test.auth)
+			req.Header.Set("Content-Type", test.contentType)
+			if test.encoding != "" {
+				req.Header.Set("Content-Encoding", test.encoding)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("local request: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != test.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, test.wantStatus)
+			}
+		})
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if report := relay.Drain(drainCtx); report != (Report{}) {
+		t.Errorf("Drain report = %+v, want empty", report)
+	}
+}
+
+func TestRelayAcceptsExistingCollectorToken(t *testing.T) {
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: "http://127.0.0.1:1/v1/traces",
+		RunKey:           "build-id",
+		CollectorToken:   "existing-upload-token",
+		TokenSource:      staticToken("oidc-token"),
+	})
+
+	if !relay.authorized(`Token token="existing-upload-token"`) {
+		t.Error("existing collector token was not accepted by the local relay")
+	}
+	if relay.authorized(`Token token="different-token"`) {
+		t.Error("unexpected collector token was accepted by the local relay")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	relay.Drain(drainCtx)
+}
+
+func TestRelayEnvironmentUsesStandardVariablesAndPreservesResourceAttributes(t *testing.T) {
+	relay := newTestRelay(t, Config{
+		UpstreamEndpoint: "http://127.0.0.1:1/v1/traces",
+		RunKey:           "build-id",
+		TokenSource:      staticToken("oidc-token"),
+	})
+	environment := relay.Environment("service.name=example")
+
+	if got := environment["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != relay.endpoint {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q", got, relay.endpoint)
+	}
+	if got := environment["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]; got != relay.endpoint+"/v1/traces" {
+		t.Errorf("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = %q", got)
+	}
+	if got := environment["OTEL_EXPORTER_OTLP_TRACES_HEADERS"]; got != "authorization=Bearer%20"+relay.token {
+		t.Errorf("OTEL_EXPORTER_OTLP_TRACES_HEADERS = %q", got)
+	}
+	if got := environment["OTEL_RESOURCE_ATTRIBUTES"]; got != "service.name=example,"+ResourceAttribute+"="+relay.endpoint+"/v1/traces" {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES = %q", got)
+	}
+	if got := environment["BUILDKITE_TESTS_OTLP_TOKEN"]; got != relay.token {
+		t.Errorf("BUILDKITE_TESTS_OTLP_TOKEN does not contain the local token")
+	}
+	if _, ok := environment["BUILDKITE_ANALYTICS_TOKEN"]; ok {
+		t.Error("relay environment overrides the collector upload token")
+	}
+	if strings.Contains(environment["OTEL_EXPORTER_OTLP_ENDPOINT"], relay.token) {
+		t.Error("advertised endpoint contains local credentials")
+	}
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	relay.Drain(drainCtx)
+}
+
+func TestTokenRefreshTimeUsesJWTExpiry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, now.Add(time.Hour).Unix())))
+	token := "header." + payload + ".signature"
+
+	got := tokenRefreshTime(token, now, 24*time.Hour)
+	want := now.Add(55 * time.Minute)
+	if !got.Equal(want) {
+		t.Errorf("tokenRefreshTime() = %s, want %s", got, want)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		value string
+		want  time.Duration
+		ok    bool
+	}{
+		{value: "12", want: 12 * time.Second, ok: true},
+		{value: now.Add(20 * time.Second).UTC().Format(http.TimeFormat), want: 20 * time.Second, ok: true},
+		{value: "invalid"},
+	}
+	for _, test := range tests {
+		got, ok := parseRetryAfter(test.value, now)
+		if got != test.want || ok != test.ok {
+			t.Errorf("parseRetryAfter(%q) = (%s, %t), want (%s, %t)", test.value, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func newTestRelay(t *testing.T, config Config) *Relay {
+	t.Helper()
+	config.initialBackoff = time.Millisecond
+	config.maxBackoff = 5 * time.Millisecond
+	relay, err := New(config)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return relay
+}
+
+func staticToken(token string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+func postTraces(t *testing.T, relay *Relay, body []byte, authorization, contentEncoding string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, relay.endpoint+"/v1/traces", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST local OTLP request: %v", err)
+	}
+	return resp
+}

--- a/internal/otlprelay/relay_test.go
+++ b/internal/otlprelay/relay_test.go
@@ -101,7 +101,7 @@ func TestRelayFailsToStartWhenInitialOIDCTokenIsUnavailable(t *testing.T) {
 	}
 }
 
-func TestRelayAcknowledgesBeforeDeliveryAndReturns429WhenByteQueueIsFull(t *testing.T) {
+func TestRelayAcknowledgesBeforeDeliveryAndReturns429WhenQueueIsFull(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -115,7 +115,7 @@ func TestRelayAcknowledgesBeforeDeliveryAndReturns429WhenByteQueueIsFull(t *test
 	relay := newTestRelay(t, Config{
 		UpstreamEndpoint: upstream.URL,
 		RunKey:           "build-id",
-		QueueCapacity:    len(body),
+		QueueCapacity:    len(body) + queueRequestOverhead,
 		TokenSource:      staticToken("oidc-token"),
 	})
 
@@ -130,7 +130,7 @@ func TestRelayAcknowledgesBeforeDeliveryAndReturns429WhenByteQueueIsFull(t *test
 		t.Fatal("upstream delivery did not start")
 	}
 
-	second := postTraces(t, relay, []byte("x"), "Bearer "+relay.token, "")
+	second := postTraces(t, relay, nil, "Bearer "+relay.token, "")
 	if second.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("second POST status = %d, want 429", second.StatusCode)
 	}
@@ -455,8 +455,11 @@ func TestRelayEnvironmentUsesStandardVariablesAndPreservesResourceAttributes(t *
 	})
 	environment := relay.Environment("service.name=example")
 
-	if got := environment["OTEL_EXPORTER_OTLP_ENDPOINT"]; got != relay.endpoint {
-		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q", got, relay.endpoint)
+	if _, ok := environment["OTEL_EXPORTER_OTLP_ENDPOINT"]; ok {
+		t.Error("relay environment overrides the generic OTLP endpoint")
+	}
+	if _, ok := environment["OTEL_EXPORTER_OTLP_PROTOCOL"]; ok {
+		t.Error("relay environment overrides the generic OTLP protocol")
 	}
 	if got := environment["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]; got != relay.endpoint+"/v1/traces" {
 		t.Errorf("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = %q", got)
@@ -473,7 +476,7 @@ func TestRelayEnvironmentUsesStandardVariablesAndPreservesResourceAttributes(t *
 	if _, ok := environment["BUILDKITE_ANALYTICS_TOKEN"]; ok {
 		t.Error("relay environment overrides the collector upload token")
 	}
-	if strings.Contains(environment["OTEL_EXPORTER_OTLP_ENDPOINT"], relay.token) {
+	if strings.Contains(environment["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"], relay.token) {
 		t.Error("advertised endpoint contains local credentials")
 	}
 

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
@@ -19,12 +20,32 @@ func buildCommand(runner TestRunner, testCases []plan.TestCase, retry bool) (*ex
 
 	cmd := exec.Command(commandName, commandArgs...)
 
-	env := os.Environ()
-	analyticsTokenEnv := fmt.Sprintf("BUILDKITE_ANALYTICS_TOKEN=%s", runner.UploadToken())
-	env = append(env, analyticsTokenEnv)
-	cmd.Env = env
+	overrides := map[string]string{
+		"BUILDKITE_ANALYTICS_TOKEN": runner.UploadToken(),
+	}
+	if provider, ok := runner.(interface{ testProcessEnvironment() map[string]string }); ok {
+		for key, value := range provider.testProcessEnvironment() {
+			overrides[key] = value
+		}
+	}
+	cmd.Env = environmentWithOverrides(os.Environ(), overrides)
 
 	return cmd, nil
+}
+
+func environmentWithOverrides(environment []string, overrides map[string]string) []string {
+	result := make([]string, 0, len(environment)+len(overrides))
+	for _, entry := range environment {
+		key, _, found := strings.Cut(entry, "=")
+		if _, overridden := overrides[key]; found && overridden {
+			continue
+		}
+		result = append(result, entry)
+	}
+	for key, value := range overrides {
+		result = append(result, fmt.Sprintf("%s=%s", key, value))
+	}
+	return result
 }
 
 // runAndForwardSignal runs the command and forwards any signals received to the command.

--- a/internal/runner/command_test.go
+++ b/internal/runner/command_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -67,5 +68,57 @@ func TestRunAndForwardSignal_SignalReceivedInSubProcess(t *testing.T) {
 	}
 	if signalError.Signal != syscall.SIGSEGV {
 		t.Errorf("runAndForwardSignal(cmd) signal = %d, want  %d", syscall.SIGSEGV, signalError.Signal)
+	}
+}
+
+func TestEnvironmentWithOverridesReplacesInheritedValues(t *testing.T) {
+	got := environmentWithOverrides(
+		[]string{"KEEP=original", "TOKEN=old", "TOKEN=duplicate"},
+		map[string]string{"TOKEN": "local", "ADDED": "value"},
+	)
+
+	values := make(map[string]string)
+	for _, entry := range got {
+		key, value, _ := strings.Cut(entry, "=")
+		if _, duplicate := values[key]; duplicate {
+			t.Errorf("environment contains duplicate key %q: %v", key, got)
+		}
+		values[key] = value
+	}
+	want := map[string]string{"KEEP": "original", "TOKEN": "local", "ADDED": "value"}
+	if len(values) != len(want) {
+		t.Fatalf("environmentWithOverrides() = %v, want %v", values, want)
+	}
+	for key, value := range want {
+		if values[key] != value {
+			t.Errorf("environmentWithOverrides()[%q] = %q, want %q", key, values[key], value)
+		}
+	}
+}
+
+func TestBuildCommandUsesTestProcessEnvironment(t *testing.T) {
+	testRunner := NewRspec(RunnerConfig{
+		TestCommand:    "echo {{testExamples}}",
+		uploadToken:    "upstream-token",
+		testProcessEnv: map[string]string{"BUILDKITE_TESTS_OTLP_TOKEN": "local-token", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://127.0.0.1:1234/v1/traces"},
+	})
+	cmd, err := buildCommand(testRunner, nil, false)
+	if err != nil {
+		t.Fatalf("buildCommand() error = %v", err)
+	}
+
+	values := make(map[string]string)
+	for _, entry := range cmd.Env {
+		key, value, _ := strings.Cut(entry, "=")
+		values[key] = value
+	}
+	if got := values["BUILDKITE_ANALYTICS_TOKEN"]; got != "upstream-token" {
+		t.Errorf("BUILDKITE_ANALYTICS_TOKEN = %q, want upstream-token", got)
+	}
+	if got := values["BUILDKITE_TESTS_OTLP_TOKEN"]; got != "local-token" {
+		t.Errorf("BUILDKITE_TESTS_OTLP_TOKEN = %q, want local-token", got)
+	}
+	if got := values["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]; got != "http://127.0.0.1:1234/v1/traces" {
+		t.Errorf("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = %q", got)
 	}
 }

--- a/internal/runner/detector.go
+++ b/internal/runner/detector.go
@@ -18,6 +18,7 @@ func DetectRunner(cfg *config.Config) (TestRunnerWithTargetDiscovery, error) {
 		TestFileExcludePattern: cfg.TestFileExcludePattern,
 		TestFilePattern:        cfg.TestFilePattern,
 		uploadToken:            cfg.UploadToken,
+		testProcessEnv:         cfg.TestProcessEnv,
 		SelectorListPath:       cfg.SelectorListPath,
 	}
 

--- a/internal/runner/runner_config.go
+++ b/internal/runner/runner_config.go
@@ -14,6 +14,7 @@ type RunnerConfig struct {
 	TestFileExcludePattern string
 	TestFilePattern        string
 	uploadToken            string
+	testProcessEnv         map[string]string
 
 	// SelectorListPath points at a file containing the selectors to run.
 	SelectorListPath string
@@ -32,6 +33,10 @@ func (rc RunnerConfig) LocationPrefix() string {
 
 func (rc RunnerConfig) UploadToken() string {
 	return rc.uploadToken
+}
+
+func (rc RunnerConfig) testProcessEnvironment() map[string]string {
+	return rc.testProcessEnv
 }
 
 // ResultFormat returns an empty string by default.


### PR DESCRIPTION
### Description

Test SDKs can emit richer OpenTelemetry trace data than bktec's result upload, but sending it directly requires each test process to manage Buildkite authentication. This adds an opt-in loopback OTLP/HTTP protobuf relay so bktec can authenticate upstream through the Buildkite Agent while SDKs export locally.

The relay acknowledges local exports immediately, forwards opaque gzip or uncompressed protobuf bodies without mutation, retries transient failures within bounded memory, refreshes suite-scoped OIDC credentials, and reports anything it cannot deliver during the final 10-second drain.

### Context

- Resolves [TE-6777](https://linear.app/buildkite/issue/TE-6777/relay-test-otlp-traces-through-bktec)
- [Implementation plan](https://slopcannon.tail952194.ts.net/paul/bktec-otlp-relay-plan/)
- Exercised by buildkite/test-engine-client-examples#63

### Changes

- add `--otlp-relay` / `BUILDKITE_TESTS_OTLP_RELAY=true` to `bktec run`
- inject standard OTLP/HTTP exporter settings and a per-run local credential into test processes without replacing existing collector credentials
- authenticate upstream requests with agent-issued OIDC and `Buildkite-Tests-Run-Key`
- bound requests to 900 KiB and the queue to 64 MiB, with retry, backpressure, token refresh, and drain accounting
- add `buildkite.otlp.endpoint=<loopback trace URL>` as a resource attribute so stored spans show they travelled through bktec

### Testing

- `go test -race ./internal/otlprelay`
- targeted CLI, command, config, and runner tests
- `go test ./... -run '^$'`
- `golangci-lint v2.5.0`
- real RSpec collector export through the relay to a fake upstream: one gzip OTLP request forwarded with the expected OIDC/run-key headers and provenance resource attribute

### Risk and rollback

This is opt-in and leaves existing runs unchanged. The relay keeps short-lived, suite-scoped OIDC and local credentials in memory, binds only to loopback, does not log credentials, and does not inspect or mutate OTLP bodies. Credential handling makes this an L3 change under Buildsworth's policy, so it requires human review. Disable `BUILDKITE_TESTS_OTLP_RELAY` or revert this PR to roll back.
