### PR TITLE
Add size/latency distributions to OTLP relay drain summary

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -175,20 +176,20 @@ func startOTLPRelay(cfg *config.Config) (*otlprelay.Relay, error) {
 
 func printOTLPRelayReport(w io.Writer, report otlprelay.Report) {
 	fmt.Fprintf(w,
-		"bktec OTLP relay: %d request(s) (%d bytes) forwarded, %d dropped permanently, %d dropped at drain deadline, %d byte(s) dropped\n",
+		"bktec OTLP relay: %d request(s) (%s) forwarded, %d dropped permanently, %d dropped at drain deadline, %s dropped\n",
 		report.ForwardedRequests,
-		report.ForwardedBytes,
+		formatBytes(report.ForwardedBytes),
 		report.DroppedPermanentRequests,
 		report.DroppedDeadlineRequests,
-		report.DroppedBytes,
+		formatBytes(report.DroppedBytes),
 	)
 	if report.ForwardedRequests == 0 {
 		return
 	}
 	size := report.ForwardedSize
 	fmt.Fprintf(w,
-		"bktec OTLP relay: request size bytes: p50 %d, p90 %d, max %d\n",
-		size.P50, size.P90, size.Max,
+		"bktec OTLP relay: request size: p50 %s, p90 %s, max %s\n",
+		formatBytes(size.P50), formatBytes(size.P90), formatBytes(size.Max),
 	)
 	latency := report.ForwardedLatency
 	fmt.Fprintf(w,
@@ -200,6 +201,24 @@ func printOTLPRelayReport(w io.Writer, report otlprelay.Report) {
 // roundLatency trims durations for display, e.g. 45.123456ms -> 45.12ms.
 func roundLatency(d time.Duration) time.Duration {
 	return d.Round(10 * time.Microsecond)
+}
+
+// formatBytes renders a byte count in the most readable decimal unit,
+// e.g. 512B, 4.8kB, 2.4MB.
+func formatBytes(n int64) string {
+	const unit = 1000
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	value := float64(n)
+	suffixes := []string{"kB", "MB", "GB", "TB"}
+	for i, suffix := range suffixes {
+		value /= unit
+		if value < unit || i == len(suffixes)-1 {
+			return strings.TrimSuffix(fmt.Sprintf("%.1f", value), ".0") + suffix
+		}
+	}
+	panic("unreachable")
 }
 
 func trimTaskLocationPrefix(task *plan.Task, locationPrefix string) error {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -47,13 +48,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 		drainCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		report := relay.Drain(drainCtx)
-		fmt.Printf(
-			"Buildkite Test Engine Client: OTLP relay: %d request(s) forwarded, %d dropped permanently, %d dropped at drain deadline, %d byte(s) dropped\n",
-			report.ForwardedRequests,
-			report.DroppedPermanentRequests,
-			report.DroppedDeadlineRequests,
-			report.DroppedBytes,
-		)
+		printOTLPRelayReport(os.Stdout, report)
 		relay = nil
 	}
 	defer drainRelay()
@@ -174,8 +169,37 @@ func startOTLPRelay(cfg *config.Config) (*otlprelay.Relay, error) {
 	}
 
 	cfg.TestProcessEnv = relay.Environment(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"))
-	fmt.Printf("Buildkite Test Engine Client: OTLP relay listening on %s\n", relay.Endpoint())
+	fmt.Printf("bktec OTLP relay: listening on %s\n", relay.Endpoint())
 	return relay, nil
+}
+
+func printOTLPRelayReport(w io.Writer, report otlprelay.Report) {
+	fmt.Fprintf(w,
+		"bktec OTLP relay: %d request(s) (%d bytes) forwarded, %d dropped permanently, %d dropped at drain deadline, %d byte(s) dropped\n",
+		report.ForwardedRequests,
+		report.ForwardedBytes,
+		report.DroppedPermanentRequests,
+		report.DroppedDeadlineRequests,
+		report.DroppedBytes,
+	)
+	if report.ForwardedRequests == 0 {
+		return
+	}
+	size := report.ForwardedSize
+	fmt.Fprintf(w,
+		"bktec OTLP relay: request size bytes: p50 %d, p90 %d, max %d\n",
+		size.P50, size.P90, size.Max,
+	)
+	latency := report.ForwardedLatency
+	fmt.Fprintf(w,
+		"bktec OTLP relay: upstream latency: p50 %s, p90 %s, max %s\n",
+		roundLatency(latency.P50), roundLatency(latency.P90), roundLatency(latency.Max),
+	)
+}
+
+// roundLatency trims durations for display, e.g. 45.123456ms -> 45.12ms.
+func roundLatency(d time.Duration) time.Duration {
+	return d.Round(10 * time.Microsecond)
 }
 
 func trimTaskLocationPrefix(task *plan.Task, locationPrefix string) error {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -203,15 +203,15 @@ func roundLatency(d time.Duration) time.Duration {
 	return d.Round(10 * time.Microsecond)
 }
 
-// formatBytes renders a byte count in the most readable decimal unit,
-// e.g. 512B, 4.8kB, 2.4MB.
+// formatBytes renders a byte count in the most readable binary unit,
+// e.g. 512B, 4.7KiB, 2.3MiB.
 func formatBytes(n int64) string {
-	const unit = 1000
+	const unit = 1024
 	if n < unit {
 		return fmt.Sprintf("%dB", n)
 	}
 	value := float64(n)
-	suffixes := []string{"kB", "MB", "GB", "TB"}
+	suffixes := []string{"KiB", "MiB", "GiB", "TiB"}
 	for i, suffix := range suffixes {
 		value /= unit
 		if value < unit || i == len(suffixes)-1 {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -158,8 +158,8 @@ func TestPrintOTLPRelayReport(t *testing.T) {
 		DroppedDeadlineRequests:  2,
 		DroppedBytes:             10240,
 	})
-	want := "bktec OTLP relay: 495 request(s) (2381932 bytes) forwarded, 3 dropped permanently, 2 dropped at drain deadline, 10240 byte(s) dropped\n" +
-		"bktec OTLP relay: request size bytes: p50 4812, p90 14206, max 88410\n" +
+	want := "bktec OTLP relay: 495 request(s) (2.4MB) forwarded, 3 dropped permanently, 2 dropped at drain deadline, 10.2kB dropped\n" +
+		"bktec OTLP relay: request size: p50 4.8kB, p90 14.2kB, max 88.4kB\n" +
 		"bktec OTLP relay: upstream latency: p50 38.12ms, p90 91.4ms, max 412.87ms\n"
 	if buf.String() != want {
 		t.Errorf("printOTLPRelayReport output = %q, want %q", buf.String(), want)
@@ -168,11 +168,32 @@ func TestPrintOTLPRelayReport(t *testing.T) {
 
 	buf.Reset()
 	printOTLPRelayReport(&buf, otlprelay.Report{})
-	want = "bktec OTLP relay: 0 request(s) (0 bytes) forwarded, 0 dropped permanently, 0 dropped at drain deadline, 0 byte(s) dropped\n"
+	want = "bktec OTLP relay: 0 request(s) (0B) forwarded, 0 dropped permanently, 0 dropped at drain deadline, 0B dropped\n"
 	if buf.String() != want {
 		t.Errorf("printOTLPRelayReport output = %q, want no distribution lines: %q", buf.String(), want)
 	}
 	t.Logf("output (nothing forwarded):\n%s", buf.String())
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := map[int64]string{
+		0:         "0B",
+		512:       "512B",
+		999:       "999B",
+		1000:      "1kB",
+		1500:      "1.5kB",
+		10240:     "10.2kB",
+		999_949:   "999.9kB",
+		1_000_000: "1MB",
+		2_381_932: "2.4MB",
+		5e9:       "5GB",
+		7_200e9:   "7.2TB", // implausible for a relay, but must not panic
+	}
+	for input, want := range cases {
+		if got := formatBytes(input); got != want {
+			t.Errorf("formatBytes(%d) = %q, want %q", input, got, want)
+		}
+	}
 }
 
 func TestRunTestsWithRetry(t *testing.T) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/api"
 	"github.com/buildkite/test-engine-client/v3/internal/config"
 	"github.com/buildkite/test-engine-client/v3/internal/git"
+	"github.com/buildkite/test-engine-client/v3/internal/otlprelay"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
 	"github.com/buildkite/test-engine-client/v3/internal/runner"
 	"github.com/buildkite/test-engine-client/v3/internal/version"
@@ -144,6 +145,34 @@ func TestStartOTLPRelaySeedsUpstreamCredentialFromOIDCUploadToken(t *testing.T) 
 	if got := <-received; got != `Token token="upload-token"` {
 		t.Errorf("upstream Authorization = %q, want seeded upload token", got)
 	}
+}
+
+func TestPrintOTLPRelayReport(t *testing.T) {
+	var buf bytes.Buffer
+	printOTLPRelayReport(&buf, otlprelay.Report{
+		ForwardedRequests:        495,
+		ForwardedBytes:           2381932,
+		ForwardedSize:            otlprelay.Stats[int64]{P50: 4812, P90: 14206, Max: 88410},
+		ForwardedLatency:         otlprelay.Stats[time.Duration]{P50: 38123456, P90: 91400000, Max: 412871900},
+		DroppedPermanentRequests: 3,
+		DroppedDeadlineRequests:  2,
+		DroppedBytes:             10240,
+	})
+	want := "bktec OTLP relay: 495 request(s) (2381932 bytes) forwarded, 3 dropped permanently, 2 dropped at drain deadline, 10240 byte(s) dropped\n" +
+		"bktec OTLP relay: request size bytes: p50 4812, p90 14206, max 88410\n" +
+		"bktec OTLP relay: upstream latency: p50 38.12ms, p90 91.4ms, max 412.87ms\n"
+	if buf.String() != want {
+		t.Errorf("printOTLPRelayReport output = %q, want %q", buf.String(), want)
+	}
+	t.Logf("output:\n%s", buf.String())
+
+	buf.Reset()
+	printOTLPRelayReport(&buf, otlprelay.Report{})
+	want = "bktec OTLP relay: 0 request(s) (0 bytes) forwarded, 0 dropped permanently, 0 dropped at drain deadline, 0 byte(s) dropped\n"
+	if buf.String() != want {
+		t.Errorf("printOTLPRelayReport output = %q, want no distribution lines: %q", buf.String(), want)
+	}
+	t.Logf("output (nothing forwarded):\n%s", buf.String())
 }
 
 func TestRunTestsWithRetry(t *testing.T) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -158,8 +158,8 @@ func TestPrintOTLPRelayReport(t *testing.T) {
 		DroppedDeadlineRequests:  2,
 		DroppedBytes:             10240,
 	})
-	want := "bktec OTLP relay: 495 request(s) (2.4MB) forwarded, 3 dropped permanently, 2 dropped at drain deadline, 10.2kB dropped\n" +
-		"bktec OTLP relay: request size: p50 4.8kB, p90 14.2kB, max 88.4kB\n" +
+	want := "bktec OTLP relay: 495 request(s) (2.3MiB) forwarded, 3 dropped permanently, 2 dropped at drain deadline, 10KiB dropped\n" +
+		"bktec OTLP relay: request size: p50 4.7KiB, p90 13.9KiB, max 86.3KiB\n" +
 		"bktec OTLP relay: upstream latency: p50 38.12ms, p90 91.4ms, max 412.87ms\n"
 	if buf.String() != want {
 		t.Errorf("printOTLPRelayReport output = %q, want %q", buf.String(), want)
@@ -179,15 +179,15 @@ func TestFormatBytes(t *testing.T) {
 	cases := map[int64]string{
 		0:         "0B",
 		512:       "512B",
-		999:       "999B",
-		1000:      "1kB",
-		1500:      "1.5kB",
-		10240:     "10.2kB",
-		999_949:   "999.9kB",
-		1_000_000: "1MB",
-		2_381_932: "2.4MB",
-		5e9:       "5GB",
-		7_200e9:   "7.2TB", // implausible for a relay, but must not panic
+		1023:      "1023B",
+		1024:      "1KiB",
+		1500:      "1.5KiB",
+		10240:     "10KiB",
+		999_949:   "976.5KiB",
+		1_048_576: "1MiB",
+		2_381_932: "2.3MiB",
+		5e9:       "4.7GiB",
+		7_200e9:   "6.5TiB", // implausible for a relay, but must not panic
 	}
 	for input, want := range cases {
 		if got := formatBytes(input); got != want {

--- a/internal/otlprelay/relay.go
+++ b/internal/otlprelay/relay.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	mathrand "math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,9 +65,73 @@ type Config struct {
 	maxBackoff     time.Duration
 }
 
-// Report summarizes requests delivered or dropped by a relay.
+// Stats summarizes the distribution of a per-request measurement.
+type Stats[T ~int64] struct {
+	P50 T
+	P90 T
+	Max T
+}
+
+// summarize computes distribution stats over samples without mutating them.
+// The zero Stats is returned for no samples. Percentiles use the nearest-rank
+// method.
+func summarize[T ~int64](samples []T) Stats[T] {
+	if len(samples) == 0 {
+		return Stats[T]{}
+	}
+	sorted := slices.Clone(samples)
+	slices.Sort(sorted)
+	n := len(sorted)
+	return Stats[T]{
+		P50: sorted[(n+1)/2-1],
+		P90: sorted[(9*n+9)/10-1],
+		Max: sorted[n-1],
+	}
+}
+
+// maxStatSamples bounds the memory retained for percentile estimation to
+// 2 reservoirs x 4096 samples x 8 bytes = 64KB regardless of request volume.
+const maxStatSamples = 4096
+
+// sampler observes per-request measurements with bounded memory: an exact
+// running max plus a fixed-size uniform reservoir (Algorithm R) for
+// percentiles. Results are exact until the reservoir fills; beyond that
+// percentiles are unbiased estimates.
+type sampler[T ~int64] struct {
+	samples []T
+	seen    int
+	max     T
+}
+
+func (s *sampler[T]) observe(value T) {
+	s.seen++
+	if value > s.max {
+		s.max = value
+	}
+	if len(s.samples) < maxStatSamples {
+		s.samples = append(s.samples, value)
+		return
+	}
+	if slot := mathrand.IntN(s.seen); slot < len(s.samples) {
+		s.samples[slot] = value
+	}
+}
+
+func (s *sampler[T]) stats() Stats[T] {
+	stats := summarize(s.samples)
+	stats.Max = s.max
+	return stats
+}
+
+// Report summarizes requests delivered or dropped by a relay. ForwardedSize
+// and ForwardedLatency cover forwarded requests only; latency is the duration
+// of each request's successful upstream POST, excluding failed attempts and
+// retry backoff.
 type Report struct {
 	ForwardedRequests        int
+	ForwardedBytes           int64
+	ForwardedSize            Stats[int64]
+	ForwardedLatency         Stats[time.Duration]
 	DroppedPermanentRequests int
 	DroppedDeadlineRequests  int
 	DroppedBytes             int64
@@ -109,6 +175,8 @@ type Relay struct {
 	drainDeadline   time.Time
 	drainRetryDelay time.Duration
 	report          Report
+	sizeSampler     sampler[int64]
+	latencySampler  sampler[time.Duration]
 
 	// upstreamToken, tokenRefreshAt, and credentialErr are only touched by New
 	// (before the worker goroutine starts) and by the single forward worker, so
@@ -200,7 +268,7 @@ func New(config Config) (*Relay, error) {
 			_ = listener.Close()
 			return nil, fmt.Errorf("get initial OTLP relay credential: %w", err)
 		}
-		relay.config.Logf("Buildkite Test Engine Client: OTLP relay starting without an upstream credential; requests will be buffered while it retries in the background: %v", err)
+		relay.config.Logf("bktec OTLP relay: starting without an upstream credential; requests will be buffered while it retries in the background: %v", err)
 	}
 	relay.server = &http.Server{
 		Handler:           relay,
@@ -211,7 +279,7 @@ func New(config Config) (*Relay, error) {
 
 	go func() {
 		if err := relay.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			relay.config.Logf("Buildkite Test Engine Client: OTLP relay listener stopped: %v", err)
+			relay.config.Logf("bktec OTLP relay: listener stopped: %v", err)
 		}
 	}()
 	go relay.forward()
@@ -339,12 +407,12 @@ func (r *Relay) forward() {
 			return
 		}
 
-		result := r.deliver(req)
+		result, latency := r.deliver(req)
 		switch result {
 		case deliveryForwarded:
-			r.complete(req, true)
+			r.complete(req, true, latency)
 		case deliveryPermanentFailure:
-			r.complete(req, false)
+			r.complete(req, false, 0)
 		case deliveryDeadline:
 			r.dropRemainingAtDeadline()
 			return
@@ -374,35 +442,40 @@ func (r *Relay) nextRequest() (*request, bool) {
 	}
 }
 
-func (r *Relay) deliver(queued *request) deliveryResult {
+// deliver returns the delivery result and, for a forwarded request, the
+// duration of the successful upstream POST.
+func (r *Relay) deliver(queued *request) (deliveryResult, time.Duration) {
 	backoff := r.config.initialBackoff
 	for {
 		token, err := r.authorizationToken()
 		if err != nil && errors.Is(err, ErrTerminalCredential) {
 			if !r.credentialErrLogged {
 				r.credentialErrLogged = true
-				r.config.Logf("Buildkite Test Engine Client: OTLP relay credential was refused and will not be retried; dropping OTLP requests: %v", err)
+				r.config.Logf("bktec OTLP relay: credential was refused and will not be retried; dropping OTLP requests: %v", err)
 			}
-			return deliveryPermanentFailure
+			return deliveryPermanentFailure, 0
 		}
 		var status int
 		var retryAfter time.Duration
 		var hasRetryAfter bool
+		var sendLatency time.Duration
 		if err == nil {
+			sendStart := time.Now()
 			status, retryAfter, hasRetryAfter, err = r.send(queued, token)
+			sendLatency = time.Since(sendStart)
 		}
 
 		if err == nil {
 			switch {
 			case status >= 200 && status < 300:
-				return deliveryForwarded
+				return deliveryForwarded, sendLatency
 			case status != http.StatusRequestTimeout && status != http.StatusTooManyRequests && status < 500:
-				r.config.Logf("Buildkite Test Engine Client: OTLP relay dropped a request after upstream returned HTTP %d", status)
-				return deliveryPermanentFailure
+				r.config.Logf("bktec OTLP relay: dropped a request after upstream returned HTTP %d", status)
+				return deliveryPermanentFailure, 0
 			}
 		}
 		if r.ctx.Err() != nil {
-			return deliveryDeadline
+			return deliveryDeadline, 0
 		}
 
 		delay := backoff
@@ -410,7 +483,7 @@ func (r *Relay) deliver(queued *request) deliveryResult {
 			delay = retryAfter
 		}
 		if !r.waitForRetry(delay) {
-			return deliveryDeadline
+			return deliveryDeadline, 0
 		}
 		backoff = min(backoff*2, r.config.maxBackoff)
 	}
@@ -537,7 +610,7 @@ func (r *Relay) clampRetryDelay(delay time.Duration) time.Duration {
 	return min(drainDelay, remaining)
 }
 
-func (r *Relay) complete(req *request, forwarded bool) {
+func (r *Relay) complete(req *request, forwarded bool, latency time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -549,6 +622,9 @@ func (r *Relay) complete(req *request, forwarded bool) {
 	r.queuedSize -= len(req.body) + queueRequestOverhead
 	if forwarded {
 		r.report.ForwardedRequests++
+		r.report.ForwardedBytes += int64(len(req.body))
+		r.sizeSampler.observe(int64(len(req.body)))
+		r.latencySampler.observe(latency)
 	} else {
 		r.report.DroppedPermanentRequests++
 		r.report.DroppedBytes += int64(len(req.body))
@@ -602,6 +678,8 @@ func (r *Relay) Drain(ctx context.Context) Report {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.report.ForwardedSize = r.sizeSampler.stats()
+	r.report.ForwardedLatency = r.latencySampler.stats()
 	return r.report
 }
 

--- a/internal/otlprelay/relay.go
+++ b/internal/otlprelay/relay.go
@@ -112,6 +112,7 @@ func (s *sampler[T]) observe(value T) {
 		s.samples = append(s.samples, value)
 		return
 	}
+	//nolint:gosec // Reservoir sampling does not require cryptographic randomness.
 	if slot := mathrand.IntN(s.seen); slot < len(s.samples) {
 		s.samples[slot] = value
 	}

--- a/internal/otlprelay/relay_test.go
+++ b/internal/otlprelay/relay_test.go
@@ -63,8 +63,8 @@ func TestRelayForwardsOpaqueGzipRequestWithTrustedHeaders(t *testing.T) {
 
 	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	report := relay.Drain(drainCtx)
-	if report != (Report{ForwardedRequests: 1}) {
+	report := stripLatencyStats(t, relay.Drain(drainCtx))
+	if report != (Report{ForwardedRequests: 1, ForwardedBytes: int64(len(body)), ForwardedSize: singleStat(int64(len(body)))}) {
 		t.Errorf("Drain report = %+v, want one forwarded request", report)
 	}
 
@@ -140,8 +140,8 @@ func TestRelayStartsWithoutCredentialAndDeliversAfterRecovery(t *testing.T) {
 
 	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	report := relay.Drain(drainCtx)
-	if report != (Report{ForwardedRequests: 1}) {
+	report := stripLatencyStats(t, relay.Drain(drainCtx))
+	if report != (Report{ForwardedRequests: 1, ForwardedBytes: 5, ForwardedSize: singleStat[int64](5)}) {
 		t.Errorf("Drain report = %+v, want one forwarded request", report)
 	}
 
@@ -184,8 +184,8 @@ func TestRelaySeededInitialTokenSkipsTokenSource(t *testing.T) {
 
 	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	report := relay.Drain(drainCtx)
-	if report != (Report{ForwardedRequests: 1}) {
+	report := stripLatencyStats(t, relay.Drain(drainCtx))
+	if report != (Report{ForwardedRequests: 1, ForwardedBytes: 5, ForwardedSize: singleStat[int64](5)}) {
 		t.Errorf("Drain report = %+v, want one forwarded request", report)
 	}
 
@@ -302,11 +302,11 @@ func TestRelayRetriesRetryableResponses(t *testing.T) {
 
 	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	report := relay.Drain(drainCtx)
+	report := stripLatencyStats(t, relay.Drain(drainCtx))
 	if got := requests.Load(); got != 2 {
 		t.Errorf("upstream requests = %d, want 2", got)
 	}
-	if report != (Report{ForwardedRequests: 1}) {
+	if report != (Report{ForwardedRequests: 1, ForwardedBytes: 7, ForwardedSize: singleStat[int64](7)}) {
 		t.Errorf("Drain report = %+v, want one forwarded request", report)
 	}
 }
@@ -343,8 +343,8 @@ func TestRelayRefreshesExpiredOIDCTokenWhileRetrying(t *testing.T) {
 
 	drainCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	report := relay.Drain(drainCtx)
-	if report != (Report{ForwardedRequests: 1}) {
+	report := stripLatencyStats(t, relay.Drain(drainCtx))
+	if report != (Report{ForwardedRequests: 1, ForwardedBytes: 7, ForwardedSize: singleStat[int64](7)}) {
 		t.Errorf("Drain report = %+v, want one forwarded request", report)
 	}
 	if got := tokenRequests.Load(); got != 2 {
@@ -646,6 +646,60 @@ func TestParseRetryAfter(t *testing.T) {
 			t.Errorf("parseRetryAfter(%q) = (%s, %t), want (%s, %t)", test.value, got, ok, test.want, test.ok)
 		}
 	}
+}
+
+func TestSummarize(t *testing.T) {
+	if got := summarize[int64](nil); got != (Stats[int64]{}) {
+		t.Errorf("summarize(nil) = %+v, want zero stats", got)
+	}
+	samples := []int64{100, 10, 20, 30, 40, 50, 60, 70, 80, 90}
+	want := Stats[int64]{P50: 50, P90: 90, Max: 100}
+	if got := summarize(samples); got != want {
+		t.Errorf("summarize = %+v, want %+v", got, want)
+	}
+	if samples[0] != 100 {
+		t.Error("summarize mutated its input")
+	}
+}
+
+func TestSamplerBoundsMemoryAndKeepsExactMax(t *testing.T) {
+	var s sampler[int64]
+	const n = 3 * maxStatSamples
+	for value := int64(1); value <= n; value++ {
+		s.observe(value)
+	}
+	if len(s.samples) != maxStatSamples {
+		t.Errorf("len(samples) = %d, want capped at %d", len(s.samples), maxStatSamples)
+	}
+	stats := s.stats()
+	if stats.Max != n {
+		t.Errorf("Max = %d, want exact %d", stats.Max, n)
+	}
+	if stats.P50 < 1 || stats.P50 > n || stats.P50 > stats.P90 || stats.P90 > stats.Max {
+		t.Errorf("stats = %+v, want ordered estimates within observed range", stats)
+	}
+}
+
+// singleStat is the expected distribution when exactly one value was observed.
+func singleStat[T ~int64](value T) Stats[T] {
+	return Stats[T]{P50: value, P90: value, Max: value}
+}
+
+// stripLatencyStats checks that latency stats are present and ordered exactly
+// when requests were forwarded, then zeroes them so callers can compare the
+// rest of the report exactly (latency values are nondeterministic).
+func stripLatencyStats(t *testing.T, report Report) Report {
+	t.Helper()
+	latency := report.ForwardedLatency
+	if report.ForwardedRequests > 0 {
+		if latency.Max <= 0 || latency.P50 > latency.P90 || latency.P90 > latency.Max {
+			t.Errorf("ForwardedLatency = %+v, want ordered positive stats", latency)
+		}
+	} else if latency != (Stats[time.Duration]{}) {
+		t.Errorf("ForwardedLatency = %+v, want zero stats without forwarded requests", latency)
+	}
+	report.ForwardedLatency = Stats[time.Duration]{}
+	return report
 }
 
 func newTestRelay(t *testing.T, config Config) *Relay {


### PR DESCRIPTION
### Description

The OTLP relay's end-of-run summary only reported request/byte totals, e.g.:

> Buildkite Test Engine Client: OTLP relay: 495 request(s) forwarded, 0 dropped permanently, 0 dropped at drain deadline, 0 byte(s) dropped

This adds per-request size and upstream-latency distributions so one glance at the job log shows whether telemetry was healthy:

```
bktec OTLP relay: 495 request(s) (2.3MiB) forwarded, 0 dropped permanently, 0 dropped at drain deadline, 0B dropped
bktec OTLP relay: request size: p50 4.7KiB, p90 13.9KiB, max 86.3KiB
bktec OTLP relay: upstream latency: p50 38.12ms, p90 91.4ms, max 412.87ms
```

Design choices:
- **p50/p90/max** rather than min/avg: min is noise, avg is derivable from the totals line, median beats mean for skewed latency; p99 omitted as it equals max below ~100 samples.
- **Latency** measures each request's successful upstream POST only (excludes failed attempts and retry backoff), i.e. upstream health, not queueing delay.
- **Bounded memory, no new dependency**: each sampler keeps an exact running max plus a 4096-slot uniform reservoir (Algorithm R) — 64KB cap total. Percentiles are exact up to 4096 forwarded requests, unbiased estimates beyond. Sketch libraries (DDSketch/KLL) considered and rejected as overkill.
- Byte values render in binary units (4.7KiB, 2.3MiB) via a small local helper.
- All relay log lines now use the shorter `bktec OTLP relay: ` prefix.

### Context

- Amp thread: https://ampcode.com/threads/T-01a04712-87f7-73ce-800a-4a4c1a6d9523

### Changes

- `internal/otlprelay`: `Report` gains `ForwardedBytes`, `ForwardedSize`, `ForwardedLatency` (`Stats[T]` with reservoir-backed `sampler`); `deliver` times successful POSTs.
- `internal/command`: summary printer takes an `io.Writer` and prints the distribution lines (only when ≥1 request was forwarded); adds `formatBytes`.

### Testing

- Unit tests cover the sampler cap/exact max, percentile math, byte formatting, and the exact summary output (`go test ./internal/otlprelay ./internal/command`).
- Pre-existing `TestCreateRequestParams_*TagFilters` failures on `main` are unrelated and untouched.
