### PR TITLE
Add --plan-out to bktec run to write the executed test plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Add `bktec run --plan-out <path>` (env: `BUILDKITE_TEST_ENGINE_PLAN_OUT`) to save the full cached or freshly created API plan before running tests, retaining selection and server-only fields without extra requests. Local fallback output includes the actual tasks and `fallback: true`. Parent directories are created; write failures stop the run.
+
 ## 3.0.0 - 2026-07-31
 - ⚠️ **BREAKING:** Selector-based splitting now replaces file-based splitting for supported runners. The deprecated `--selector-splitting` flag and `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING` environment variable are still accepted for upgrade compatibility, but their values no longer affect behavior. Existing bktec v2 releases continue to send file-based requests and remain compatible with file-based splitting; remain on v2 if file-based requests are required. See [Migrating from bktec v2 to v3](./docs/migrating-to-v3.md).
 - The Go module path is now `github.com/buildkite/test-engine-client/v3`.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,50 @@ printed to stderr). Only when the server cannot be reached at all does `bktec`
 fall back to a minimal locally-generated plan; this carries the identifier and
 parallelism but no tasks (it is not a computed split), and is noted on stderr.
 
+### Saving the plan used by a run
+
+`bktec run --plan-out <path>` writes the full plan before running tests, so
+verification tools can compare results against the actual split and selection
+without fetching the plan again or managing another API token:
+
+```sh
+bktec run --plan-out tmp/test-engine/plan.json
+# Or configure the output path through the environment:
+BUILDKITE_TEST_ENGINE_PLAN_OUT=tmp/test-engine/plan.json bktec run
+```
+
+The flag takes precedence over `BUILDKITE_TEST_ENGINE_PLAN_OUT`. Parent
+directories are created and existing files are overwritten. If the file cannot
+be created, written, or closed, the run stops before executing tests (exit 16).
+Otherwise test execution and exit statuses are unchanged. Unlike `bktec plan`,
+`run --plan-out` accepts only file paths: `-` names a literal file, not stdout.
+
+For cached and freshly created plans, the file is the API's full `test_plan`
+JSON response, indented with a trailing newline. All server fields are retained,
+including `identifier`, `parallelism`, all nodes in `tasks`, test `format`,
+`path`, `identifier`, and `value`, and `selection`, `skipped_reason`, and timing
+metadata when present. It is saved before node-specific location-prefix
+adjustments or retries. Every parallel node writes the entire plan without any
+additional network requests; consumers can upload the file from node 0.
+
+When bktec falls back to local splitting (including an empty server error plan),
+the file instead records the actual local tasks with an explicit `fallback: true`:
+
+```json
+{
+  "identifier": "build-id/step-id",
+  "parallelism": 2,
+  "tasks": {
+    "0": {"node_number": 0, "tests": [{"path": "spec/apple_spec.rb"}]},
+    "1": {"node_number": 1, "tests": [{"path": "spec/banana_spec.rb"}]}
+  },
+  "fallback": true
+}
+```
+
+This is a local full-suite split, not a server selection. Verification tools
+should check `fallback` before interpreting the document as a server plan.
+
 ### Selector-based test splitting
 
 By default, `bktec` discovers tests and requests a plan by sending runner-specific **selectors**, the values Test Engine looks up when computing a split for the current job. For every runner except gotest, the selector is the same file path that bktec discovers, so selector splitting doesn't change which tests run where, only how that path is reported and matched. gotest is the exception: its selector is a Go package import path from `go list`, and selector splitting replaces the legacy even-count package split with duration-aware splitting, so Go users may see a different (and better balanced) split once historical timing data is available.

--- a/cli.go
+++ b/cli.go
@@ -464,6 +464,13 @@ var planIdentifierFlag = &cli.StringFlag{
 	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER"),
 }
 
