### PR TITLE
Improve test selection logging

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -80,6 +80,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	}
 
+	plan.PrintSelectionSummary(os.Stderr, testPlan, cfg.SelectionStrategy)
 	printSplitSummary(os.Stderr, testPlan)
 
 	switch outputFormat {
@@ -169,6 +170,7 @@ func planOut(ctx context.Context, cfg *config.Config, testTargets []string, apiC
 	}
 
 	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
+	plan.PrintSelectionSummary(os.Stderr, testPlan, cfg.SelectionStrategy)
 	printSplitSummary(os.Stderr, testPlan)
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -89,6 +89,7 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
 
+	plan.PrintSelectionSummary(os.Stdout, testPlan, cfg.SelectionStrategy)
 	printSplitSummary(os.Stdout, testPlan)
 
 	// get plan for this node

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -23,7 +23,7 @@ func PrintSelectionSummary(w io.Writer, p TestPlan, strategy string) {
 		reason := p.Selection.SkippedReason
 		switch reason {
 		case "no_changed_files":
-			reason = "no changed files were provided"
+			reason = "no changed files"
 		case "no_model":
 			reason = "no active model was available"
 		case "invoke_error":

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -7,6 +7,36 @@ import (
 	"strconv"
 )
 
+// PrintSelectionSummary writes a human-readable summary of test selection to
+// w (typically os.Stderr). Plans without selection metadata are skipped.
+func PrintSelectionSummary(w io.Writer, p TestPlan, strategy string) {
+	if p.Selection == nil {
+		return
+	}
+
+	fmt.Fprintln(w, "\n+++ Buildkite Test Engine Client: 🎯 Selection summary")
+	fmt.Fprintf(w, "Selected %d of %d tests\n", p.Selection.SelectedCount, p.Selection.CandidateCount)
+	if strategy != "" {
+		fmt.Fprintf(w, "Selection strategy: %s\n", strategy)
+	}
+	if !p.Selection.Applied {
+		reason := p.Selection.SkippedReason
+		switch reason {
+		case "no_changed_files":
+			reason = "no changed files were provided"
+		case "no_model":
+			reason = "no active model was available"
+		case "invoke_error":
+			reason = "model invocation failed"
+		}
+		if reason == "" {
+			fmt.Fprintln(w, "⚠️ Selection was not applied")
+		} else {
+			fmt.Fprintf(w, "⚠️ Selection was not applied: %s\n", reason)
+		}
+	}
+}
+
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
 // to w (typically os.Stderr). At parallelism > 1 it uses per-format
 // TimingMetadata to break down known vs unknown cases. At parallelism == 1 the

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -8,6 +8,98 @@ import (
 
 func fp(v float64) *float64 { return &v }
 
+func TestPrintSelectionSummary(t *testing.T) {
+	p := TestPlan{
+		Selection: &SelectionMetadata{
+			Applied:        true,
+			CandidateCount: 100,
+			SelectedCount:  40,
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintSelectionSummary(&buf, p, "manual")
+
+	want := "\n+++ Buildkite Test Engine Client: 🎯 Selection summary\n" +
+		"Selected 40 of 100 tests\n" +
+		"Selection strategy: manual\n"
+	if got := buf.String(); got != want {
+		t.Errorf("PrintSelectionSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestPrintSelectionSummary_SkipsWhenNoSelectionMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	PrintSelectionSummary(&buf, TestPlan{}, "manual")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got: %s", buf.String())
+	}
+}
+
+func TestPrintSelectionSummary_OmitsUnknownStrategy(t *testing.T) {
+	p := TestPlan{Selection: &SelectionMetadata{Applied: true, CandidateCount: 10, SelectedCount: 10}}
+
+	var buf bytes.Buffer
+	PrintSelectionSummary(&buf, p, "")
+	got := buf.String()
+	if !strings.Contains(got, "Selected 10 of 10 tests") {
+		t.Errorf("output missing selection counts: %s", got)
+	}
+	if strings.Contains(got, "Selection strategy:") {
+		t.Errorf("unexpected empty selection strategy: %s", got)
+	}
+}
+
+func TestPrintSelectionSummary_ExplainsWhenSelectionWasNotApplied(t *testing.T) {
+	tests := map[string]string{
+		"no_changed_files": "no changed files were provided",
+		"no_model":         "no active model was available",
+		"invoke_error":     "model invocation failed",
+		"future_reason":    "future_reason",
+		"":                 "",
+	}
+
+	for reason, message := range tests {
+		t.Run(reason, func(t *testing.T) {
+			p := TestPlan{Selection: &SelectionMetadata{
+				CandidateCount: 10,
+				SelectedCount:  10,
+				SkippedReason:  reason,
+			}}
+
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, p, "xgboost")
+			want := "⚠️ Selection was not applied"
+			if message != "" {
+				want += ": " + message
+			}
+			if !strings.Contains(buf.String(), want) {
+				t.Errorf("output missing %q: %s", want, buf.String())
+			}
+		})
+	}
+}
+
+func TestSelectionAndSplitSummariesHaveOneEmptyLineBetweenThem(t *testing.T) {
+	p := TestPlan{
+		Parallelism: 1,
+		Tasks: map[string]*Task{
+			"0": {NodeNumber: 0, Tests: []TestCase{{Path: "a"}}},
+		},
+		Selection:      &SelectionMetadata{Applied: true, CandidateCount: 2, SelectedCount: 1},
+		TimingMetadata: &TimingMetadata{},
+	}
+
+	var buf bytes.Buffer
+	PrintSelectionSummary(&buf, p, "manual")
+	PrintSplitSummary(&buf, p)
+
+	want := "Selection strategy: manual\n\n+++ Buildkite Test Engine Client: 📊 Split summary"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("expected one empty line between summaries, got: %q", buf.String())
+	}
+}
+
 func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 	p := TestPlan{
 		Parallelism: 2,

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -52,7 +52,7 @@ func TestPrintSelectionSummary_OmitsUnknownStrategy(t *testing.T) {
 
 func TestPrintSelectionSummary_ExplainsWhenSelectionWasNotApplied(t *testing.T) {
 	tests := map[string]string{
-		"no_changed_files": "no changed files were provided",
+		"no_changed_files": "no changed files",
 		"no_model":         "no active model was available",
 		"invoke_error":     "model invocation failed",
 		"future_reason":    "future_reason",

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -54,6 +54,15 @@ type FormatTimingMetadata struct {
 	DefaultDuration float64 `json:"default_duration"`
 }
 
+// SelectionMetadata describes the result of applying test selection before
+// the selected tests are split across nodes.
+type SelectionMetadata struct {
+	Applied        bool   `json:"applied"`
+	CandidateCount int    `json:"candidate_count"`
+	SelectedCount  int    `json:"selected_count"`
+	SkippedReason  string `json:"skipped_reason,omitempty"`
+}
+
 // Task represents the task for the given node.
 type Task struct {
 	NodeNumber int `json:"node_number"`
@@ -72,6 +81,9 @@ type TestPlan struct {
 	Fallback     bool
 	MutedTests   []TestCase `json:"muted_tests,omitempty"`
 	SkippedTests []TestCase `json:"skipped_tests,omitempty"`
+	// Selection describes how many candidate tests remained after selection.
+	// Nil when no selection strategy was requested or for older cached plans.
+	Selection *SelectionMetadata `json:"selection,omitempty"`
 	// TimingMetadata describes the historical timing data the server used to
 	// build this plan. Nil when missing (e.g. error plans, plans cached before
 	// the server began emitting it).

--- a/internal/plan/type_test.go
+++ b/internal/plan/type_test.go
@@ -24,7 +24,8 @@ func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
 			"file": {"median_duration": 1200, "default_duration": 1000},
 			"example": {"median_duration": 800, "default_duration": 1000},
 			"selector": {"median_duration": 2000, "default_duration": 1000}
-		}
+		},
+		"selection": {"applied": true, "candidate_count": 100, "selected_count": 40}
 	}`
 
 	var p TestPlan
@@ -55,6 +56,12 @@ func TestTestPlan_UnmarshalWithTimingMetadata(t *testing.T) {
 	}
 	if p.TimingMetadata.Selector.MedianDuration == nil || *p.TimingMetadata.Selector.MedianDuration != 2000 {
 		t.Errorf("Selector.MedianDuration = %v, want 2000", p.TimingMetadata.Selector.MedianDuration)
+	}
+	if p.Selection == nil {
+		t.Fatal("Selection is nil, want non-nil")
+	}
+	if diff := cmp.Diff(*p.Selection, SelectionMetadata{Applied: true, CandidateCount: 100, SelectedCount: 40}); diff != "" {
+		t.Errorf("Selection diff (-got +want):\n%s", diff)
 	}
 	gotTests := p.Tasks["0"].Tests
 	wantTests := []TestCase{


### PR DESCRIPTION
### Description

Add a concise selection summary before the existing split summary so builds show how many candidate tests were selected and which strategy was requested. When selection is not applied, explain the server-provided reason.
<img width="484" height="119" alt="Screenshot 2026-09-08 at 4 13 43 PM" src="https://github.com/user-attachments/assets/a08a8577-5bc7-424d-9fe1-f50a6a553e5f" />

<img width="550" height="202" alt="Screenshot 2026-09-08 at 4 19 50 PM" src="https://github.com/user-attachments/assets/a55eefb5-92f4-47aa-b45b-0ab844d67390" />


### Context

[TE-7017: Better bktec logging for test selection](https://linear.app/buildkite/issue/TE-7017/better-bktec-logging-for-test-selection)

### Changes

- Decode selection metadata returned with test plans.
- Print selection summaries from both `bktec plan` and `bktec run`.
- Humanize known selection skip reasons while retaining unknown reason codes.
- Keep one empty line between selection and split summaries.

### Testing

- `go test ./internal/plan ./internal/api`
- `go test ./internal/command -skip 'TestCreateRequestParams_(WithTagFilters|SelectorSplittingWithTagFilters)$'`
- Manually exercised manual selection, selection-not-applied, and empty/error-plan fallback states on the local Test Engine sample pipeline.