+var runPlanOutFlag = &cli.StringFlag{
+	Name:        "plan-out",
+	Usage:       "write the full test plan as JSON to file `PATH` before running tests, creating parent directories; local fallback plans include fallback: true. Write failures stop the run. Unlike 'plan --plan-out', '-' is a literal file path",
+	Destination: &cfg.PlanOut,
+	Sources:     cli.EnvVars("BUILDKITE_TEST_ENGINE_PLAN_OUT"),
+}
+
 // `plan` command flags
 var maxParallelismFlag = &cli.IntFlag{
 	Name:        "max-parallelism",
@@ -684,6 +691,7 @@ func runCommandFlags() []cli.Flag {
 		filesFlag,
 		tagFiltersFlag,
 		planIdentifierFlag,
+		runPlanOutFlag,
 	}
 	flags = append(flags, buildEnvironmentFlags...)
 	flags = append(flags, testEngineFlags...)

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -30,8 +32,12 @@ func TestRunPlanOut(t *testing.T) {
 		},
 		"selection":{"strategy":"percent","params":{"percent":50},"applied":true,"skipped_reason":null},
 		"skipped_tests":[{"format":"example","path":"app/cherry[1:1]","skipped_reason":"selection"}],
-		"server_only":{"future_field":true}
+		"server_only":{"future_field":true,"decimal":1.0,"exponent":1e3,"negative_zero":-0.0,"large_integer":12345678901234567890123,"escaped":"\u00e9","nullable":null}
 	}`
+	var indentedPlan bytes.Buffer
+	require.NoError(t, json.Indent(&indentedPlan, []byte(serverPlan), "", "  "))
+	indentedPlan.WriteByte('\n')
+
 	fallbackPlan := `{"identifier":"my-plan","parallelism":2,"fallback":true,"tasks":{
 		"0":{"node_number":0,"tests":[{"path":"apple"}]},
 		"1":{"node_number":1,"tests":[{"path":"banana"}]}
@@ -40,8 +46,10 @@ func TestRunPlanOut(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
 		envOnly    bool
+		noPlanOut  bool
 		cacheMiss  bool
 		fallback   bool
+		emptyBody  bool
 		billing    bool
 		node       int
 		exitCode   int
@@ -53,6 +61,10 @@ func TestRunPlanOut(t *testing.T) {
 		{name: "other node writes entire plan", node: 1},
 		{name: "cached error plan fallback", fallback: true},
 		{name: "created error plan fallback", cacheMiss: true, fallback: true},
+		{name: "empty GET fallback", emptyBody: true, fallback: true},
+		{name: "empty POST fallback", cacheMiss: true, emptyBody: true, fallback: true},
+		{name: "empty GET fallback without plan-out", emptyBody: true, fallback: true, noPlanOut: true},
+		{name: "empty POST fallback without plan-out", cacheMiss: true, emptyBody: true, fallback: true, noPlanOut: true},
 		{name: "API unavailable fallback", fallback: true, billing: true},
 		{name: "test exit status preserved", exitCode: 7},
 		{name: "cannot open destination", writeError: "opening --plan-out file"},
@@ -77,7 +89,12 @@ func TestRunPlanOut(t *testing.T) {
 			require.NoError(t, os.WriteFile(targetsPath, []byte("apple\nbanana\n"), 0o600))
 			ranPath := filepath.Join(dir, "ran.txt")
 			// Prove the file exists before tests start, and record the node's runnable target.
-			testCommand := fmt.Sprintf(`sh -c 'test -s "$1" || exit 99; printf "%%s" "$3" > "$2"; exit %d' sh %q %q {{testExamples}}`, tt.exitCode, planPath, ranPath)
+			planCheck := `test -s "$1" || exit 99;`
+			if tt.noPlanOut {
+				t.Setenv("BUILDKITE_TEST_ENGINE_PLAN_OUT", "")
+				planCheck = ""
+			}
+			testCommand := fmt.Sprintf(`sh -c '%s printf "%%s" "$3" > "$2"; exit %d' sh %q %q {{testExamples}}`, planCheck, tt.exitCode, planPath, ranPath)
 
 			planRequests := 0
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +110,8 @@ func TestRunPlanOut(t *testing.T) {
 				case tt.cacheMiss && r.Method == http.MethodGet:
 					w.WriteHeader(http.StatusNotFound)
 					fmt.Fprint(w, `{"message":"not found"}`)
+				case tt.emptyBody:
+					w.WriteHeader(http.StatusOK)
 				case tt.fallback:
 					fmt.Fprint(w, `{"tasks":{}}`)
 				default:
@@ -115,7 +134,7 @@ func TestRunPlanOut(t *testing.T) {
 				"--organization-slug", "org", "--suite-slug", "suite", "--base-url", svr.URL,
 				"--plan-identifier", "my-plan", "--parallelism", "2", "--parallel-job", strconv.Itoa(tt.node),
 				"--location-prefix", "app/"}
-			if !tt.envOnly {
+			if !tt.envOnly && !tt.noPlanOut {
 				args = append(args, "--plan-out", planPath)
 			}
 			err := cmd.Run(context.Background(), args)
@@ -132,12 +151,16 @@ func TestRunPlanOut(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			contents, err := os.ReadFile(planPath)
-			require.NoError(t, err)
-			if tt.fallback {
-				assert.JSONEq(t, fallbackPlan, string(contents))
+			if tt.noPlanOut {
+				assert.NoFileExists(t, planPath)
 			} else {
-				assert.JSONEq(t, serverPlan, string(contents))
+				contents, err := os.ReadFile(planPath)
+				require.NoError(t, err)
+				if tt.fallback {
+					assert.JSONEq(t, fallbackPlan, string(contents))
+				} else {
+					assert.Equal(t, indentedPlan.String(), string(contents))
+				}
 			}
 			ran, err := os.ReadFile(ranPath)
 			require.NoError(t, err)

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,14 +2,157 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/buildkite/test-engine-client/v3/internal/command"
 	"github.com/buildkite/test-engine-client/v3/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
+
+func TestRunPlanOut(t *testing.T) {
+	serverPlan := `{
+		"identifier":"my-plan","parallelism":2,
+		"tasks":{
+			"0":{"node_number":0,"tests":[{"format":"selector","path":"app/apple","identifier":"apple-id","value":"apple"}]},
+			"1":{"node_number":1,"tests":[{"format":"file","path":"app/banana"}]}
+		},
+		"selection":{"strategy":"percent","params":{"percent":50},"applied":true,"skipped_reason":null},
+		"skipped_tests":[{"format":"example","path":"app/cherry[1:1]","skipped_reason":"selection"}],
+		"server_only":{"future_field":true}
+	}`
+	fallbackPlan := `{"identifier":"my-plan","parallelism":2,"fallback":true,"tasks":{
+		"0":{"node_number":0,"tests":[{"path":"apple"}]},
+		"1":{"node_number":1,"tests":[{"path":"banana"}]}
+	}}`
+
+	for _, tt := range []struct {
+		name       string
+		envOnly    bool
+		cacheMiss  bool
+		fallback   bool
+		billing    bool
+		node       int
+		exitCode   int
+		writeError string
+	}{
+		{name: "cached plan and flag overrides env"},
+		{name: "environment variable", envOnly: true},
+		{name: "freshly created plan", cacheMiss: true},
+		{name: "other node writes entire plan", node: 1},
+		{name: "cached error plan fallback", fallback: true},
+		{name: "created error plan fallback", cacheMiss: true, fallback: true},
+		{name: "API unavailable fallback", fallback: true, billing: true},
+		{name: "test exit status preserved", exitCode: 7},
+		{name: "cannot open destination", writeError: "opening --plan-out file"},
+		{name: "cannot create parents", writeError: "creating --plan-out parent directories"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg = config.New()
+			t.Cleanup(func() { cfg = config.New() })
+			dir := t.TempDir()
+			planPath := filepath.Join(dir, "nested", "plan.json")
+			envPath := filepath.Join(dir, "env-plan.json")
+			if tt.envOnly {
+				planPath = envPath
+			}
+			if tt.writeError == "opening --plan-out file" {
+				planPath = dir
+			} else if tt.writeError != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "nested"), nil, 0o600))
+			}
+			t.Setenv("BUILDKITE_TEST_ENGINE_PLAN_OUT", envPath)
+			targetsPath := filepath.Join(dir, "targets.txt")
+			require.NoError(t, os.WriteFile(targetsPath, []byte("apple\nbanana\n"), 0o600))
+			ranPath := filepath.Join(dir, "ran.txt")
+			// Prove the file exists before tests start, and record the node's runnable target.
+			testCommand := fmt.Sprintf(`sh -c 'test -s "$1" || exit 99; printf "%%s" "$3" > "$2"; exit %d' sh %q %q {{testExamples}}`, tt.exitCode, planPath, ranPath)
+
+			planRequests := 0
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v2/analytics/organizations/org/suites/suite/test_plan" {
+					fmt.Fprint(w, `{}`) // Existing post-run metadata request.
+					return
+				}
+				planRequests++
+				switch {
+				case tt.billing:
+					w.WriteHeader(http.StatusForbidden)
+					fmt.Fprint(w, `{"message":"Billing Error: please update your plan"}`)
+				case tt.cacheMiss && r.Method == http.MethodGet:
+					w.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(w, `{"message":"not found"}`)
+				case tt.fallback:
+					fmt.Fprint(w, `{"tasks":{}}`)
+				default:
+					fmt.Fprint(w, serverPlan)
+				}
+			}))
+			defer svr.Close()
+
+			cmd := &cli.Command{
+				Name: "bktec",
+				Commands: []*cli.Command{{
+					Name: "run", Flags: runCommandFlags(),
+					Action: func(ctx context.Context, cmd *cli.Command) error {
+						return command.Run(ctx, &cfg, cmd.String("files"))
+					},
+				}},
+			}
+			args := []string{"bktec", "run", "--files", targetsPath,
+				"--test-runner", "custom", "--test-file-pattern", "*", "--test-command", testCommand,
+				"--organization-slug", "org", "--suite-slug", "suite", "--base-url", svr.URL,
+				"--plan-identifier", "my-plan", "--parallelism", "2", "--parallel-job", strconv.Itoa(tt.node),
+				"--location-prefix", "app/"}
+			if !tt.envOnly {
+				args = append(args, "--plan-out", planPath)
+			}
+			err := cmd.Run(context.Background(), args)
+			if tt.writeError != "" {
+				require.ErrorContains(t, err, tt.writeError)
+				assert.Contains(t, err.Error(), planPath)
+				assert.NoFileExists(t, ranPath)
+				return
+			}
+			if tt.exitCode != 0 {
+				var exitErr *exec.ExitError
+				require.True(t, errors.As(err, &exitErr), "error = %v", err)
+				assert.Equal(t, tt.exitCode, exitErr.ExitCode())
+			} else {
+				require.NoError(t, err)
+			}
+			contents, err := os.ReadFile(planPath)
+			require.NoError(t, err)
+			if tt.fallback {
+				assert.JSONEq(t, fallbackPlan, string(contents))
+			} else {
+				assert.JSONEq(t, serverPlan, string(contents))
+			}
+			ran, err := os.ReadFile(ranPath)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"apple", "banana"}[tt.node], string(ran))
+			if !tt.envOnly {
+				assert.NoFileExists(t, envPath)
+			}
+			wantRequests := 1
+			if tt.cacheMiss {
+				wantRequests = 2
+			}
+			assert.Equal(t, wantRequests, planRequests, "no extra plan requests")
+		})
+	}
+}
 
 func TestPreviewSelectionEnabled(t *testing.T) {
 	truthyValues := []string{"1", "true", "TRUE", "yes", "on", "t", "y"}

--- a/internal/api/create_test_plan.go
+++ b/internal/api/create_test_plan.go
@@ -87,8 +87,12 @@ func (c Client) CreateTestPlanRaw(ctx context.Context, suiteSlug string, params 
 	}
 
 	var testPlan plan.TestPlan
-	if err := json.Unmarshal(raw, &testPlan); err != nil {
-		return plan.TestPlan{}, nil, fmt.Errorf("parsing test plan: %w", err)
+	// Match doJSONWithRetry: an empty successful response leaves a zero plan,
+	// allowing run to use its existing empty-plan fallback.
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &testPlan); err != nil {
+			return plan.TestPlan{}, nil, fmt.Errorf("parsing test plan: %w", err)
+		}
 	}
 
 	return testPlan, raw, nil

--- a/internal/api/create_test_plan_test.go
+++ b/internal/api/create_test_plan_test.go
@@ -147,6 +147,28 @@ func TestCreateTestPlanRaw(t *testing.T) {
 	}
 }
 
+func TestCreateTestPlanRaw_EmptyBody(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("request method = %q, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	c := NewClient(ClientConfig{ServerBaseURL: svr.URL})
+	got, raw, err := c.CreateTestPlanRaw(context.Background(), "suite", TestPlanParams{})
+	if err != nil {
+		t.Fatalf("CreateTestPlanRaw() error = %v", err)
+	}
+	if diff := cmp.Diff(got, plan.TestPlan{}); diff != "" {
+		t.Errorf("CreateTestPlanRaw() diff (-got +want):\n%s", diff)
+	}
+	if len(raw) != 0 {
+		t.Errorf("CreateTestPlanRaw() raw = %q, want empty", raw)
+	}
+}
+
 func TestCreateTestPlan_SplitByExample(t *testing.T) {
 	params := TestPlanParams{
 		Identifier:  "abc123",

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -38,8 +38,12 @@ func (c Client) FetchTestPlanRaw(ctx context.Context, suiteSlug string, identifi
 	}
 
 	var testPlan plan.TestPlan
-	if err := json.Unmarshal(raw, &testPlan); err != nil {
-		return nil, nil, fmt.Errorf("parsing test plan: %w", err)
+	// Match doJSONWithRetry: an empty successful response leaves a zero plan,
+	// allowing run to use its existing empty-plan fallback.
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &testPlan); err != nil {
+			return nil, nil, fmt.Errorf("parsing test plan: %w", err)
+		}
 	}
 	return &testPlan, raw, nil
 }

--- a/internal/api/fetch_test_plan.go
+++ b/internal/api/fetch_test_plan.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,22 +13,33 @@ import (
 // FetchTestPlan fetchs a test plan from the server.
 // ErrRetryTimeout is returned if the client failed to communicate with the server after exceeding the retry limit.
 func (c Client) FetchTestPlan(ctx context.Context, suiteSlug string, identifier string, jobRetryCount int) (*plan.TestPlan, error) {
+	testPlan, _, err := c.FetchTestPlanRaw(ctx, suiteSlug, identifier, jobRetryCount)
+	return testPlan, err
+}
+
+// FetchTestPlanRaw is like FetchTestPlan but also returns the unmodified JSON
+// response, preserving fields not modeled by the execution structs.
+func (c Client) FetchTestPlanRaw(ctx context.Context, suiteSlug string, identifier string, jobRetryCount int) (*plan.TestPlan, json.RawMessage, error) {
 	url := fmt.Sprintf("%s/v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s&job_retry_count=%d", c.ServerBaseURL, c.OrganizationSlug, suiteSlug, identifier, jobRetryCount)
 
-	var testPlan plan.TestPlan
+	var raw json.RawMessage
 
 	_, err := c.doJSONWithRetry(ctx, httpRequest{
 		Method: http.MethodGet,
 		URL:    url,
-	}, &testPlan)
+	}, &raw)
 
 	if err != nil {
 		var notFoundErr *NotFoundError
 		if errors.As(err, &notFoundErr) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &testPlan, nil
+	var testPlan plan.TestPlan
+	if err := json.Unmarshal(raw, &testPlan); err != nil {
+		return nil, nil, fmt.Errorf("parsing test plan: %w", err)
+	}
+	return &testPlan, raw, nil
 }

--- a/internal/api/fetch_test_plan_test.go
+++ b/internal/api/fetch_test_plan_test.go
@@ -82,6 +82,28 @@ func TestFetchTestPlan(t *testing.T) {
 	}
 }
 
+func TestFetchTestPlanRaw_EmptyBody(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("request method = %q, want GET", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	c := NewClient(ClientConfig{ServerBaseURL: svr.URL})
+	got, raw, err := c.FetchTestPlanRaw(context.Background(), "suite", "plan", 0)
+	if err != nil {
+		t.Fatalf("FetchTestPlanRaw() error = %v", err)
+	}
+	if diff := cmp.Diff(got, &plan.TestPlan{}); diff != "" {
+		t.Errorf("FetchTestPlanRaw() diff (-got +want):\n%s", diff)
+	}
+	if len(raw) != 0 {
+		t.Errorf("FetchTestPlanRaw() raw = %q, want empty", raw)
+	}
+}
+
 func TestFetchTestPlan_NotFound(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -2,11 +2,13 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -72,9 +74,17 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 		OrganizationSlug: cfg.OrganizationSlug,
 	})
 
-	testPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, testTargets, testRunner)
+	testPlan, rawPlan, err := fetchOrCreateTestPlan(ctx, apiClient, cfg, testTargets, testRunner)
 	if err != nil {
 		return err
+	}
+
+	// Save the entire plan before applying node-specific location-prefix trims
+	// or retries. The raw response retains selection and other server-only fields.
+	if cfg.PlanOut != "" {
+		if err := writeRunPlan(cfg, testPlan, rawPlan); err != nil {
+			return err
+		}
 	}
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
@@ -534,17 +544,18 @@ func logSignalAndExit(name string, signal syscall.Signal) {
 
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, testTargets []string, testRunner runner.TestRunner) (plan.TestPlan, error) {
+// The raw response is nil for a local fallback.
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, testTargets []string, testRunner runner.TestRunner) (plan.TestPlan, json.RawMessage, error) {
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.
-	cachedPlan, err := apiClient.FetchTestPlan(ctx, cfg.SuiteSlug, cfg.Identifier, cfg.JobRetryCount)
+	cachedPlan, raw, err := apiClient.FetchTestPlanRaw(ctx, cfg.SuiteSlug, cfg.Identifier, cfg.JobRetryCount)
 
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
-			return plan.TestPlan{}, handledErr
+			return plan.TestPlan{}, nil, handledErr
 		}
-		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil, nil
 	}
 
 	if cachedPlan != nil {
@@ -552,11 +563,11 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 		// In this case, we should create a fallback plan.
 		if len(cachedPlan.Tasks) == 0 {
 			warnErrorPlan()
-			return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
+			return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil, nil
 		}
 
 		debug.Printf("Test plan found. Identifier: %q", cfg.Identifier)
-		return *cachedPlan, nil
+		return *cachedPlan, raw, nil
 	}
 
 	debug.Println("No test plan found, creating a new plan")
@@ -570,28 +581,59 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	params, err := createRequestParam(ctx, cfg, testTargets, *apiClient, testRunner)
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
-			return plan.TestPlan{}, handledErr
+			return plan.TestPlan{}, nil, handledErr
 		}
-		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil, nil
 	}
 
 	debug.Println("Creating test plan")
-	testPlan, err := apiClient.CreateTestPlan(ctx, cfg.SuiteSlug, params)
+	testPlan, raw, err := apiClient.CreateTestPlanRaw(ctx, cfg.SuiteSlug, params)
 
 	if err != nil {
 		if handledErr := handleError(err); handledErr != nil {
-			return plan.TestPlan{}, handledErr
+			return plan.TestPlan{}, nil, handledErr
 		}
-		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil, nil
 	}
 
 	// The server can return an "error" plan indicated by an empty task list (i.e. `{"tasks": {}}`).
 	// In this case, we should create a fallback plan.
 	if len(testPlan.Tasks) == 0 {
 		warnErrorPlan()
-		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil
+		return plan.CreateFallbackPlan(testTargets, cfg.Parallelism), nil, nil
 	}
 
 	debug.Printf("Test plan created. Identifier: %q", cfg.Identifier)
-	return testPlan, nil
+	return testPlan, raw, nil
+}
+
+// writeRunPlan writes the server response, or the actual local fallback split.
+// Unlike plan --plan-out, this is file-only: stdout contains test runner output.
+func writeRunPlan(cfg *config.Config, testPlan plan.TestPlan, raw json.RawMessage) error {
+	if testPlan.Fallback {
+		var err error
+		raw, err = json.Marshal(struct {
+			Identifier  string                `json:"identifier"`
+			Parallelism int                   `json:"parallelism"`
+			Tasks       map[string]*plan.Task `json:"tasks"`
+			Fallback    bool                  `json:"fallback"`
+		}{cfg.Identifier, cfg.Parallelism, testPlan.Tasks, true})
+		if err != nil {
+			return fmt.Errorf("encoding --plan-out fallback: %w", err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.PlanOut), 0o755); err != nil {
+		return fmt.Errorf("creating --plan-out parent directories for %q: %w", cfg.PlanOut, err)
+	}
+	f, err := os.Create(cfg.PlanOut)
+	if err != nil {
+		return fmt.Errorf("opening --plan-out file %q: %w", cfg.PlanOut, err)
+	}
+	writeErr := writeIndentedJSON(f, raw)
+	closeErr := f.Close()
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		return fmt.Errorf("writing --plan-out file %q: %w", cfg.PlanOut, err)
+	}
+	return nil
 }

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -630,10 +630,11 @@ func TestFetchOrCreateTestPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	got, raw, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
+	assert.JSONEq(t, response, string(raw))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
@@ -707,7 +708,7 @@ func TestFetchOrCreateTestPlan_CollectsGitMetadataWhenSelectionActive(t *testing
 	}
 	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
 
-	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
+	if _, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
 		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
 	}
 
@@ -736,7 +737,7 @@ func TestFetchOrCreateTestPlan_NoGitMetadataWithoutSelection(t *testing.T) {
 	}
 	apiClient := api.NewClient(api.ClientConfig{ServerBaseURL: cfg.ServerBaseURL})
 
-	if _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
+	if _, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner); err != nil {
 		t.Fatalf("fetchOrCreateTestPlan(...) error = %v", err)
 	}
 
@@ -824,10 +825,11 @@ func TestFetchOrCreateTestPlan_CachedPlan(t *testing.T) {
 		},
 	}
 
-	got, err := fetchOrCreateTestPlan(context.Background(), apiClient, &cfg, tests, testRunner)
+	got, raw, err := fetchOrCreateTestPlan(context.Background(), apiClient, &cfg, tests, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, tests, err)
 	}
+	assert.JSONEq(t, cachedPlan, string(raw))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, tests, diff)
 	}
@@ -863,10 +865,11 @@ func TestFetchOrCreateTestPlan_PlanError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, TestRunner)
+	got, raw, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, TestRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
+	assert.Nil(t, raw)
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
@@ -906,10 +909,11 @@ func TestFetchOrCreateTestPlan_InternalServerError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, &cfg, files, testRunner)
+	got, raw, err := fetchOrCreateTestPlan(fetchCtx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
+	assert.Nil(t, raw)
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) diff (-got +want):\n%s", cfg, files, diff)
 	}
@@ -947,7 +951,7 @@ func TestFetchOrCreateTestPlan_SelectorOptInFallbackUsesPathTasks(t *testing.T) 
 		ServerBaseURL: cfg.ServerBaseURL,
 	})
 
-	got, err := fetchOrCreateTestPlan(fetchCtx, apiClient, &cfg, packages, testRunner)
+	got, _, err := fetchOrCreateTestPlan(fetchCtx, apiClient, &cfg, packages, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, packages, err)
 	}
@@ -994,7 +998,7 @@ func TestFetchOrCreateTestPlan_BadRequest(t *testing.T) {
 	// we want the function to return an empty test plan and an error
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	got, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Invalid Request:")
 	assert.Contains(t, err.Error(), "Invalid parameters: runner is required")
@@ -1032,7 +1036,7 @@ func TestFetchOrCreateTestPlan_BillingError(t *testing.T) {
 	// we want the function to return a fallback plan
 	want := plan.CreateFallbackPlan(files, cfg.Parallelism)
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	got, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	if err != nil {
 		t.Errorf("fetchOrCreateTestPlan(ctx, %v, %v) error = %v", cfg, files, err)
 	}
@@ -1072,7 +1076,7 @@ func TestFetchOrCreateTestPlan_AuthError(t *testing.T) {
 
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	got, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Authentication Failed:")
 	assert.Contains(t, err.Error(), "Authentication required. Please supply a valid API Access Token")
@@ -1109,7 +1113,7 @@ func TestFetchOrCreateTestPlan_ForbiddenError(t *testing.T) {
 
 	want := plan.TestPlan{}
 
-	got, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
+	got, _, err := fetchOrCreateTestPlan(ctx, apiClient, &cfg, files, testRunner)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "❌ Access Denied:")
 	assert.Contains(t, err.Error(), "Your access token doesn't have the write_suites scope")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,9 +63,8 @@ type Config struct {
 	Output string `json:"-"`
 	// Parallelism is the number of parallel tasks to run.
 	Parallelism int `json:"-"`
-	// PlanOut is the destination for the `bktec plan --plan-out` output: "-" for
-	// stdout, or a file path. The full test plan is written as the server's
-	// response, unmodified.
+	// PlanOut is the full test plan output path for run and plan. Only plan
+	// supports "-" for stdout. Run marks local fallback plans with fallback: true.
 	PlanOut string `json:"-"`
 	// Remote is the git remote name for fetching missing commits and detecting default branch (default "origin").
 	Remote string `json:"-"`


### PR DESCRIPTION
### Description

Let consumers save the plan `bktec run` actually uses instead of fetching it again. bk/bk's plan-aware RSpec verification currently re-requests the cached plan on shard 0 with a fresh OIDC token; saving it in bktec removes that extra request and token handling, and records local fallback runs accurately.

```sh
bktec run --plan-out tmp/test-engine/plan.json
# Or:
BUILDKITE_TEST_ENGINE_PLAN_OUT=tmp/test-engine/plan.json bktec run
```

### Context

- [bk/bk plan-aware RSpec verification](https://github.com/buildkite/buildkite/pull/33801)
- Related to [TE-6949](https://linear.app/buildkite/issue/TE-6949) (this does not complete its broader Austral rollout/evaluation scope).

### Changes

- Add the run-only env binding `BUILDKITE_TEST_ENGINE_PLAN_OUT`; the CLI flag takes precedence. Create parent directories and overwrite the destination before executing tests. File open/write/close failures stop the run with exit 16; otherwise runner exit semantics are unchanged.
- Write the full cached or freshly created API response as indented JSON with a trailing newline, before node-specific prefix trimming or retries. Preserve every server field, including `selection`, `skipped_reason`, and fields not modeled by the execution structs. Every node writes the entire plan; no extra network requests are added.
- For local full-suite fallback splitting, write the actual tasks, configured identifier and parallelism, and explicit `"fallback": true`. Empty server error plans are replaced by the fallback bktec actually executes, not emitted as empty plans.
- `run --plan-out` is file-only: `-` is a literal filename, not stdout, which already carries test output. Existing `plan --plan-out` behavior is unchanged.
- Document the contract in help, README, and CHANGELOG.

Example server-plan contents (all additional API fields are retained):

```json
{
  "identifier": "build-id/step-id",
  "parallelism": 1,
  "tasks": {
    "0": {
      "node_number": 0,
      "tests": [{"format": "selector", "path": "spec/apple_spec.rb", "identifier": "apple-id", "value": "spec/apple_spec.rb"}]
    }
  },
  "selection": {"strategy": "austral", "applied": true, "skipped_reason": null}
}
```

Local fallback uses the same node/task shape, with path-only tests:

```json
{"identifier":"build-id/step-id","parallelism":1,"tasks":{"0":{"node_number":0,"tests":[{"path":"spec/apple_spec.rb"}]}},"fallback":true}
```

### Testing

Set up fixtures with `bin/setup`; Python tests use the worktree's `.venv` and `CI=true`. Tests cover cache hits/misses, both empty-plan fallback paths, API-error fallback, env/flag precedence, both nodes retaining the full response, prefix trimming, write errors preventing execution, and preserving test exit status 7.

Addressed both [independent review findings](https://github.com/buildkite/test-engine-client/pull/633#issuecomment-5557597546): empty HTTP 200 bodies now leave a zero plan on both GET and POST, restoring local fallback with or without `--plan-out`. New API and run-level tests failed before the fix and pass after it. Server-plan output is compared byte-for-byte with the re-indented original, including `1.0`, `1e3`, `-0.0`, a 23-digit integer, `\u00e9`, nulls, unknown fields, key order, and the trailing newline.

- `go build ./...`: exit 0, no output.
- `go vet ./...`: exit 0, no output.
- `golangci-lint fmt --diff` on changed Go files: exit 0, no output (gofmt/goimports).
- `golangci-lint run` v2.5.0 (matching CI): `0 issues.`
- `git diff --check`: exit 0, no output.
- `go run . run --help`: confirmed `--plan-out PATH`, env var, fallback marker, and write-failure behavior.
- `./bin/test`: `DONE 613 tests in 34.775s`

`source .venv/bin/activate; export CI=true; go test ./...`:

```text
ok  	github.com/buildkite/test-engine-client/v3	0.300s
ok  	github.com/buildkite/test-engine-client/v3/internal/api	6.810s
ok  	github.com/buildkite/test-engine-client/v3/internal/command	33.754s
ok  	github.com/buildkite/test-engine-client/v3/internal/config	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/debug	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/git	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/otlprelay	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/packaging	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/plan	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/runner	38.945s
ok  	github.com/buildkite/test-engine-client/v3/internal/upload	(cached)
?   	github.com/buildkite/test-engine-client/v3/internal/version	[no test files]
?   	github.com/buildkite/test-engine-client/v3/util/supported_features	[no test files]
```

Full-suite race check, `source .venv/bin/activate; export CI=true; go test -race ./...`:

```text
ok  	github.com/buildkite/test-engine-client/v3	1.601s
ok  	github.com/buildkite/test-engine-client/v3/internal/api	8.131s
ok  	github.com/buildkite/test-engine-client/v3/internal/command	34.289s
ok  	github.com/buildkite/test-engine-client/v3/internal/config	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/debug	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/git	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/otlprelay	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/packaging	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/plan	(cached)
ok  	github.com/buildkite/test-engine-client/v3/internal/runner	36.377s
ok  	github.com/buildkite/test-engine-client/v3/internal/upload	(cached)
?   	github.com/buildkite/test-engine-client/v3/internal/version	[no test files]
?   	github.com/buildkite/test-engine-client/v3/util/supported_features	[no test files]
```

Opt-in, with no migration required. Rollback: remove the flag/env setting, or revert this change; consumers must retain their previous plan-fetching path until they adopt a release containing it.
