### PR TITLE
Explain requested selection and returned test plans in CI logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## Unreleased
 - Add `bktec run --plan-out <path>` (env: `BUILDKITE_TEST_ENGINE_PLAN_OUT`) to save the full cached or freshly created API plan before running tests, retaining selection and server-only fields without extra requests. Local fallback output includes the actual tasks and `fallback: true`. Parent directories are created; write failures stop the run.
-- Explain requested selection and returned plans in one planning stderr group for `bktec plan` and `run`, including cached-plan provenance and available selection, duration, and sizing metadata. Replace the ASCII banner with a version line and move the run split summary from stdout to stderr; JSON and raw plan output are unchanged.
+- Explain requested selection and returned plans in one concise planning stderr group for `bktec plan` and `run`, including test selector counts, compute share, timing coverage, and binding node limits when metadata is available. Omit repeated selection parameters and routine create-response labels. Replace the ASCII banner with a version line and move the run split summary from stdout to stderr; JSON and raw plan output are unchanged.
 
 ## 3.0.0 - 2026-07-31
 - ⚠️ **BREAKING:** Selector-based splitting now replaces file-based splitting for supported runners. The deprecated `--selector-splitting` flag and `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING` environment variable are still accepted for upgrade compatibility, but their values no longer affect behavior. Existing bktec v2 releases continue to send file-based requests and remain compatible with file-based splitting; remain on v2 if file-based requests are required. See [Migrating from bktec v2 to v3](./docs/migrating-to-v3.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 - Add `bktec run --plan-out <path>` (env: `BUILDKITE_TEST_ENGINE_PLAN_OUT`) to save the full cached or freshly created API plan before running tests, retaining selection and server-only fields without extra requests. Local fallback output includes the actual tasks and `fallback: true`. Parent directories are created; write failures stop the run.
+- Explain requested selection and returned plans in one planning stderr group for `bktec plan` and `run`, including cached-plan provenance and available selection, duration, and sizing metadata. Replace the ASCII banner with a version line and move the run split summary from stdout to stderr; JSON and raw plan output are unchanged.
 
 ## 3.0.0 - 2026-07-31
 - ⚠️ **BREAKING:** Selector-based splitting now replaces file-based splitting for supported runners. The deprecated `--selector-splitting` flag and `BUILDKITE_TEST_ENGINE_SELECTOR_SPLITTING` environment variable are still accepted for upgrade compatibility, but their values no longer affect behavior. Existing bktec v2 releases continue to send file-based requests and remain compatible with file-based splitting; remain on v2 if file-based requests are required. See [Migrating from bktec v2 to v3](./docs/migrating-to-v3.md).

--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ Returned selection parameters appear only when they differ from this invocation;
 matching values do not establish that the invocation created the plan. Ordinary
 values use `key = value`; whitespace/control characters are escaped, long values
 are bounded, and unknown request payloads are omitted.
+Returned strategy names are displayed as bounded, escaped text, including names
+introduced by newer servers. Applied/skipped status comes from the returned
+metadata, not the strategy name or this invocation's settings.
 
 Selection counts use the backend's eligible denominator, labelled **test
 selectors**, even when it includes a mixture of file and example formats.

--- a/README.md
+++ b/README.md
@@ -271,8 +271,11 @@ selection counts, and estimated selected/candidate cumulative compute share
 with timing coverage. That share is not the requested duration cutoff or a
 wall-clock saving. Split diagnostics explain the actual sizing method,
 independently binding caps (not merely reached caps), and the P90-packed
-longest-node test-work estimate versus the target actually used. Sparse-history
-sizing does not use the configured target. Estimates are not runtime guarantees;
+longest-node test-work estimate versus the target actually used. The required
+node count labels its returned decision basis (mean or P90); an absent or unknown
+basis is not inferred. A P90 allocation estimate above target does not establish
+that a mean-based sizing estimate missed it. Sparse-history and unusable-timing
+sizing do not use the configured target. Estimates are not runtime guarantees;
 older plans or unavailable metadata leave these details unknown rather than
 inferring them from current flags.
 

--- a/README.md
+++ b/README.md
@@ -260,9 +260,21 @@ the muted and skipped tests, and the timing metadata. It takes a destination:
 ./bktec plan --plan-out plan.json    # a file
 ```
 
-The human-readable split summary and any warnings are written to stderr, so
+The human-readable planning summary and any warnings are written to stderr, so
 stdout carries only the plan. `--json`, `--plan-out` and `--pipeline-upload`
 are mutually exclusive; choose one.
+
+Both `plan` and `run` distinguish this invocation's requested selection and
+split settings from the returned plan, which may be cached. When supplied by
+the server, the summary shows the applied or attempted/skipped strategy,
+selection counts, and estimated selected/candidate cumulative compute share
+with timing coverage. That share is not the requested duration cutoff or a
+wall-clock saving. Split diagnostics explain the actual sizing method,
+independently binding caps (not merely reached caps), and the P90-packed
+longest-node test-work estimate versus the target actually used. Sparse-history
+sizing does not use the configured target. Estimates are not runtime guarantees;
+older plans or unavailable metadata leave these details unknown rather than
+inferring them from current flags.
 
 `--plan-out` writes what the server returns, unmodified. If the server cannot
 generate a plan it returns an empty plan, which is emitted as-is (a warning is

--- a/README.md
+++ b/README.md
@@ -265,19 +265,33 @@ stdout carries only the plan. `--json`, `--plan-out` and `--pipeline-upload`
 are mutually exclusive; choose one.
 
 Both `plan` and `run` distinguish this invocation's requested selection and
-split settings from the returned plan, which may be cached. When supplied by
-the server, the summary shows the applied or attempted/skipped strategy,
-selection counts, and estimated selected/candidate cumulative compute share
-with timing coverage. That share is not the requested duration cutoff or a
-wall-clock saving. Split diagnostics explain the actual sizing method,
-independently binding caps (not merely reached caps), and the P90-packed
-longest-node test-work estimate versus the target actually used. The required
-node count labels its returned decision basis (mean or P90); an absent or unknown
-basis is not inferred. A P90 allocation estimate above target does not establish
-that a mean-based sizing estimate missed it. Sparse-history and unusable-timing
-sizing do not use the configured target. Estimates are not runtime guarantees;
-older plans or unavailable metadata leave these details unknown rather than
-inferring them from current flags.
+split settings (`Requested`) from the returned `Selection summary` and `Split
+summary`. The returned plan may be cached: `Using existing plan` identifies a
+successful fetch, while a create response makes no claim about cache status.
+Returned selection parameters appear only when they differ from this invocation;
+matching values do not establish that the invocation created the plan. Ordinary
+values use `key = value`; whitespace/control characters are escaped, long values
+are bounded, and unknown request payloads are omitted.
+
+Selection counts use the backend's eligible denominator, labelled **test
+selectors**, even when it includes a mixture of file and example formats.
+`Estimated compute` compares selected and candidate cumulative mean durations
+using the same candidate-pool median/default fallbacks. It requires supported
+metadata and at least 50% candidate timing coverage. Its share is not the
+requested duration cutoff or a wall-clock saving; a zero candidate total has no
+defined share. It does not use the separate top-level duration estimates.
+
+`Estimated nodes needed` is the pre-cap count and labels the returned sizing
+basis (mean or P90 durations, including median/default fallbacks). `Node limit:
+capped at N` appears only for an independently binding cap, not merely a reached
+limit; tied constraints are not independently binding. The longest-node estimate
+uses the actual P90-packed allocation. `P90 durations; target exceeded` compares
+that estimate with the target used by sizing, not the mean decision estimate or
+whole-build runtime. Sparse-history and unusable-timing sizing do not use the
+configured target. Estimates are not runtime guarantees, and zero estimates do
+not promise instant execution. Older plans and unknown estimators leave details
+unavailable rather than inferring them from current flags. Historical timing
+counts and missing-history median/default estimates remain visible separately.
 
 `--plan-out` writes what the server returns, unmodified. If the server cannot
 generate a plan it returns an empty plan, which is emitted as-is (a warning is

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -41,6 +41,17 @@ func printWarn(label, message string, hints ...string) {
 	printWarning(os.Stderr, label+": "+message, append(hints, fallbackExtra)...)
 }
 
+const sourceCreateResponse = "create endpoint response (may be cached)"
+
+func printPlanningSummary(w io.Writer, testPlan plan.TestPlan, source string) {
+	if testPlan.Fallback {
+		source = "local fallback"
+	}
+	fmt.Fprintln(w, "Plan source: "+source)
+	plan.PrintSelectionSummary(w, testPlan)
+	printSplitSummary(w, testPlan)
+}
+
 // printSplitSummary prints the plan summary and warns when a selector plan had
 // to use default durations because no selector timing history was available.
 func printSplitSummary(w io.Writer, testPlan plan.TestPlan) {

--- a/internal/command/errors.go
+++ b/internal/command/errors.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/buildkite/test-engine-client/v3/internal/api"
+	"github.com/buildkite/test-engine-client/v3/internal/config"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
 )
 
@@ -41,14 +42,21 @@ func printWarn(label, message string, hints ...string) {
 	printWarning(os.Stderr, label+": "+message, append(hints, fallbackExtra)...)
 }
 
-const sourceCreateResponse = "create endpoint response (may be cached)"
+const sourceCreateResponse = ""
 
-func printPlanningSummary(w io.Writer, testPlan plan.TestPlan, source string) {
+func printPlanningSummary(w io.Writer, testPlan plan.TestPlan, source string, cfg *config.Config) {
+	fmt.Fprintln(w)
 	if testPlan.Fallback {
-		source = "local fallback"
+		fmt.Fprint(w, "Using local fallback\n\n")
+	} else if source != sourceCreateResponse {
+		fmt.Fprint(w, "Using existing plan\n\n")
 	}
-	fmt.Fprintln(w, "Plan source: "+source)
-	plan.PrintSelectionSummary(w, testPlan)
+	var requested map[string]string
+	if selection := buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams); selection != nil {
+		requested = selection.Params
+	}
+	plan.PrintSelectionSummary(w, testPlan, requested)
+	fmt.Fprintln(w)
 	printSplitSummary(w, testPlan)
 }
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -79,7 +79,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	}
 
-	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse)
+	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse, cfg)
 
 	switch outputFormat {
 
@@ -168,7 +168,7 @@ func planOut(ctx context.Context, cfg *config.Config, testTargets []string, apiC
 	}
 
 	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
-	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse)
+	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse, cfg)
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}
@@ -197,7 +197,7 @@ func planOutWriter(dest string) (io.Writer, func(), error) {
 // parallelism are emitted.
 func emitLocalFallback(out io.Writer, cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
-	printPlanningSummary(os.Stderr, makeFallbackPlan(cfg), "local fallback")
+	printPlanningSummary(os.Stderr, makeFallbackPlan(cfg), "local fallback", cfg)
 
 	// A fixed-shape struct of plain fields, so marshalling cannot fail.
 	encoded, _ := json.MarshalIndent(struct {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/git"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
 	"github.com/buildkite/test-engine-client/v3/internal/runner"
-	"github.com/buildkite/test-engine-client/v3/internal/version"
 )
 
 type PlanOutput int
@@ -36,7 +35,7 @@ var (
 
 // This command creates a test plan via the API
 func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFormat PlanOutput, template string) error {
-	fmt.Fprintln(os.Stderr, "+++ Buildkite Test Engine Client: bktec "+version.Version+"\n")
+	printPlanningRequest(os.Stderr, cfg)
 
 	// Auto-collect git metadata when selection is active or explicitly requested
 	if cfg.SelectionStrategy != "" || cfg.CollectGitMetadata {
@@ -80,7 +79,7 @@ func Plan(ctx context.Context, cfg *config.Config, testFileList string, outputFo
 		debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
 	}
 
-	printSplitSummary(os.Stderr, testPlan)
+	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse)
 
 	switch outputFormat {
 
@@ -169,7 +168,7 @@ func planOut(ctx context.Context, cfg *config.Config, testTargets []string, apiC
 	}
 
 	debug.Printf("Test plan created. Identifier: %q, Parallelism: %d", testPlan.Identifier, testPlan.Parallelism)
-	printSplitSummary(os.Stderr, testPlan)
+	printPlanningSummary(os.Stderr, testPlan, sourceCreateResponse)
 	if testPlan.Parallelism == 0 {
 		fmt.Fprintln(os.Stderr, "⚠️ Parallelism is 0, there is nothing to run.")
 	}
@@ -198,6 +197,7 @@ func planOutWriter(dest string) (io.Writer, func(), error) {
 // parallelism are emitted.
 func emitLocalFallback(out io.Writer, cfg *config.Config) error {
 	fmt.Fprintln(os.Stderr, "⚠️ This is a locally-computed fallback plan, not a plan from the server.")
+	printPlanningSummary(os.Stderr, makeFallbackPlan(cfg), "local fallback")
 
 	// A fixed-shape struct of plain fields, so marshalling cannot fail.
 	encoded, _ := json.MarshalIndent(struct {

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -39,9 +39,19 @@ func TestPlanJSON(t *testing.T) {
 	setPlanWriter(t, &buf)
 
 	// This is the method under test
+	getStderr := captureStderr(t)
 	err := Plan(ctx, cfg, "", PlanOutputJSON, "")
+	stderr := getStderr()
 	if err != nil {
 		t.Errorf("command.Plan(...) error = %v", err)
+	}
+	for _, want := range []string{"+++ Buildkite Test Engine Client: Planning\nbktec ", "Selection: none requested", "Plan source: create endpoint response (may be cached)", "Outcome unknown (selection metadata unavailable).", "Split summary"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	if strings.Count(stderr, "+++ ") != 1 || strings.Contains(stderr, "\n\n") {
+		t.Errorf("redundant planning group/whitespace:\n%s", stderr)
 	}
 
 	want := `{"BUILDKITE_TEST_ENGINE_PLAN_IDENTIFIER":"facecafe","BUILDKITE_TEST_ENGINE_PARALLELISM":"42"}
@@ -57,7 +67,7 @@ func TestPlanPlanOut(t *testing.T) {
 	// The server's exact response body, including a field the client struct
 	// does not model (server_only), to prove --plan-out passes the response
 	// through unmodified rather than re-marshalling a struct.
-	serverBody := `{"identifier":"facecafe","parallelism":42,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"server_only":"kept"}`
+	serverBody := `{"identifier":"facecafe","parallelism":42,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"selection":{"applied":true,"candidate_count":10,"selected_count":1,"count_cutoff":1,"scores":[{"prediction_score":0.7}]},"settings":{"target_time":120,"max_parallelism":42},"server_only":"kept"}`
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -89,8 +99,18 @@ func TestPlanPlanOut(t *testing.T) {
 	setPlanWriter(t, &buf)
 
 	// This is the method under test
+	getStderr := captureStderr(t)
 	if err := Plan(ctx, cfg, "", PlanOutputPlanOut, ""); err != nil {
 		t.Errorf("command.Plan(...) error = %v", err)
+	}
+	stderr := getStderr()
+	for _, want := range []string{"Selected 1 of 10 eligible runnable units (10%).", "Returned parameters: count_cutoff=1", "target time 120s; maximum nodes 42"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	if strings.Contains(stderr, "prediction_score") {
+		t.Errorf("scores must not appear in normal diagnostics: %s", stderr)
 	}
 
 	// stdout is the server's exact response, only re-indented. Comparing the

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -506,6 +506,7 @@ func TestPlanJSON_ErrorPlanFallback(t *testing.T) {
 	planErr := Plan(ctx, cfg, "", PlanOutputJSON, "")
 
 	stderrOutput := getStderr()
+	assertTasklessFallbackSummary(t, stderrOutput)
 
 	// Verify command exits successfully
 	if planErr != nil {
@@ -554,6 +555,7 @@ func TestPlanPipelineUpload_ErrorPlanFallback(t *testing.T) {
 	planErr := Plan(ctx, cfg, "", PlanOutputPipelineUpload, "testtemplate.yml")
 
 	stderrOutput := getStderr()
+	assertTasklessFallbackSummary(t, stderrOutput)
 
 	if planErr != nil {
 		t.Errorf("command.Plan(...) error = %v", planErr)
@@ -1167,6 +1169,7 @@ func TestPlanPlanOut_FallbackWarnsOnStderr(t *testing.T) {
 	planErr := Plan(fetchCtx, cfg, "", PlanOutputPlanOut, "")
 
 	stderrOutput := getStderr()
+	assertTasklessFallbackSummary(t, stderrOutput)
 
 	if planErr != nil {
 		t.Errorf("command.Plan(...) error = %v", planErr)
@@ -1192,6 +1195,20 @@ func TestPlanPlanOut_FallbackWarnsOnStderr(t *testing.T) {
 	// The fallback caveat is written to stderr.
 	if !strings.Contains(stderrOutput, "locally-computed fallback plan") {
 		t.Errorf("expected stderr to contain the fallback caveat, got: %s", stderrOutput)
+	}
+}
+
+func assertTasklessFallbackSummary(t *testing.T, stderr string) {
+	t.Helper()
+	for _, want := range []string{"Not determined: taskless fallback placeholder.", "no test allocation computed."} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("missing %q:\n%s", want, stderr)
+		}
+	}
+	for _, unwanted := range []string{"full locally discovered suite", "  Local non-intelligent split;"} {
+		if strings.Contains(stderr, unwanted) {
+			t.Errorf("placeholder claims computed split %q:\n%s", unwanted, stderr)
+		}
 	}
 }
 

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,8 +18,52 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/config"
 	"github.com/buildkite/test-engine-client/v3/internal/debug"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
+	"github.com/buildkite/test-engine-client/v3/internal/version"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestPrintPlanningSummaryConcise(t *testing.T) {
+	var p plan.TestPlan
+	if err := json.Unmarshal([]byte(`{"parallelism":4,"settings":{"target_time":10,"max_parallelism":4},"selection":{"applied":true,"strategy":"xgboost","candidate_count":100,"selected_count":40,"duration_proportion_cutoff":0.5,"duration_estimates":{"estimator":"mean_with_candidate_median_fallbacks_v1","candidate_total_duration_ms":120000,"selected_total_duration_ms":60000,"candidate_timing_coverage":1}},"sizing":{"method":"timing","target_time_source":"explicit","target_time_ms":10000,"target_time_estimator":"mean_with_fallbacks_v1","estimated_required_parallelism":6,"runnable_units":40,"max_parallelism_binding":true,"runnable_units_binding":false,"estimator":"p90_with_median_fallbacks_v1","estimated_max_task_duration_ms":18000},"timing_metadata":{"selector":{"median_duration":1800,"default_duration":1000}}}`), &p); err != nil {
+		t.Fatal(err)
+	}
+	p.Tasks = make(map[string]*plan.Task)
+	for n := range 4 {
+		task := &plan.Task{NodeNumber: n}
+		for range 10 {
+			task.Tests = append(task.Tests, plan.TestCase{Format: plan.TestCaseFormatSelector, TimingSampleSize: 10})
+		}
+		p.Tasks[strconv.Itoa(n)] = task
+	}
+	cfg := &config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"duration_proportion_cutoff": "0.5"}, TargetTime: 10 * time.Second, MaxParallelism: 4}
+	var buf bytes.Buffer
+	printPlanningRequest(&buf, cfg)
+	printPlanningSummary(&buf, p, sourceCreateResponse, cfg)
+	want, err := os.ReadFile("testdata/planning-summary.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(strings.Replace(string(want), "bktec dev", "bktec "+version.Version, 1), buf.String()); diff != "" {
+		t.Fatalf("approved example mismatch (-want +got):\n%s", diff)
+	}
+	// Comparison never assigns this invocation's strategy to the returned plan.
+	// A disabled request must not hide a same-valued returned cutoff either.
+	for _, strategy := range []string{"manual", "off"} {
+		cfg.SelectionStrategy = strategy
+		if strategy == "manual" {
+			cfg.SelectionParams["duration_proportion_cutoff"] = "0.9"
+		} else {
+			cfg.SelectionParams["duration_proportion_cutoff"] = "0.5"
+		}
+		buf.Reset()
+		printPlanningSummary(&buf, p, "fetched existing plan", cfg)
+		for _, want := range []string{"Using existing plan", "Applied strategy: xgboost", "Returned parameter: duration_proportion_cutoff = 0.5"} {
+			if !strings.Contains(buf.String(), want) {
+				t.Errorf("missing %q:\n%s", want, &buf)
+			}
+		}
+	}
+}
 
 func TestPlanJSON(t *testing.T) {
 	svr := getHttptestServer()
@@ -45,12 +90,12 @@ func TestPlanJSON(t *testing.T) {
 	if err != nil {
 		t.Errorf("command.Plan(...) error = %v", err)
 	}
-	for _, want := range []string{"+++ Buildkite Test Engine Client: Planning\nbktec ", "Selection: none requested", "Plan source: create endpoint response (may be cached)", "Outcome unknown (selection metadata unavailable).", "Split summary"} {
+	for _, want := range []string{"+++ Buildkite Test Engine Client: Planning\nbktec ", "\n\nRequested\n", "Selection: none requested", "No selection metadata returned", "\n\nSplit summary"} {
 		if !strings.Contains(stderr, want) {
 			t.Errorf("stderr missing %q:\n%s", want, stderr)
 		}
 	}
-	if strings.Count(stderr, "+++ ") != 1 || strings.Contains(stderr, "\n\n") {
+	if strings.Count(stderr, "+++ ") != 1 || strings.Contains(stderr, "\n\n\n") || strings.Contains(stderr, "Plan source:") || strings.Contains(stderr, "Using existing plan") {
 		t.Errorf("redundant planning group/whitespace:\n%s", stderr)
 	}
 
@@ -104,7 +149,7 @@ func TestPlanPlanOut(t *testing.T) {
 		t.Errorf("command.Plan(...) error = %v", err)
 	}
 	stderr := getStderr()
-	for _, want := range []string{"Applied strategy: manual", "Selected 1 of 10 eligible runnable units (10%).", "Returned parameters: count_cutoff=1", "target time 120s; maximum nodes 42", "Estimated duration share: 35.7%; candidate timing coverage: 50%", "insufficient timing history; target time not used", "Estimated longest node: unavailable"} {
+	for _, want := range []string{"Applied strategy: manual", "Selected: 1 of 10 test selectors (10%)", "Returned parameter: count_cutoff = 1", "Node limit: 42 (not independently binding)", "Estimated compute: 5s of 14s (35.7%)\n  Candidate timing coverage: 50%", "insufficient timing history; target not used", "Estimated longest node: unavailable"} {
 		if !strings.Contains(stderr, want) {
 			t.Errorf("stderr missing %q:\n%s", want, stderr)
 		}

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -65,6 +65,25 @@ func TestPrintPlanningSummaryConcise(t *testing.T) {
 	}
 }
 
+func TestPlanningReturnedStrategyDoesNotUseInvocation(t *testing.T) {
+	for _, tt := range []struct{ body, want string }{
+		{`{"selection":{"applied":true,"strategy":"future_strategy"}}`, "Applied strategy: future_strategy"},
+		{`{"selection":{"applied":true,"strategy":""}}`, "Applied (strategy unavailable)"},
+		{`{"selection":{"applied":true}}`, "Applied (strategy unavailable)"},
+		{`{}`, "No selection metadata returned"},
+	} {
+		var p plan.TestPlan
+		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		printPlanningSummary(&buf, p, "fetched existing plan", &config.Config{SelectionStrategy: "xgboost"})
+		if !strings.Contains(buf.String(), tt.want) || strings.Contains(buf.String(), "xgboost") {
+			t.Fatalf("returned strategy changed by invocation: %s", &buf)
+		}
+	}
+}
+
 func TestPlanJSON(t *testing.T) {
 	svr := getHttptestServer()
 	defer svr.Close()

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -67,7 +67,7 @@ func TestPlanPlanOut(t *testing.T) {
 	// The server's exact response body, including a field the client struct
 	// does not model (server_only), to prove --plan-out passes the response
 	// through unmodified rather than re-marshalling a struct.
-	serverBody := `{"identifier":"facecafe","parallelism":42,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"selection":{"applied":true,"candidate_count":10,"selected_count":1,"count_cutoff":1,"scores":[{"prediction_score":0.7}]},"settings":{"target_time":120,"max_parallelism":42},"server_only":"kept"}`
+	serverBody := `{"identifier":"facecafe","parallelism":1,"experiment":"","tasks":{"0":{"node_number":0,"tests":[{"path":"testdata/rspec/spec/fruits/apple_spec.rb"}]}},"selection":{"applied":true,"strategy":"manual","candidate_count":10,"selected_count":1,"count_cutoff":1,"duration_estimates":{"estimator":"mean_with_candidate_median_fallbacks_v1","candidate_total_duration_ms":14000,"selected_total_duration_ms":5000,"candidate_timing_coverage":0.5},"scores":[{"prediction_score":0.7}]},"settings":{"target_time":120,"max_parallelism":42},"sizing":{"method":"insufficient_history","runnable_units":1,"max_parallelism_binding":false,"runnable_units_binding":true},"duration_estimates":{"estimator":"mean_with_fallbacks_v1","total_duration_ms":3000,"max_task_duration_ms":3000},"server_only":"kept"}`
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -104,7 +104,7 @@ func TestPlanPlanOut(t *testing.T) {
 		t.Errorf("command.Plan(...) error = %v", err)
 	}
 	stderr := getStderr()
-	for _, want := range []string{"Selected 1 of 10 eligible runnable units (10%).", "Returned parameters: count_cutoff=1", "target time 120s; maximum nodes 42"} {
+	for _, want := range []string{"Applied strategy: manual", "Selected 1 of 10 eligible runnable units (10%).", "Returned parameters: count_cutoff=1", "target time 120s; maximum nodes 42", "Estimated duration share: 35.7%; candidate timing coverage: 50%", "insufficient timing history; target time not used", "Estimated longest node: unavailable"} {
 		if !strings.Contains(stderr, want) {
 			t.Errorf("stderr missing %q:\n%s", want, stderr)
 		}

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -3,6 +3,9 @@ package command
 import (
 	"context"
 	"fmt"
+	"io"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/v3/internal/api"
@@ -10,11 +13,77 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/debug"
 	"github.com/buildkite/test-engine-client/v3/internal/plan"
 	"github.com/buildkite/test-engine-client/v3/internal/runner"
+	"github.com/buildkite/test-engine-client/v3/internal/version"
 )
 
 type requestTarget struct {
 	value string
 	file  api.TestPlanFile
+}
+
+// printPlanningRequest describes this invocation, not the provenance of a
+// returned (possibly cached) plan. Share normalization with the API request.
+func printPlanningRequest(w io.Writer, cfg *config.Config) {
+	fmt.Fprintln(w, "+++ Buildkite Test Engine Client: Planning")
+	fmt.Fprintln(w, "bktec "+version.Version)
+	fmt.Fprintln(w, "Requested (this invocation; an existing plan may use different settings)")
+	selection := buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams)
+	if selection == nil {
+		fmt.Fprint(w, "  Selection: none requested")
+		if cfg.SelectionStrategy != "" {
+			fmt.Fprintf(w, " (strategy %s disables selection; omitted from API request)", boundedRequestValue(cfg.SelectionStrategy))
+		}
+		fmt.Fprintln(w)
+	} else {
+		fmt.Fprintf(w, "  Selection strategy: %s\n", boundedRequestValue(selection.Strategy))
+	}
+	keys := make([]string, 0, len(cfg.SelectionParams))
+	for key := range cfg.SelectionParams {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		value := cfg.SelectionParams[key]
+		var rendered string
+		switch key {
+		case "sample_rate", "threshold", "score_cutoff", "count_cutoff", "proportion_cutoff", "duration_proportion_cutoff", "include_scores", "percent", "top":
+			rendered = boundedRequestValue(value)
+		case "files":
+			// Manual selection accepts newline-delimited file paths. Count the
+			// supplied nonblank entries without exposing the list in CI logs.
+			count := 0
+			for line := range strings.SplitSeq(value, "\n") {
+				if strings.TrimSpace(line) != "" {
+					count++
+				}
+			}
+			rendered = fmt.Sprintf("<%d nonblank entries; %d bytes>", count, len(value))
+		default:
+			// Unknown payloads may contain model inputs, predictions or secrets.
+			rendered = fmt.Sprintf("<value omitted; %d bytes>", len(value))
+		}
+		ignored := ""
+		if selection == nil {
+			ignored = " (not sent)"
+		}
+		fmt.Fprintf(w, "    %s=%s%s\n", boundedRequestValue(key), rendered, ignored)
+	}
+	if cfg.MaxParallelism > 0 {
+		target := "automatic"
+		if cfg.TargetTime > 0 {
+			target = cfg.TargetTime.String()
+		}
+		fmt.Fprintf(w, "  Split: dynamic; target time %s; maximum nodes %d\n", target, cfg.MaxParallelism)
+	} else {
+		fmt.Fprintf(w, "  Split: fixed parallelism %d\n", cfg.Parallelism)
+	}
+}
+
+func boundedRequestValue(value string) string {
+	if len(value) > 160 {
+		return fmt.Sprintf("<value omitted; %d bytes>", len(value))
+	}
+	return strconv.Quote(value)
 }
 
 // createRequestParam generates the parameters needed for a test plan request.

--- a/internal/command/request_param.go
+++ b/internal/command/request_param.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/buildkite/test-engine-client/v3/internal/api"
@@ -26,7 +25,7 @@ type requestTarget struct {
 func printPlanningRequest(w io.Writer, cfg *config.Config) {
 	fmt.Fprintln(w, "+++ Buildkite Test Engine Client: Planning")
 	fmt.Fprintln(w, "bktec "+version.Version)
-	fmt.Fprintln(w, "Requested (this invocation; an existing plan may use different settings)")
+	fmt.Fprintln(w, "\nRequested")
 	selection := buildSelectionParams(cfg.SelectionStrategy, cfg.SelectionParams)
 	if selection == nil {
 		fmt.Fprint(w, "  Selection: none requested")
@@ -66,16 +65,16 @@ func printPlanningRequest(w io.Writer, cfg *config.Config) {
 		if selection == nil {
 			ignored = " (not sent)"
 		}
-		fmt.Fprintf(w, "    %s=%s%s\n", boundedRequestValue(key), rendered, ignored)
+		fmt.Fprintf(w, "    %s = %s%s\n", boundedRequestValue(key), rendered, ignored)
 	}
 	if cfg.MaxParallelism > 0 {
 		target := "automatic"
 		if cfg.TargetTime > 0 {
 			target = cfg.TargetTime.String()
 		}
-		fmt.Fprintf(w, "  Split: dynamic; target time %s; maximum nodes %d\n", target, cfg.MaxParallelism)
+		fmt.Fprintf(w, "  Target time: %s\n  Maximum nodes: %d\n", target, cfg.MaxParallelism)
 	} else {
-		fmt.Fprintf(w, "  Split: fixed parallelism %d\n", cfg.Parallelism)
+		fmt.Fprintf(w, "  Parallelism: %d (fixed)\n", cfg.Parallelism)
 	}
 }
 
@@ -83,7 +82,7 @@ func boundedRequestValue(value string) string {
 	if len(value) > 160 {
 		return fmt.Sprintf("<value omitted; %d bytes>", len(value))
 	}
-	return strconv.Quote(value)
+	return plan.SummaryValue(value)
 }
 
 // createRequestParam generates the parameters needed for a test plan request.

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +17,47 @@ import (
 	"github.com/buildkite/test-engine-client/v3/internal/runner"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestPrintPlanningRequest(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  config.Config
+		want []string
+	}{
+		{"fixed", config.Config{Parallelism: 4}, []string{"Selection: none requested", "Split: fixed parallelism 4"}},
+		{"automatic", config.Config{MaxParallelism: 20}, []string{"Split: dynamic; target time automatic; maximum nodes 20"}},
+		{"target", config.Config{TargetTime: 2 * time.Minute, MaxParallelism: 20}, []string{"target time 2m0s; maximum nodes 20"}},
+		{"selection", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": "0.8", "count_cutoff": "12"}}, []string{"Selection strategy: \"xgboost\"", "\"count_cutoff\"=\"12\"\n    \"score_cutoff\"=\"0.8\""}},
+		{"manual", config.Config{SelectionStrategy: "manual", SelectionParams: map[string]string{"files": "a\n\n b\n"}}, []string{"\"files\"=<2 nonblank entries; 6 bytes>"}},
+		{"escaped", config.Config{SelectionStrategy: "random\n+++ fake", SelectionParams: map[string]string{"sample_rate": "0.1\n\x1b"}}, []string{`"random\n+++ fake"`, `"sample_rate"="0.1\n\x1b"`}},
+		{"bounded", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": strings.Repeat("x", 1000), "features": "secret-features"}}, []string{"\"score_cutoff\"=<value omitted; 1000 bytes>", "\"features\"=<value omitted; 15 bytes>"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printPlanningRequest(&buf, &tt.cfg)
+			for _, want := range tt.want {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("want %q in:\n%s", want, &buf)
+				}
+			}
+			if strings.Contains(buf.String(), "secret-features") || strings.Contains(buf.String(), "\n\n") || strings.Count(buf.String(), "\n+++ ") != 0 {
+				t.Errorf("unsafe or redundant output: %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestPrintPlanningRequestDisabledSentinels(t *testing.T) {
+	for _, strategy := range []string{"none", "off", "false", "disabled", "no", " OFF ", "NoNe", "\t\n"} {
+		var buf bytes.Buffer
+		printPlanningRequest(&buf, &config.Config{SelectionStrategy: strategy, SelectionParams: map[string]string{"count_cutoff": "0"}})
+		for _, want := range []string{"Selection: none requested", "disables selection; omitted from API request", "\"count_cutoff\"=\"0\" (not sent)"} {
+			if !strings.Contains(buf.String(), want) {
+				t.Errorf("strategy %q: want %q in:\n%s", strategy, want, &buf)
+			}
+		}
+	}
+}
 
 func TestCreateRequestParams(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/command/request_param_test.go
+++ b/internal/command/request_param_test.go
@@ -24,13 +24,13 @@ func TestPrintPlanningRequest(t *testing.T) {
 		cfg  config.Config
 		want []string
 	}{
-		{"fixed", config.Config{Parallelism: 4}, []string{"Selection: none requested", "Split: fixed parallelism 4"}},
-		{"automatic", config.Config{MaxParallelism: 20}, []string{"Split: dynamic; target time automatic; maximum nodes 20"}},
-		{"target", config.Config{TargetTime: 2 * time.Minute, MaxParallelism: 20}, []string{"target time 2m0s; maximum nodes 20"}},
-		{"selection", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": "0.8", "count_cutoff": "12"}}, []string{"Selection strategy: \"xgboost\"", "\"count_cutoff\"=\"12\"\n    \"score_cutoff\"=\"0.8\""}},
-		{"manual", config.Config{SelectionStrategy: "manual", SelectionParams: map[string]string{"files": "a\n\n b\n"}}, []string{"\"files\"=<2 nonblank entries; 6 bytes>"}},
-		{"escaped", config.Config{SelectionStrategy: "random\n+++ fake", SelectionParams: map[string]string{"sample_rate": "0.1\n\x1b"}}, []string{`"random\n+++ fake"`, `"sample_rate"="0.1\n\x1b"`}},
-		{"bounded", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": strings.Repeat("x", 1000), "features": "secret-features"}}, []string{"\"score_cutoff\"=<value omitted; 1000 bytes>", "\"features\"=<value omitted; 15 bytes>"}},
+		{"fixed", config.Config{Parallelism: 4}, []string{"Selection: none requested", "Parallelism: 4 (fixed)"}},
+		{"automatic", config.Config{MaxParallelism: 20}, []string{"Target time: automatic\n  Maximum nodes: 20"}},
+		{"target", config.Config{TargetTime: 2 * time.Minute, MaxParallelism: 20}, []string{"Target time: 2m0s\n  Maximum nodes: 20"}},
+		{"selection", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": "0.8", "count_cutoff": "12"}}, []string{"Selection strategy: xgboost", "count_cutoff = 12\n    score_cutoff = 0.8"}},
+		{"manual", config.Config{SelectionStrategy: "manual", SelectionParams: map[string]string{"files": "a\n\n b\n"}}, []string{"files = <2 nonblank entries; 6 bytes>"}},
+		{"escaped", config.Config{SelectionStrategy: "random\n+++ fake", SelectionParams: map[string]string{"sample_rate": "0.1\n\x1b"}}, []string{`"random\n+++ fake"`, `sample_rate = "0.1\n\x1b"`}},
+		{"bounded", config.Config{SelectionStrategy: "xgboost", SelectionParams: map[string]string{"score_cutoff": strings.Repeat("x", 1000), "features": "secret-features"}}, []string{"score_cutoff = <value omitted; 1000 bytes>", "features = <value omitted; 15 bytes>"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
@@ -40,7 +40,7 @@ func TestPrintPlanningRequest(t *testing.T) {
 					t.Errorf("want %q in:\n%s", want, &buf)
 				}
 			}
-			if strings.Contains(buf.String(), "secret-features") || strings.Contains(buf.String(), "\n\n") || strings.Count(buf.String(), "\n+++ ") != 0 {
+			if strings.Contains(buf.String(), "secret-features") || strings.Contains(buf.String(), "\n\n\n") || strings.Count(buf.String(), "\n+++ ") != 0 {
 				t.Errorf("unsafe or redundant output: %q", buf.String())
 			}
 		})
@@ -51,7 +51,7 @@ func TestPrintPlanningRequestDisabledSentinels(t *testing.T) {
 	for _, strategy := range []string{"none", "off", "false", "disabled", "no", " OFF ", "NoNe", "\t\n"} {
 		var buf bytes.Buffer
 		printPlanningRequest(&buf, &config.Config{SelectionStrategy: strategy, SelectionParams: map[string]string{"count_cutoff": "0"}})
-		for _, want := range []string{"Selection: none requested", "disables selection; omitted from API request", "\"count_cutoff\"=\"0\" (not sent)"} {
+		for _, want := range []string{"Selection: none requested", "disables selection; omitted from API request", "count_cutoff = 0 (not sent)"} {
 			if !strings.Contains(buf.String(), want) {
 				t.Errorf("strategy %q: want %q in:\n%s", strategy, want, &buf)
 			}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -25,20 +25,12 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-const Logo = `
-______ ______ _____
-___  /____  /___  /____________
-__  __ \_  //_/  __/  _ \  ___/
-_  /_/ /  ,<  / /_ /  __/ /__
-/_.___//_/|_| \__/ \___/\___/
-`
-
 // newGitRunner constructs the git runner used for metadata auto-collection.
 // Overridable in tests to inject a deterministic fake.
 var newGitRunner = func() git.GitRunner { return &git.ExecGitRunner{} }
 
 func Run(ctx context.Context, cfg *config.Config, testListFilename string) error {
-	printStartUpMessage()
+	printPlanningRequest(os.Stderr, cfg)
 
 	relay, err := startOTLPRelay(cfg)
 	if err != nil {
@@ -88,8 +80,6 @@ func Run(ctx context.Context, cfg *config.Config, testListFilename string) error
 	}
 
 	debug.Printf("My favourite ice cream is %s", testPlan.Experiment)
-
-	printSplitSummary(os.Stdout, testPlan)
 
 	// get plan for this node
 	thisNodeTask := testPlan.Tasks[strconv.Itoa(cfg.NodeIndex)]
@@ -320,13 +310,6 @@ func makePromiseFailureCommand(ctx context.Context, cfg *config.Config, exitStat
 	return cmd
 }
 
-func printStartUpMessage() {
-	const green = "\033[32m"
-	const reset = "\033[0m"
-	fmt.Println("+++ Buildkite Test Engine Client: bktec " + version.Version + "\n")
-	fmt.Println(green + Logo + reset)
-}
-
 func printReport(runResult runner.RunResult, testsSkippedByTestEngine []plan.TestCase, runnerName string) {
 	status := runResult.Status()
 	if status == runner.RunStatusUnknown {
@@ -545,7 +528,13 @@ func logSignalAndExit(name string, signal syscall.Signal) {
 // fetchOrCreateTestPlan fetches a test plan from the server, or creates a
 // fallback plan if the server is unavailable or returns an error plan.
 // The raw response is nil for a local fallback.
-func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, testTargets []string, testRunner runner.TestRunner) (plan.TestPlan, json.RawMessage, error) {
+func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *config.Config, testTargets []string, testRunner runner.TestRunner) (resolved plan.TestPlan, response json.RawMessage, resultErr error) {
+	source := "fetched existing plan"
+	defer func() {
+		if resultErr == nil {
+			printPlanningSummary(os.Stderr, resolved, source)
+		}
+	}()
 	debug.Println("Fetching test plan")
 
 	// Fetch the plan from the server's cache.
@@ -571,6 +560,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	}
 
 	debug.Println("No test plan found, creating a new plan")
+	source = sourceCreateResponse
 
 	// Auto-collect git metadata when selection is active, mirroring `bktec plan`.
 	if cfg.SelectionStrategy != "" {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -532,7 +532,7 @@ func fetchOrCreateTestPlan(ctx context.Context, apiClient *api.Client, cfg *conf
 	source := "fetched existing plan"
 	defer func() {
 		if resultErr == nil {
-			printPlanningSummary(os.Stderr, resolved, source)
+			printPlanningSummary(os.Stderr, resolved, source, cfg)
 		}
 	}()
 	debug.Println("Fetching test plan")

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -649,6 +649,84 @@ func withGitRunner(t *testing.T, r git.GitRunner) {
 	t.Cleanup(func() { newGitRunner = prev })
 }
 
+func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
+	const body = `{"identifier":"existing","parallelism":2,"tasks":{"0":{"tests":[]},"1":{"tests":[{"format":"selector","value":"apple"}]}},"selection":{"applied":true,"candidate_count":4,"selected_count":1,"proportion_cutoff":0.25},"settings":{"target_time":60,"max_parallelism":2},"server_only":"unchanged"}`
+	for _, mode := range []string{"cached", "create", "old cached", "fetch fallback", "create fallback", "error plan"} {
+		t.Run(mode, func(t *testing.T) {
+			posts := 0
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/filter_tests") {
+					fmt.Fprint(w, `{"tests":[]}`)
+					return
+				}
+				if r.Method == http.MethodGet && (mode == "create" || mode == "create fallback") {
+					w.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(w, `{"message":"Not Found"}`)
+					return
+				}
+				if r.Method == http.MethodPost {
+					posts++
+				}
+				switch mode {
+				case "fetch fallback", "create fallback":
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					fmt.Fprint(w, `{"message":"API disabled"}`)
+				case "old cached":
+					fmt.Fprint(w, `{"parallelism":2,"tasks":{"0":{"tests":[]},"1":{"tests":[]}}}`)
+				case "error plan":
+					fmt.Fprint(w, `{"parallelism":0,"tasks":{}}`)
+				default:
+					fmt.Fprint(w, body)
+				}
+			}))
+			defer svr.Close()
+			cfg := &config.Config{Identifier: "invocation", Parallelism: 2, SelectionStrategy: "OFF", SelectionParams: map[string]string{"proportion_cutoff": "0.9"}}
+			client := api.NewClient(api.ClientConfig{ServerBaseURL: svr.URL})
+			getStderr := captureStderr(t)
+			printPlanningRequest(os.Stderr, cfg)
+			p, raw, err := fetchOrCreateTestPlan(context.Background(), client, cfg, []string{"apple", "banana"}, runner.Rspec{})
+			stderr := getStderr()
+			if err != nil {
+				t.Fatal(err)
+			}
+			wants := []string{"Selection: none requested", "\"proportion_cutoff\"=\"0.9\" (not sent)"}
+			switch mode {
+			case "cached", "create":
+				wants = append(wants, "Selected 1 of 4 eligible runnable units (25%).", "Returned parameters: proportion_cutoff=0.25", "target time 60s; maximum nodes 2")
+				if string(raw) != body {
+					t.Errorf("raw plan changed: %s", raw)
+				}
+			case "old cached":
+				wants = append(wants, "Outcome unknown (selection metadata unavailable).")
+			default:
+				wants = append(wants, "Plan source: local fallback", "Not applied: local fallback", "2 runnable units across 2 nodes")
+				if !p.Fallback || raw != nil {
+					t.Errorf("expected unchanged local fallback contract: %+v, %s", p, raw)
+				}
+			}
+			if mode == "cached" || mode == "old cached" {
+				wants = append(wants, "Plan source: fetched existing plan")
+				if posts != 0 {
+					t.Errorf("cache hit created a plan")
+				}
+			} else if mode == "create" {
+				wants = append(wants, "Plan source: create endpoint response (may be cached)")
+				if posts != 1 {
+					t.Errorf("expected one creation request, got %d", posts)
+				}
+			}
+			for _, want := range wants {
+				if !strings.Contains(stderr, want) {
+					t.Errorf("missing %q:\n%s", want, stderr)
+				}
+			}
+			if strings.Count(stderr, "+++ ") != 1 || strings.Count(stderr, "Selection summary") != 1 || strings.Contains(stderr, "\n\n") {
+				t.Errorf("redundant planning output:\n%s", stderr)
+			}
+		})
+	}
+}
+
 // captureRequestBody serves a cache-miss on GET and records the POST body used
 // to create the plan, returning the server and a getter for the captured body.
 func captureRequestBody(t *testing.T) (*httptest.Server, func() []byte) {

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -650,7 +650,7 @@ func withGitRunner(t *testing.T, r git.GitRunner) {
 }
 
 func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
-	const body = `{"identifier":"existing","parallelism":2,"tasks":{"0":{"tests":[]},"1":{"tests":[{"format":"selector","value":"apple"}]}},"selection":{"applied":true,"candidate_count":4,"selected_count":1,"proportion_cutoff":0.25},"settings":{"target_time":60,"max_parallelism":2},"server_only":"unchanged"}`
+	const body = `{"identifier":"existing","parallelism":1,"tasks":{"0":{"tests":[{"format":"selector","value":"apple"}]}},"selection":{"applied":true,"strategy":"manual","candidate_count":4,"selected_count":1,"proportion_cutoff":0.25,"duration_estimates":{"estimator":"mean_with_candidate_median_fallbacks_v1","candidate_total_duration_ms":14000,"selected_total_duration_ms":5000,"candidate_timing_coverage":1.0}},"settings":{"target_time":60,"max_parallelism":2},"sizing":{"method":"timing","target_time_source":"explicit","target_time_ms":60000,"estimated_required_parallelism":1,"runnable_units":1,"max_parallelism_binding":false,"runnable_units_binding":false,"estimator":"p90_with_median_fallbacks_v1","estimated_max_task_duration_ms":8000},"server_only":"unchanged"}`
 	for _, mode := range []string{"cached", "create", "old cached", "fetch fallback", "create fallback", "error plan"} {
 		t.Run(mode, func(t *testing.T) {
 			posts := 0
@@ -692,7 +692,7 @@ func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
 			wants := []string{"Selection: none requested", "\"proportion_cutoff\"=\"0.9\" (not sent)"}
 			switch mode {
 			case "cached", "create":
-				wants = append(wants, "Selected 1 of 4 eligible runnable units (25%).", "Returned parameters: proportion_cutoff=0.25", "target time 60s; maximum nodes 2")
+				wants = append(wants, "Applied strategy: manual", "Selected 1 of 4 eligible runnable units (25%).", "Returned parameters: proportion_cutoff=0.25", "target time 60s; maximum nodes 2", "Estimated duration share: 35.7%", "Sizing: timing-based; estimated need 1 node before caps", "Sizing target: 60s (explicit)", "Estimated longest node: 8s (P90 packing", "within sizing target")
 				if string(raw) != body {
 					t.Errorf("raw plan changed: %s", raw)
 				}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -689,29 +689,31 @@ func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			wants := []string{"Selection: none requested", "\"proportion_cutoff\"=\"0.9\" (not sent)"}
+			wants := []string{"Selection: none requested", "proportion_cutoff = 0.9 (not sent)"}
 			switch mode {
 			case "cached", "create":
-				wants = append(wants, "Applied strategy: manual", "Selected 1 of 4 eligible runnable units (25%).", "Returned parameters: proportion_cutoff=0.25", "target time 60s; maximum nodes 2", "Estimated duration share: 35.7%", "Sizing: timing-based; estimated need 1 node before caps", "Sizing target: 60s (explicit)", "Estimated longest node: 8s (P90 packing", "within sizing target")
+				wants = append(wants, "Applied strategy: manual", "Selected: 1 of 4 test selectors (25%)", "Returned parameter: proportion_cutoff = 0.25", "Target time: 60s", "Estimated compute: 5s of 14s (35.7%)", "Estimated nodes needed: 1 (basis unavailable)", "Estimated longest node: 8s (P90 durations; within target)")
 				if string(raw) != body {
 					t.Errorf("raw plan changed: %s", raw)
 				}
 			case "old cached":
-				wants = append(wants, "Outcome unknown (selection metadata unavailable).")
+				wants = append(wants, "No selection metadata returned")
 			default:
-				wants = append(wants, "Plan source: local fallback", "Not applied: local fallback", "2 runnable units across 2 nodes")
+				wants = append(wants, "Using local fallback", "Not applied: local fallback", "2 test selectors across 2 nodes")
 				if !p.Fallback || raw != nil {
 					t.Errorf("expected unchanged local fallback contract: %+v, %s", p, raw)
 				}
 			}
 			switch mode {
 			case "cached", "old cached":
-				wants = append(wants, "Plan source: fetched existing plan")
+				wants = append(wants, "Using existing plan")
 				if posts != 0 {
 					t.Errorf("cache hit created a plan")
 				}
 			case "create":
-				wants = append(wants, "Plan source: create endpoint response (may be cached)")
+				if strings.Contains(stderr, "Using existing plan") || strings.Contains(stderr, "Plan source:") {
+					t.Errorf("create response must not claim cache provenance: %s", stderr)
+				}
 				if posts != 1 {
 					t.Errorf("expected one creation request, got %d", posts)
 				}
@@ -721,7 +723,7 @@ func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
 					t.Errorf("missing %q:\n%s", want, stderr)
 				}
 			}
-			if strings.Count(stderr, "+++ ") != 1 || strings.Count(stderr, "Selection summary") != 1 || strings.Contains(stderr, "\n\n") {
+			if strings.Count(stderr, "+++ ") != 1 || strings.Count(stderr, "Selection summary") != 1 || strings.Contains(stderr, "\n\n\n") {
 				t.Errorf("redundant planning output:\n%s", stderr)
 			}
 		})

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -704,12 +704,13 @@ func TestFetchOrCreateTestPlanPlanningSummary(t *testing.T) {
 					t.Errorf("expected unchanged local fallback contract: %+v, %s", p, raw)
 				}
 			}
-			if mode == "cached" || mode == "old cached" {
+			switch mode {
+			case "cached", "old cached":
 				wants = append(wants, "Plan source: fetched existing plan")
 				if posts != 0 {
 					t.Errorf("cache hit created a plan")
 				}
-			} else if mode == "create" {
+			case "create":
 				wants = append(wants, "Plan source: create endpoint response (may be cached)")
 				if posts != 1 {
 					t.Errorf("expected one creation request, got %d", posts)

--- a/internal/command/testdata/planning-summary.txt
+++ b/internal/command/testdata/planning-summary.txt
@@ -1,0 +1,22 @@
++++ Buildkite Test Engine Client: Planning
+bktec dev
+
+Requested
+  Selection strategy: xgboost
+    duration_proportion_cutoff = 0.5
+  Target time: 10s
+  Maximum nodes: 4
+
+Selection summary
+  Applied strategy: xgboost
+  Selected: 40 of 100 test selectors (40%)
+  Estimated compute: 60s of 120s (50%)
+  Candidate timing coverage: 100%
+
+Split summary
+  40 selectors across 4 nodes
+  Target time: 10s
+  Estimated nodes needed: 6 (mean durations)
+  Node limit: capped at 4
+  Estimated longest node: 18s (P90 durations; target exceeded)
+  Historical timings: 40 of 40 selectors (100%)

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -14,7 +14,11 @@ import (
 func PrintSelectionSummary(w io.Writer, p TestPlan) {
 	fmt.Fprintln(w, "Selection summary")
 	if p.Fallback {
-		fmt.Fprintln(w, "  Not applied: local fallback uses the full locally discovered suite.")
+		if len(p.Tasks) == 0 {
+			fmt.Fprintln(w, "  Not determined: taskless fallback placeholder.")
+		} else {
+			fmt.Fprintln(w, "  Not applied: local fallback uses the full locally discovered suite.")
+		}
 		return
 	}
 	s := p.Selection
@@ -115,6 +119,11 @@ func printSelectionDurationSummary(w io.Writer, s *SelectionMetadata) {
 // server skips the per-format timing fetch and emits an empty TimingMetadata,
 // so there is no history breakdown. Missing metadata is not evidence of no history.
 func PrintSplitSummary(w io.Writer, p TestPlan) {
+	if p.Fallback && len(p.Tasks) == 0 {
+		fmt.Fprintln(w, "Split summary")
+		fmt.Fprintf(w, "  Placeholder only: %d %s; no test allocation computed.\n", p.Parallelism, pluralize(p.Parallelism, "node"))
+		return
+	}
 	fileTotal, fileKnown := countByFormat(p, TestCaseFormatFile)
 	exampleTotal, exampleKnown := countByFormat(p, TestCaseFormatExample)
 	selectorTotal, selectorKnown := countByFormat(p, TestCaseFormatSelector)

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -191,17 +191,30 @@ func printSizingSummary(w io.Writer, s *SizingMetadata) {
 		fmt.Fprintln(w, "  Sizing: single-node maximum; no timing target used.")
 	case "insufficient_history":
 		fmt.Fprintln(w, "  Sizing: insufficient timing history; target time not used.")
+	case "unusable_timings":
+		fmt.Fprintln(w, "  Sizing: unusable timing estimates; target time not used.")
 	case "timing":
 		fmt.Fprint(w, "  Sizing: timing-based")
 		if s.EstimatedRequiredParallelism != nil {
-			fmt.Fprintf(w, "; estimated need %d %s before caps", *s.EstimatedRequiredParallelism, pluralize(*s.EstimatedRequiredParallelism, "node"))
+			basis := "unavailable"
+			if s.TargetTimeEstimator != nil {
+				switch *s.TargetTimeEstimator {
+				case "p90_with_median_fallbacks_v1":
+					basis = "P90 with median/default fallbacks"
+				case "mean_with_fallbacks_v1":
+					basis = "mean with median/default fallbacks"
+				default:
+					basis = "unknown"
+				}
+			}
+			fmt.Fprintf(w, "; estimated need %d %s before caps (decision basis: %s)", *s.EstimatedRequiredParallelism, pluralize(*s.EstimatedRequiredParallelism, "node"), basis)
 		}
 		fmt.Fprintln(w, ".")
 	default:
 		fmt.Fprintln(w, "  Sizing: unavailable (unknown method).")
 		return
 	}
-	if s.Method == "timing" || s.Method == "insufficient_history" {
+	if s.Method == "timing" || s.Method == "insufficient_history" || s.Method == "unusable_timings" {
 		if s.RunnableUnits != nil {
 			fmt.Fprintf(w, "  Sizing runnable units: %d\n", *s.RunnableUnits)
 		}
@@ -229,9 +242,9 @@ func printSizingSummary(w io.Writer, s *SizingMetadata) {
 	fmt.Fprintf(w, "  Estimated longest node: %s (P90 packing with median/default fallbacks)", planningDurationMS(float64(*s.EstimatedMaxTaskDurationMS)))
 	if hasTarget {
 		if float64(*s.EstimatedMaxTaskDurationMS) > *s.TargetTimeMS {
-			fmt.Fprint(w, "; exceeds sizing target")
+			fmt.Fprint(w, "; P90 estimate exceeds sizing target")
 		} else {
-			fmt.Fprint(w, "; within sizing target")
+			fmt.Fprint(w, "; P90 estimate within sizing target")
 		}
 	}
 	fmt.Fprintln(w, ". Test-work estimate, not a runtime guarantee.")

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -6,12 +6,15 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // PrintSelectionSummary uses only returned metadata. In particular, neither
 // task formats nor this invocation's flags establish the eligible denominator
-// or the strategy used by an existing plan.
-func PrintSelectionSummary(w io.Writer, p TestPlan) {
+// or the strategy used by an existing plan. requested only suppresses matching
+// parameter lines; it never supplies missing returned metadata.
+func PrintSelectionSummary(w io.Writer, p TestPlan, requested map[string]string) {
 	fmt.Fprintln(w, "Selection summary")
 	if p.Fallback {
 		if len(p.Tasks) == 0 {
@@ -23,45 +26,46 @@ func PrintSelectionSummary(w io.Writer, p TestPlan) {
 	}
 	s := p.Selection
 	if s == nil {
-		fmt.Fprintln(w, "  Outcome unknown (selection metadata unavailable).")
+		fmt.Fprintln(w, "  No selection metadata returned")
 		return
 	}
-	switch {
-	case s.Applied == nil:
-		fmt.Fprintln(w, "  Outcome unknown (applied status unavailable).")
-	case *s.Applied:
-		fmt.Fprintln(w, "  Applied.")
-	default:
-		fmt.Fprintln(w, "  Not applied.")
-	}
+	strategy := ""
 	if s.Strategy != nil {
 		switch *s.Strategy {
 		case "random", "manual", "rspec_changed_files", "xgboost", "austral":
-			switch {
-			case s.Applied == nil:
-				fmt.Fprintf(w, "  Returned strategy: %s (applied status unavailable).\n", *s.Strategy)
-			case *s.Applied:
-				fmt.Fprintf(w, "  Applied strategy: %s\n", *s.Strategy)
-			default:
-				fmt.Fprintf(w, "  Attempted strategy: %s (skipped; not applied).\n", *s.Strategy)
-			}
-		default:
-			fmt.Fprintln(w, "  Returned strategy: unavailable (unsupported).")
+			strategy = *s.Strategy
 		}
+	}
+	switch {
+	case strategy == "":
+		switch {
+		case s.Applied == nil:
+			fmt.Fprintln(w, "  Applied status: unavailable")
+		case *s.Applied:
+			fmt.Fprintln(w, "  Applied (strategy unavailable)")
+		default:
+			fmt.Fprintln(w, "  Not applied (strategy unavailable)")
+		}
+	case s.Applied == nil:
+		fmt.Fprintf(w, "  Returned strategy: %s (applied status unavailable)\n", strategy)
+	case *s.Applied:
+		fmt.Fprintf(w, "  Applied strategy: %s\n", strategy)
+	default:
+		fmt.Fprintf(w, "  Attempted strategy: %s (skipped)\n", strategy)
 	}
 	if s.SkippedReason != nil {
 		reason := *s.SkippedReason
 		if len(reason) > 200 {
 			reason = reason[:200] + "…"
 		}
-		fmt.Fprintf(w, "  Reason: %q\n", reason)
+		fmt.Fprintf(w, "  Reason: %s\n", SummaryValue(reason))
 	}
 	if s.SelectedCount != nil && s.CandidateCount != nil {
-		share := "percentage unavailable: no eligible units"
+		share := "percentage unavailable"
 		if *s.CandidateCount > 0 {
 			share = percentOf(*s.SelectedCount, *s.CandidateCount)
 		}
-		fmt.Fprintf(w, "  Selected %d of %d eligible runnable units (%s).\n", *s.SelectedCount, *s.CandidateCount, share)
+		fmt.Fprintf(w, "  Selected: %d of %d test selectors (%s)\n", *s.SelectedCount, *s.CandidateCount, share)
 	} else {
 		selected, eligible := "unknown", "unknown"
 		if s.SelectedCount != nil {
@@ -70,26 +74,39 @@ func PrintSelectionSummary(w io.Writer, p TestPlan) {
 		if s.CandidateCount != nil {
 			eligible = strconv.Itoa(*s.CandidateCount)
 		}
-		fmt.Fprintf(w, "  Selected: %s; eligible runnable units: %s.\n", selected, eligible)
+		fmt.Fprintf(w, "  Selected: %s of %s test selectors\n", selected, eligible)
 	}
-	var params []string
-	if s.ScoreCutoff != nil {
-		params = append(params, fmt.Sprintf("score_cutoff=%g", *s.ScoreCutoff))
-	}
-	if s.CountCutoff != nil {
-		params = append(params, fmt.Sprintf("count_cutoff=%d", *s.CountCutoff))
-	}
-	if s.ProportionCutoff != nil {
-		params = append(params, fmt.Sprintf("proportion_cutoff=%g", *s.ProportionCutoff))
-	}
-	if s.DurationProportionCutoff != nil {
-		params = append(params, fmt.Sprintf("duration_proportion_cutoff=%g", *s.DurationProportionCutoff))
+	for _, param := range []struct {
+		name  string
+		value any
+	}{
+		{"score_cutoff", s.ScoreCutoff},
+		{"count_cutoff", s.CountCutoff},
+		{"proportion_cutoff", s.ProportionCutoff},
+		{"duration_proportion_cutoff", s.DurationProportionCutoff},
+	} {
+		var value string
+		matches := false
+		switch v := param.value.(type) {
+		case *float64:
+			if v != nil {
+				value = strconv.FormatFloat(*v, 'g', -1, 64)
+				invocation, err := strconv.ParseFloat(requested[param.name], 64)
+				matches = err == nil && *v == invocation
+			}
+		case *int:
+			if v != nil {
+				value = strconv.Itoa(*v)
+				invocation, err := strconv.Atoi(requested[param.name])
+				matches = err == nil && *v == invocation
+			}
+		}
+		if value != "" && !matches {
+			fmt.Fprintf(w, "  Returned parameter: %s = %s\n", param.name, value)
+		}
 	}
 	if s.EffectiveCount != nil {
-		params = append(params, fmt.Sprintf("effective_count=%d", *s.EffectiveCount))
-	}
-	if len(params) > 0 {
-		fmt.Fprintf(w, "  Returned parameters: %s\n", strings.Join(params, ", "))
+		fmt.Fprintf(w, "  Effective count: %d\n", *s.EffectiveCount)
 	}
 	printSelectionDurationSummary(w, s)
 }
@@ -100,17 +117,16 @@ func printSelectionDurationSummary(w io.Writer, s *SelectionMetadata) {
 		d.Estimator != "mean_with_candidate_median_fallbacks_v1" ||
 		d.CandidateTotalDurationMS == nil || d.SelectedTotalDurationMS == nil ||
 		d.CandidateTimingCoverage == nil || *d.CandidateTimingCoverage < 0.5 {
-		fmt.Fprintln(w, "  Estimated duration share: unavailable.")
+		fmt.Fprintln(w, "  Estimated compute: unavailable")
 		return
 	}
-	fmt.Fprintf(w, "  Estimated cumulative compute: selected %s of %s eligible candidate total (mean with candidate median/default fallbacks).\n",
-		planningDurationMS(float64(*d.SelectedTotalDurationMS)), planningDurationMS(float64(*d.CandidateTotalDurationMS)))
-	share := "unavailable (zero candidate total)"
+	share := "share unavailable"
 	if *d.CandidateTotalDurationMS > 0 {
 		share = percentOf(*d.SelectedTotalDurationMS, *d.CandidateTotalDurationMS)
 	}
-	fmt.Fprintf(w, "  Estimated duration share: %s; candidate timing coverage: %.0f%%. Compute, not wall time or the requested cutoff.\n",
-		share, *d.CandidateTimingCoverage*100)
+	fmt.Fprintf(w, "  Estimated compute: %s of %s (%s)\n",
+		planningDurationMS(float64(*d.SelectedTotalDurationMS)), planningDurationMS(float64(*d.CandidateTotalDurationMS)), share)
+	fmt.Fprintf(w, "  Candidate timing coverage: %.0f%%\n", *d.CandidateTimingCoverage*100)
 }
 
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
@@ -135,12 +151,12 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	if p.Fallback && p.Tasks != nil {
 		// Run's local splitter populates tasks but not Parallelism or Format.
 		nodes = len(p.Tasks)
-		noun = "runnable unit"
+		noun = "test selector"
 	}
 
 	fmt.Fprintln(w, "Split summary")
 	if p.Tasks == nil {
-		fmt.Fprintf(w, "  %d %s (runnable unit count unavailable)\n", nodes, pluralize(nodes, "node"))
+		fmt.Fprintf(w, "  %d %s (test selector count unavailable)\n", nodes, pluralize(nodes, "node"))
 	} else {
 		fmt.Fprintf(w, "  %d %s across %d %s\n",
 			total, pluralize(total, noun), nodes, pluralize(nodes, "node"))
@@ -149,26 +165,9 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 		fmt.Fprintln(w, "  Local non-intelligent split; timing estimates unavailable.")
 		return
 	}
-	target, cap := "unknown", "unknown"
-	if p.Settings != nil {
-		if p.Settings.TargetTime != nil {
-			target = fmt.Sprintf("%gs", *p.Settings.TargetTime)
-		}
-		if p.Settings.MaxParallelism != nil {
-			cap = strconv.Itoa(*p.Settings.MaxParallelism)
-		}
-	}
-	fmt.Fprintf(w, "  Returned constraints: target time %s; maximum nodes %s\n", target, cap)
-	if p.Settings != nil && p.Settings.MaxParallelism != nil && nodes == *p.Settings.MaxParallelism && nodes > 0 {
-		if p.Sizing != nil && p.Sizing.MaxParallelismBinding != nil {
-			fmt.Fprintln(w, "  At maximum nodes.")
-		} else {
-			fmt.Fprintln(w, "  At maximum nodes (does not establish that the cap limited sizing).")
-		}
-	}
-	printSizingSummary(w, p.Sizing)
+	printSizingSummary(w, p)
 	if p.TimingMetadata == nil {
-		fmt.Fprintln(w, "  Timing history unavailable.")
+		fmt.Fprintln(w, "  Historical timings: unavailable")
 		return
 	}
 
@@ -189,84 +188,119 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	}
 }
 
-func printSizingSummary(w io.Writer, s *SizingMetadata) {
+func printSizingSummary(w io.Writer, p TestPlan) {
+	s := p.Sizing
 	if s == nil {
+		fmt.Fprintln(w, "  Sizing: unavailable")
+		if p.Settings != nil {
+			if p.Settings.TargetTime != nil {
+				fmt.Fprintf(w, "  Target time: %gs (usage unknown)\n", *p.Settings.TargetTime)
+			}
+			printNodeLimit(w, p.Settings.MaxParallelism, nil)
+		}
 		return
 	}
+	// Configured targets are not necessarily used by the sizing branch.
+	hasTarget := s.Method == "timing" && s.TargetTimeMS != nil &&
+		(s.TargetTimeSource == "explicit" || s.TargetTimeSource == "longest_test")
 	switch s.Method {
 	case "fixed":
-		fmt.Fprintln(w, "  Sizing: fixed parallelism; no timing target used.")
+		fmt.Fprintln(w, "  Sizing: fixed parallelism; target not used")
 	case "single_node":
-		fmt.Fprintln(w, "  Sizing: single-node maximum; no timing target used.")
+		fmt.Fprintln(w, "  Sizing: single-node maximum; target not used")
 	case "insufficient_history":
-		fmt.Fprintln(w, "  Sizing: insufficient timing history; target time not used.")
+		fmt.Fprintln(w, "  Sizing: insufficient timing history; target not used")
 	case "unusable_timings":
-		fmt.Fprintln(w, "  Sizing: unusable timing estimates; target time not used.")
+		fmt.Fprintln(w, "  Sizing: unusable timing estimates; target not used")
 	case "timing":
-		fmt.Fprint(w, "  Sizing: timing-based")
+		if hasTarget {
+			suffix := ""
+			if s.TargetTimeSource == "longest_test" {
+				suffix = " (automatic, longest P90 test)"
+			}
+			fmt.Fprintf(w, "  Target time: %s%s\n", planningDurationMS(*s.TargetTimeMS), suffix)
+		} else {
+			fmt.Fprintln(w, "  Target time: unavailable")
+		}
 		if s.EstimatedRequiredParallelism != nil {
-			basis := "unavailable"
+			basis := "basis unavailable"
 			if s.TargetTimeEstimator != nil {
 				switch *s.TargetTimeEstimator {
 				case "p90_with_median_fallbacks_v1":
-					basis = "P90 with median/default fallbacks"
+					basis = "P90 durations"
 				case "mean_with_fallbacks_v1":
-					basis = "mean with median/default fallbacks"
+					basis = "mean durations"
 				default:
-					basis = "unknown"
+					basis = "unknown basis"
 				}
 			}
-			fmt.Fprintf(w, "; estimated need %d %s before caps (decision basis: %s)", *s.EstimatedRequiredParallelism, pluralize(*s.EstimatedRequiredParallelism, "node"), basis)
+			fmt.Fprintf(w, "  Estimated nodes needed: %d (%s)\n", *s.EstimatedRequiredParallelism, basis)
+		} else {
+			fmt.Fprintln(w, "  Estimated nodes needed: unavailable")
 		}
-		fmt.Fprintln(w, ".")
 	default:
-		fmt.Fprintln(w, "  Sizing: unavailable (unknown method).")
+		fmt.Fprintln(w, "  Sizing: unavailable (unknown method)")
 		return
 	}
 	if s.Method == "timing" || s.Method == "insufficient_history" || s.Method == "unusable_timings" {
-		if s.RunnableUnits != nil {
-			fmt.Fprintf(w, "  Sizing runnable units: %d\n", *s.RunnableUnits)
+		var maximum *int
+		if p.Settings != nil {
+			maximum = p.Settings.MaxParallelism
 		}
-		fmt.Fprintf(w, "  Caps: maximum nodes %s; runnable units %s.\n", bindingStatus(s.MaxParallelismBinding), bindingStatus(s.RunnableUnitsBinding))
-	}
-	// Only timing-based sizing has an applicable target. In particular, a
-	// configured settings.target_time was not used by sparse-history sizing.
-	hasTarget := s.Method == "timing" && s.TargetTimeMS != nil &&
-		(s.TargetTimeSource == "explicit" || s.TargetTimeSource == "longest_test")
-	if s.Method == "timing" {
-		if hasTarget {
-			source := "explicit"
-			if s.TargetTimeSource == "longest_test" {
-				source = "automatic: longest test P90 estimate"
+		printNodeLimit(w, maximum, s.MaxParallelismBinding)
+		if s.RunnableUnitsBinding == nil {
+			fmt.Fprintln(w, "  Test selector limit: binding unknown")
+		} else if *s.RunnableUnitsBinding {
+			if s.RunnableUnits != nil {
+				fmt.Fprintf(w, "  Test selector limit: capped at %d\n", *s.RunnableUnits)
+			} else {
+				fmt.Fprintln(w, "  Test selector limit: binding (count unavailable)")
 			}
-			fmt.Fprintf(w, "  Sizing target: %s (%s).\n", planningDurationMS(*s.TargetTimeMS), source)
-		} else {
-			fmt.Fprintln(w, "  Sizing target: unavailable.")
 		}
 	}
 	if s.Estimator != "p90_with_median_fallbacks_v1" || s.EstimatedMaxTaskDurationMS == nil {
-		fmt.Fprintln(w, "  Estimated longest node: unavailable.")
+		fmt.Fprintln(w, "  Estimated longest node: unavailable")
 		return
 	}
-	fmt.Fprintf(w, "  Estimated longest node: %s (P90 packing with median/default fallbacks)", planningDurationMS(float64(*s.EstimatedMaxTaskDurationMS)))
+	fmt.Fprintf(w, "  Estimated longest node: %s (P90 durations", planningDurationMS(float64(*s.EstimatedMaxTaskDurationMS)))
 	if hasTarget {
 		if float64(*s.EstimatedMaxTaskDurationMS) > *s.TargetTimeMS {
-			fmt.Fprint(w, "; P90 estimate exceeds sizing target")
+			fmt.Fprint(w, "; target exceeded")
 		} else {
-			fmt.Fprint(w, "; P90 estimate within sizing target")
+			fmt.Fprint(w, "; within target")
 		}
 	}
-	fmt.Fprintln(w, ". Test-work estimate, not a runtime guarantee.")
+	fmt.Fprintln(w, ")")
 }
 
-func bindingStatus(binding *bool) string {
-	if binding == nil {
-		return "binding unknown"
+func printNodeLimit(w io.Writer, maximum *int, binding *bool) {
+	limit := "unavailable"
+	if maximum != nil {
+		limit = strconv.Itoa(*maximum)
 	}
-	if *binding {
-		return "binding"
+	switch {
+	case binding == nil:
+		fmt.Fprintf(w, "  Node limit: %s (binding unknown)\n", limit)
+	case *binding:
+		if maximum == nil {
+			fmt.Fprintln(w, "  Node limit: binding (maximum unavailable)")
+		} else {
+			fmt.Fprintf(w, "  Node limit: capped at %s\n", limit)
+		}
+	default:
+		fmt.Fprintf(w, "  Node limit: %s (not independently binding)\n", limit)
 	}
-	return "not independently binding"
+}
+
+// SummaryValue leaves ordinary values readable while escaping whitespace,
+// control characters and quotes so a value cannot forge another log line.
+func SummaryValue(value string) string {
+	if value == "" || !utf8.ValidString(value) || strings.IndexFunc(value, func(r rune) bool {
+		return unicode.IsSpace(r) || !unicode.IsPrint(r) || r == '"' || r == '\\'
+	}) >= 0 {
+		return strconv.Quote(value)
+	}
+	return value
 }
 
 // Keep fractional sizing targets visible so a near-boundary comparison does
@@ -323,11 +357,11 @@ func countNonZero(values ...int) int {
 
 // summaryNoun returns the singular heading noun. The plan-level summary uses
 // "file"/"example"/"selector" when the plan only contains one format, or
-// "runnable unit" when multiple formats are present. Callers pluralize as needed.
+// "test selector" when multiple formats are present. Callers pluralize as needed.
 func summaryNoun(fileTotal, exampleTotal, selectorTotal int) string {
 	switch {
 	case fileTotal+exampleTotal+selectorTotal == 0:
-		return "runnable unit"
+		return "test selector"
 	case exampleTotal == 0 && selectorTotal == 0:
 		return "file"
 	case fileTotal == 0 && selectorTotal == 0:
@@ -335,7 +369,7 @@ func summaryNoun(fileTotal, exampleTotal, selectorTotal int) string {
 	case fileTotal == 0 && exampleTotal == 0:
 		return "selector"
 	default:
-		return "runnable unit"
+		return "test selector"
 	}
 }
 
@@ -351,37 +385,22 @@ func pluralize(n int, singular string) string {
 // ("file" or "example"); each line is pluralized to match its own count.
 func printFormatBreakdown(w io.Writer, total, known int, noun string, meta *FormatTimingMetadata, mixed bool) {
 	indent := "  "
-	itemNounFor := func(n int) string { return " " + pluralize(n, noun) }
 	if mixed {
 		fmt.Fprintf(w, "  %d %s\n", total, pluralize(total, noun))
 		indent = "    "
-		// In nested form the "files"/"examples" header carries the noun, so
-		// each line just shows counts.
-		itemNounFor = func(int) string { return "" }
 	}
-
-	width := len(strconv.Itoa(total))
-
-	if known == 0 {
-		suffix := " and used the default duration"
-		if meta != nil {
-			suffix += fmt.Sprintf(" (%s)", formatDurationMS(meta.DefaultDuration))
-		}
-		fmt.Fprintf(w, "%s%*d%s (100%%) had no history%s\n",
-			indent, width, total, itemNounFor(total), suffix)
-		return
-	}
-
+	fmt.Fprintf(w, "%sHistorical timings: %d of %d %s (%s)\n", indent, known, total, pluralize(total, noun), percentOf(known, total))
 	unknown := total - known
-	fmt.Fprintf(w, "%s%*d%s (%s) estimated from past historical durations\n",
-		indent, width, known, itemNounFor(known), percentOf(known, total))
 	if unknown > 0 {
 		suffix := ""
-		if meta != nil && meta.MedianDuration != nil {
-			suffix = fmt.Sprintf(" — assumed median (%s)", formatDurationMS(*meta.MedianDuration))
+		if meta != nil {
+			if known == 0 {
+				suffix = fmt.Sprintf("; default duration %s", formatDurationMS(meta.DefaultDuration))
+			} else if meta.MedianDuration != nil {
+				suffix = fmt.Sprintf("; median duration %s", formatDurationMS(*meta.MedianDuration))
+			}
 		}
-		fmt.Fprintf(w, "%s%*d%s (%s) had no history%s\n",
-			indent, width, unknown, itemNounFor(unknown), percentOf(unknown, total), suffix)
+		fmt.Fprintf(w, "%sNo history: %d %s (%s)%s\n", indent, unknown, pluralize(unknown, noun), percentOf(unknown, total), suffix)
 	}
 }
 

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -30,22 +30,16 @@ func PrintSelectionSummary(w io.Writer, p TestPlan, requested map[string]string)
 		return
 	}
 	strategy := ""
-	if s.Strategy != nil {
-		switch *s.Strategy {
-		case "random", "manual", "rspec_changed_files", "xgboost", "austral":
-			strategy = *s.Strategy
-		}
+	if s.Strategy != nil && *s.Strategy != "" {
+		strategy = boundedSelectionText(*s.Strategy)
 	}
 	switch {
+	case strategy == "" && s.Applied == nil:
+		fmt.Fprintln(w, "  Applied status: unavailable")
+	case strategy == "" && *s.Applied:
+		fmt.Fprintln(w, "  Applied (strategy unavailable)")
 	case strategy == "":
-		switch {
-		case s.Applied == nil:
-			fmt.Fprintln(w, "  Applied status: unavailable")
-		case *s.Applied:
-			fmt.Fprintln(w, "  Applied (strategy unavailable)")
-		default:
-			fmt.Fprintln(w, "  Not applied (strategy unavailable)")
-		}
+		fmt.Fprintln(w, "  Not applied (strategy unavailable)")
 	case s.Applied == nil:
 		fmt.Fprintf(w, "  Returned strategy: %s (applied status unavailable)\n", strategy)
 	case *s.Applied:
@@ -54,11 +48,7 @@ func PrintSelectionSummary(w io.Writer, p TestPlan, requested map[string]string)
 		fmt.Fprintf(w, "  Attempted strategy: %s (skipped)\n", strategy)
 	}
 	if s.SkippedReason != nil {
-		reason := *s.SkippedReason
-		if len(reason) > 200 {
-			reason = reason[:200] + "…"
-		}
-		fmt.Fprintf(w, "  Reason: %s\n", SummaryValue(reason))
+		fmt.Fprintf(w, "  Reason: %s\n", boundedSelectionText(*s.SkippedReason))
 	}
 	if s.SelectedCount != nil && s.CandidateCount != nil {
 		share := "percentage unavailable"
@@ -301,6 +291,22 @@ func SummaryValue(value string) string {
 		return strconv.Quote(value)
 	}
 	return value
+}
+
+// Bound returned text to 200 bytes before escaping, without splitting a UTF-8
+// sequence. Invalid input bytes remain intact so SummaryValue can escape them.
+func boundedSelectionText(value string) string {
+	if len(value) > 200 {
+		end := 0
+		for i := range value {
+			if i > 200 {
+				break
+			}
+			end = i
+		}
+		value = value[:end] + "…"
+	}
+	return SummaryValue(value)
 }
 
 // Keep fractional sizing targets visible so a near-boundary comparison does

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -30,6 +30,21 @@ func PrintSelectionSummary(w io.Writer, p TestPlan) {
 	default:
 		fmt.Fprintln(w, "  Not applied.")
 	}
+	if s.Strategy != nil {
+		switch *s.Strategy {
+		case "random", "manual", "rspec_changed_files", "xgboost", "austral":
+			switch {
+			case s.Applied == nil:
+				fmt.Fprintf(w, "  Returned strategy: %s (applied status unavailable).\n", *s.Strategy)
+			case *s.Applied:
+				fmt.Fprintf(w, "  Applied strategy: %s\n", *s.Strategy)
+			default:
+				fmt.Fprintf(w, "  Attempted strategy: %s (skipped; not applied).\n", *s.Strategy)
+			}
+		default:
+			fmt.Fprintln(w, "  Returned strategy: unavailable (unsupported).")
+		}
+	}
 	if s.SkippedReason != nil {
 		reason := *s.SkippedReason
 		if len(reason) > 200 {
@@ -72,6 +87,26 @@ func PrintSelectionSummary(w io.Writer, p TestPlan) {
 	if len(params) > 0 {
 		fmt.Fprintf(w, "  Returned parameters: %s\n", strings.Join(params, ", "))
 	}
+	printSelectionDurationSummary(w, s)
+}
+
+func printSelectionDurationSummary(w io.Writer, s *SelectionMetadata) {
+	d := s.DurationEstimates
+	if s.Applied == nil || !*s.Applied || d == nil ||
+		d.Estimator != "mean_with_candidate_median_fallbacks_v1" ||
+		d.CandidateTotalDurationMS == nil || d.SelectedTotalDurationMS == nil ||
+		d.CandidateTimingCoverage == nil || *d.CandidateTimingCoverage < 0.5 {
+		fmt.Fprintln(w, "  Estimated duration share: unavailable.")
+		return
+	}
+	fmt.Fprintf(w, "  Estimated cumulative compute: selected %s of %s eligible candidate total (mean with candidate median/default fallbacks).\n",
+		planningDurationMS(float64(*d.SelectedTotalDurationMS)), planningDurationMS(float64(*d.CandidateTotalDurationMS)))
+	share := "unavailable (zero candidate total)"
+	if *d.CandidateTotalDurationMS > 0 {
+		share = percentOf(*d.SelectedTotalDurationMS, *d.CandidateTotalDurationMS)
+	}
+	fmt.Fprintf(w, "  Estimated duration share: %s; candidate timing coverage: %.0f%%. Compute, not wall time or the requested cutoff.\n",
+		share, *d.CandidateTimingCoverage*100)
 }
 
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
@@ -116,8 +151,13 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	}
 	fmt.Fprintf(w, "  Returned constraints: target time %s; maximum nodes %s\n", target, cap)
 	if p.Settings != nil && p.Settings.MaxParallelism != nil && nodes == *p.Settings.MaxParallelism && nodes > 0 {
-		fmt.Fprintln(w, "  At maximum nodes (does not establish that the cap limited sizing).")
+		if p.Sizing != nil && p.Sizing.MaxParallelismBinding != nil {
+			fmt.Fprintln(w, "  At maximum nodes.")
+		} else {
+			fmt.Fprintln(w, "  At maximum nodes (does not establish that the cap limited sizing).")
+		}
 	}
+	printSizingSummary(w, p.Sizing)
 	if p.TimingMetadata == nil {
 		fmt.Fprintln(w, "  Timing history unavailable.")
 		return
@@ -138,6 +178,82 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	if selectorTotal > 0 {
 		printFormatBreakdown(w, selectorTotal, selectorKnown, "selector", p.TimingMetadata.Selector, mixed)
 	}
+}
+
+func printSizingSummary(w io.Writer, s *SizingMetadata) {
+	if s == nil {
+		return
+	}
+	switch s.Method {
+	case "fixed":
+		fmt.Fprintln(w, "  Sizing: fixed parallelism; no timing target used.")
+	case "single_node":
+		fmt.Fprintln(w, "  Sizing: single-node maximum; no timing target used.")
+	case "insufficient_history":
+		fmt.Fprintln(w, "  Sizing: insufficient timing history; target time not used.")
+	case "timing":
+		fmt.Fprint(w, "  Sizing: timing-based")
+		if s.EstimatedRequiredParallelism != nil {
+			fmt.Fprintf(w, "; estimated need %d %s before caps", *s.EstimatedRequiredParallelism, pluralize(*s.EstimatedRequiredParallelism, "node"))
+		}
+		fmt.Fprintln(w, ".")
+	default:
+		fmt.Fprintln(w, "  Sizing: unavailable (unknown method).")
+		return
+	}
+	if s.Method == "timing" || s.Method == "insufficient_history" {
+		if s.RunnableUnits != nil {
+			fmt.Fprintf(w, "  Sizing runnable units: %d\n", *s.RunnableUnits)
+		}
+		fmt.Fprintf(w, "  Caps: maximum nodes %s; runnable units %s.\n", bindingStatus(s.MaxParallelismBinding), bindingStatus(s.RunnableUnitsBinding))
+	}
+	// Only timing-based sizing has an applicable target. In particular, a
+	// configured settings.target_time was not used by sparse-history sizing.
+	hasTarget := s.Method == "timing" && s.TargetTimeMS != nil &&
+		(s.TargetTimeSource == "explicit" || s.TargetTimeSource == "longest_test")
+	if s.Method == "timing" {
+		if hasTarget {
+			source := "explicit"
+			if s.TargetTimeSource == "longest_test" {
+				source = "automatic: longest test P90 estimate"
+			}
+			fmt.Fprintf(w, "  Sizing target: %s (%s).\n", planningDurationMS(*s.TargetTimeMS), source)
+		} else {
+			fmt.Fprintln(w, "  Sizing target: unavailable.")
+		}
+	}
+	if s.Estimator != "p90_with_median_fallbacks_v1" || s.EstimatedMaxTaskDurationMS == nil {
+		fmt.Fprintln(w, "  Estimated longest node: unavailable.")
+		return
+	}
+	fmt.Fprintf(w, "  Estimated longest node: %s (P90 packing with median/default fallbacks)", planningDurationMS(float64(*s.EstimatedMaxTaskDurationMS)))
+	if hasTarget {
+		if float64(*s.EstimatedMaxTaskDurationMS) > *s.TargetTimeMS {
+			fmt.Fprint(w, "; exceeds sizing target")
+		} else {
+			fmt.Fprint(w, "; within sizing target")
+		}
+	}
+	fmt.Fprintln(w, ". Test-work estimate, not a runtime guarantee.")
+}
+
+func bindingStatus(binding *bool) string {
+	if binding == nil {
+		return "binding unknown"
+	}
+	if *binding {
+		return "binding"
+	}
+	return "not independently binding"
+}
+
+// Keep fractional sizing targets visible so a near-boundary comparison does
+// not display equal rounded durations while reporting an exceeded target.
+func planningDurationMS(ms float64) string {
+	if ms < 1000 {
+		return strconv.FormatFloat(ms, 'f', -1, 64) + "ms"
+	}
+	return strconv.FormatFloat(ms/1000, 'f', -1, 64) + "s"
 }
 
 // HasNoSelectorTimingHistory reports whether a multi-node selector plan used

--- a/internal/plan/summary.go
+++ b/internal/plan/summary.go
@@ -5,40 +5,127 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 )
+
+// PrintSelectionSummary uses only returned metadata. In particular, neither
+// task formats nor this invocation's flags establish the eligible denominator
+// or the strategy used by an existing plan.
+func PrintSelectionSummary(w io.Writer, p TestPlan) {
+	fmt.Fprintln(w, "Selection summary")
+	if p.Fallback {
+		fmt.Fprintln(w, "  Not applied: local fallback uses the full locally discovered suite.")
+		return
+	}
+	s := p.Selection
+	if s == nil {
+		fmt.Fprintln(w, "  Outcome unknown (selection metadata unavailable).")
+		return
+	}
+	switch {
+	case s.Applied == nil:
+		fmt.Fprintln(w, "  Outcome unknown (applied status unavailable).")
+	case *s.Applied:
+		fmt.Fprintln(w, "  Applied.")
+	default:
+		fmt.Fprintln(w, "  Not applied.")
+	}
+	if s.SkippedReason != nil {
+		reason := *s.SkippedReason
+		if len(reason) > 200 {
+			reason = reason[:200] + "…"
+		}
+		fmt.Fprintf(w, "  Reason: %q\n", reason)
+	}
+	if s.SelectedCount != nil && s.CandidateCount != nil {
+		share := "percentage unavailable: no eligible units"
+		if *s.CandidateCount > 0 {
+			share = percentOf(*s.SelectedCount, *s.CandidateCount)
+		}
+		fmt.Fprintf(w, "  Selected %d of %d eligible runnable units (%s).\n", *s.SelectedCount, *s.CandidateCount, share)
+	} else {
+		selected, eligible := "unknown", "unknown"
+		if s.SelectedCount != nil {
+			selected = strconv.Itoa(*s.SelectedCount)
+		}
+		if s.CandidateCount != nil {
+			eligible = strconv.Itoa(*s.CandidateCount)
+		}
+		fmt.Fprintf(w, "  Selected: %s; eligible runnable units: %s.\n", selected, eligible)
+	}
+	var params []string
+	if s.ScoreCutoff != nil {
+		params = append(params, fmt.Sprintf("score_cutoff=%g", *s.ScoreCutoff))
+	}
+	if s.CountCutoff != nil {
+		params = append(params, fmt.Sprintf("count_cutoff=%d", *s.CountCutoff))
+	}
+	if s.ProportionCutoff != nil {
+		params = append(params, fmt.Sprintf("proportion_cutoff=%g", *s.ProportionCutoff))
+	}
+	if s.DurationProportionCutoff != nil {
+		params = append(params, fmt.Sprintf("duration_proportion_cutoff=%g", *s.DurationProportionCutoff))
+	}
+	if s.EffectiveCount != nil {
+		params = append(params, fmt.Sprintf("effective_count=%d", *s.EffectiveCount))
+	}
+	if len(params) > 0 {
+		fmt.Fprintf(w, "  Returned parameters: %s\n", strings.Join(params, ", "))
+	}
+}
 
 // PrintSplitSummary writes a human-readable summary of the resolved test plan
 // to w (typically os.Stderr). At parallelism > 1 it uses per-format
 // TimingMetadata to break down known vs unknown cases. At parallelism == 1 the
 // server skips the per-format timing fetch and emits an empty TimingMetadata,
-// so only the header and case count are printed. Skipped for fallback plans and
-// plans without TimingMetadata at all (e.g. error or older cached plans).
+// so there is no history breakdown. Missing metadata is not evidence of no history.
 func PrintSplitSummary(w io.Writer, p TestPlan) {
-	if p.Fallback || p.TimingMetadata == nil {
-		return
-	}
-
 	fileTotal, fileKnown := countByFormat(p, TestCaseFormatFile)
 	exampleTotal, exampleKnown := countByFormat(p, TestCaseFormatExample)
 	selectorTotal, selectorKnown := countByFormat(p, TestCaseFormatSelector)
 
 	total := fileTotal + exampleTotal + selectorTotal
-	if total == 0 {
-		return
-	}
-
 	nodes := p.Parallelism
 	mixed := countNonZero(fileTotal, exampleTotal, selectorTotal) > 1
 	noun := summaryNoun(fileTotal, exampleTotal, selectorTotal)
+	if p.Fallback && p.Tasks != nil {
+		// Run's local splitter populates tasks but not Parallelism or Format.
+		nodes = len(p.Tasks)
+		noun = "runnable unit"
+	}
 
-	fmt.Fprintln(w, "\n+++ Buildkite Test Engine Client: 📊 Split summary")
-	fmt.Fprintf(w, "%d %s across %d %s\n",
-		total, pluralize(total, noun), nodes, pluralize(nodes, "node"))
+	fmt.Fprintln(w, "Split summary")
+	if p.Tasks == nil {
+		fmt.Fprintf(w, "  %d %s (runnable unit count unavailable)\n", nodes, pluralize(nodes, "node"))
+	} else {
+		fmt.Fprintf(w, "  %d %s across %d %s\n",
+			total, pluralize(total, noun), nodes, pluralize(nodes, "node"))
+	}
+	if p.Fallback {
+		fmt.Fprintln(w, "  Local non-intelligent split; timing estimates unavailable.")
+		return
+	}
+	target, cap := "unknown", "unknown"
+	if p.Settings != nil {
+		if p.Settings.TargetTime != nil {
+			target = fmt.Sprintf("%gs", *p.Settings.TargetTime)
+		}
+		if p.Settings.MaxParallelism != nil {
+			cap = strconv.Itoa(*p.Settings.MaxParallelism)
+		}
+	}
+	fmt.Fprintf(w, "  Returned constraints: target time %s; maximum nodes %s\n", target, cap)
+	if p.Settings != nil && p.Settings.MaxParallelism != nil && nodes == *p.Settings.MaxParallelism && nodes > 0 {
+		fmt.Fprintln(w, "  At maximum nodes (does not establish that the cap limited sizing).")
+	}
+	if p.TimingMetadata == nil {
+		fmt.Fprintln(w, "  Timing history unavailable.")
+		return
+	}
 
 	// At parallelism == 1 the server skips the per-format timing fetch and
 	// emits an empty TimingMetadata, so there is no breakdown to print.
 	if p.TimingMetadata.File == nil && p.TimingMetadata.Example == nil && p.TimingMetadata.Selector == nil {
-		fmt.Fprintln(w)
 		return
 	}
 
@@ -51,7 +138,6 @@ func PrintSplitSummary(w io.Writer, p TestPlan) {
 	if selectorTotal > 0 {
 		printFormatBreakdown(w, selectorTotal, selectorKnown, "selector", p.TimingMetadata.Selector, mixed)
 	}
-	fmt.Fprintln(w)
 }
 
 // HasNoSelectorTimingHistory reports whether a multi-node selector plan used
@@ -99,9 +185,11 @@ func countNonZero(values ...int) int {
 
 // summaryNoun returns the singular heading noun. The plan-level summary uses
 // "file"/"example"/"selector" when the plan only contains one format, or
-// "test" when multiple formats are present. Callers pluralize as needed.
+// "runnable unit" when multiple formats are present. Callers pluralize as needed.
 func summaryNoun(fileTotal, exampleTotal, selectorTotal int) string {
 	switch {
+	case fileTotal+exampleTotal+selectorTotal == 0:
+		return "runnable unit"
 	case exampleTotal == 0 && selectorTotal == 0:
 		return "file"
 	case fileTotal == 0 && selectorTotal == 0:
@@ -109,7 +197,7 @@ func summaryNoun(fileTotal, exampleTotal, selectorTotal int) string {
 	case fileTotal == 0 && exampleTotal == 0:
 		return "selector"
 	default:
-		return "test"
+		return "runnable unit"
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -654,8 +654,15 @@ func TestReturnedStrategyAvailability(t *testing.T) {
 		{`{"selection":{"strategy":"random","applied":true}}`, "Applied strategy: random"},
 		{`{"selection":{"strategy":"rspec_changed_files","applied":false}}`, "Attempted strategy: rspec_changed_files"},
 		{`{"selection":{"strategy":"austral","applied":null}}`, "Returned strategy: austral (applied status unavailable)"},
-		{`{"selection":{"strategy":"future\n+++ forged","applied":true}}`, "Applied (strategy unavailable)"},
+		{`{"selection":{"strategy":"future_strategy","applied":true}}`, "Applied strategy: future_strategy"},
+		{`{"selection":{"strategy":"future_strategy","applied":false}}`, "Attempted strategy: future_strategy (skipped)"},
+		{`{"selection":{"strategy":"future_strategy"}}`, "Returned strategy: future_strategy (applied status unavailable)"},
 		{`{"selection":{"strategy":null,"applied":true}}`, "Applied (strategy unavailable)"},
+		{`{"selection":{"strategy":null,"applied":false}}`, "Not applied (strategy unavailable)"},
+		{`{"selection":{"strategy":null}}`, "Applied status: unavailable"},
+		{`{"selection":{"strategy":"","applied":true}}`, "Applied (strategy unavailable)"},
+		{`{"selection":{"strategy":"","applied":false}}`, "Not applied (strategy unavailable)"},
+		{`{"selection":{"strategy":""}}`, "Applied status: unavailable"},
 	} {
 		var p TestPlan
 		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
@@ -663,7 +670,28 @@ func TestReturnedStrategyAvailability(t *testing.T) {
 		}
 		var buf bytes.Buffer
 		PrintSelectionSummary(&buf, p, nil)
-		assertSummary(t, buf.String(), []string{tt.want}, []string{"forged"})
+		assertSummary(t, buf.String(), []string{tt.want}, []string{"unsupported", "not recognised"})
+	}
+}
+
+func TestReturnedSelectionTextSafety(t *testing.T) {
+	for _, tt := range []struct{ name, value, want string }{
+		{"controls", "future\n+++ forged\x1b[31m\u202e", `"future\n+++ forged\x1b[31m\u202e"`},
+		{"invalid bytes", "future\xff", `"future\xff"`},
+		{"multibyte across limit", strings.Repeat("界", 100), strings.Repeat("界", 66) + "…"},
+		{"exact byte limit", strings.Repeat("界", 66) + "ab", strings.Repeat("界", 66) + "ab"},
+		{"multibyte at limit", strings.Repeat("x", 200) + "界", strings.Repeat("x", 200) + "…"},
+		{"invalid byte at limit", strings.Repeat("x", 199) + "\xffz", `"` + strings.Repeat("x", 199) + `\xff…"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := TestPlan{Selection: &SelectionMetadata{Strategy: &tt.value, SkippedReason: &tt.value}}
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, p, nil)
+			want := "Selection summary\n  Returned strategy: " + tt.want + " (applied status unavailable)\n  Reason: " + tt.want + "\n  Selected: unknown of unknown test selectors\n  Estimated compute: unavailable\n"
+			if got := buf.String(); got != want {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -32,7 +33,7 @@ func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n5 files across 2 nodes",
+		"Split summary\n  5 files across 2 nodes",
 		"3 files (60%) estimated from past historical durations",
 		"2 files (40%) had no history — assumed median (4.2s)",
 	} {
@@ -59,7 +60,7 @@ func TestPrintSplitSummary_NoHistory(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n3 files across 2 nodes",
+		"Split summary\n  3 files across 2 nodes",
 		"3 files (100%) had no history and used the default duration (1.0s)",
 	} {
 		if !strings.Contains(got, want) {
@@ -97,7 +98,7 @@ func TestPrintSplitSummary_NullMedianWithUnknowns(t *testing.T) {
 	}
 }
 
-func TestPrintSplitSummary_SkipsWhenNoMetadata(t *testing.T) {
+func TestPrintSplitSummary_NoMetadata(t *testing.T) {
 	p := TestPlan{
 		Parallelism: 1,
 		Tasks: map[string]*Task{
@@ -106,8 +107,8 @@ func TestPrintSplitSummary_SkipsWhenNoMetadata(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "1 file across 1 node") || !strings.Contains(buf.String(), "Timing history unavailable.") {
+		t.Errorf("expected count and unknown history, got: %s", buf.String())
 	}
 }
 
@@ -155,7 +156,7 @@ func TestPrintSplitSummary_ExampleMode(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 examples across 2 nodes",
+		"Split summary\n  2 examples across 2 nodes",
 		"1 example (50%) estimated from past historical durations",
 		"1 example (50%) had no history",
 		"2.0s",
@@ -189,7 +190,7 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"+++ Buildkite Test Engine Client: 📊 Split summary\n2 selectors across 2 nodes",
+		"Split summary\n  2 selectors across 2 nodes",
 		"1 selector (50%) estimated from past historical durations",
 		"1 selector (50%) had no history — assumed median (1.8s)",
 	} {
@@ -284,7 +285,7 @@ func TestPrintSplitSummary_MixedFormats(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"4 tests across 2 nodes",
+		"4 runnable units across 2 nodes",
 		"  2 files\n",
 		"    1 (50%) estimated from past historical durations",
 		"    1 (50%) had no history — assumed median (4.2s)",
@@ -323,7 +324,7 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"4 tests across 2 nodes",
+		"4 runnable units across 2 nodes",
 		"  1 file\n",
 		"    1 (100%) estimated from past historical durations",
 		"  1 example\n",
@@ -341,7 +342,7 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 	}
 }
 
-func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
+func TestPrintSplitSummary_Fallback(t *testing.T) {
 	p := TestPlan{
 		Parallelism: 1,
 		Fallback:    true,
@@ -354,8 +355,76 @@ func TestPrintSplitSummary_SkipsFallback(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output for fallback plan, got: %s", buf.String())
+	if !strings.Contains(buf.String(), "1 runnable unit across 1 node") || !strings.Contains(buf.String(), "Local non-intelligent split") {
+		t.Errorf("expected local fallback summary, got: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "had no history") {
+		t.Errorf("unexpected server timing breakdown for fallback: %s", buf.String())
+	}
+}
+
+func TestPrintSelectionSummary(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, want string
+	}{
+		{"old plan", `{}`, "Outcome unknown (selection metadata unavailable)."},
+		{"null", `{"selection":null}`, "Outcome unknown (selection metadata unavailable)."},
+		{"missing applied", `{"selection":{"applied":null,"selected_count":0}}`, "Outcome unknown (applied status unavailable).\n  Selected: 0; eligible runnable units: unknown."},
+		{"zero selected", `{"selection":{"applied":true,"candidate_count":5,"selected_count":0}}`, "Applied.\n  Selected 0 of 5 eligible runnable units (0%)."},
+		{"zero eligible", `{"selection":{"applied":true,"candidate_count":0,"selected_count":0}}`, "Selected 0 of 0 eligible runnable units (percentage unavailable: no eligible units)."},
+		{"full selection", `{"selection":{"applied":true,"candidate_count":5,"selected_count":5}}`, "Selected 5 of 5 eligible runnable units (100%)."},
+		{"mixed denominator", `{"selection":{"applied":true,"candidate_count":6,"selected_count":2},"tasks":{"0":{"tests":[{"format":"file"},{"format":"example"}]}}}`, "Selected 2 of 6 eligible runnable units (33.3%)."},
+		{"fallback reason", `{"selection":{"applied":false,"candidate_count":5,"selected_count":5,"skipped_reason":"no_model"}}`, "Not applied.\n  Reason: \"no_model\"\n  Selected 5 of 5 eligible runnable units (100%)."},
+		{"zero cutoffs", `{"selection":{"score_cutoff":0,"count_cutoff":0,"proportion_cutoff":0,"duration_proportion_cutoff":0,"effective_count":0}}`, "Returned parameters: score_cutoff=0, count_cutoff=0, proportion_cutoff=0, duration_proportion_cutoff=0, effective_count=0"},
+		{"null cutoffs", `{"selection":{"score_cutoff":null,"count_cutoff":null}}`, "Selected: unknown; eligible runnable units: unknown."},
+		{"local fallback", `{"Fallback":true}`, "Not applied: local fallback uses the full locally discovered suite."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var p TestPlan
+			if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, p)
+			if !strings.Contains(buf.String(), tt.want) {
+				t.Errorf("want %q, got:\n%s", tt.want, &buf)
+			}
+			if strings.Contains(buf.String(), "+++") || strings.Contains(buf.String(), "\n\n") {
+				t.Errorf("redundant group or blank line: %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestSelectionReasonBoundedAndEscaped(t *testing.T) {
+	reason := "no_model\n+++ forged\x1b" + strings.Repeat("x", 1000)
+	p := TestPlan{Selection: &SelectionMetadata{SkippedReason: &reason}}
+	var buf bytes.Buffer
+	PrintSelectionSummary(&buf, p)
+	if !strings.Contains(buf.String(), `no_model\n+++ forged\x1b`) || len(buf.String()) > 400 {
+		t.Fatalf("reason not safely bounded: %q", buf.String())
+	}
+}
+
+func TestPrintSplitSummary_ReturnedConstraints(t *testing.T) {
+	for _, tt := range []struct {
+		body, want string
+		atCap      bool
+	}{
+		{`{"parallelism":2,"settings":{"target_time":120.5,"max_parallelism":2}}`, "target time 120.5s; maximum nodes 2", true},
+		{`{"parallelism":2,"settings":{"max_parallelism":5}}`, "target time unknown; maximum nodes 5", false},
+		{`{"parallelism":0,"tasks":{},"settings":{"target_time":0,"max_parallelism":0}}`, "target time 0s; maximum nodes 0", false},
+		{`{"parallelism":1,"settings":{"target_time":null,"max_parallelism":null}}`, "target time unknown; maximum nodes unknown", false},
+	} {
+		var p TestPlan
+		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		PrintSplitSummary(&buf, p)
+		if !strings.Contains(buf.String(), tt.want) || strings.Contains(buf.String(), "At maximum nodes") != tt.atCap {
+			t.Errorf("unexpected constraints for %s:\n%s", tt.body, &buf)
+		}
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -590,6 +590,51 @@ func TestSizingMetadataOutcomes(t *testing.T) {
 	}
 }
 
+func TestSizingDecisionEstimator(t *testing.T) {
+	for _, tt := range []struct {
+		name, estimator, basis string
+	}{
+		{"mean decision", `"mean_with_fallbacks_v1"`, "mean with median/default fallbacks"},
+		{"P90 decision or fallback", `"p90_with_median_fallbacks_v1"`, "P90 with median/default fallbacks"},
+		{"missing decision basis", `null`, "unavailable"},
+		{"unknown decision basis", `"future\n+++ forged"`, "unknown"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planningMetadataFixture(t, "reached_cap")
+			// Decode the new field independently of the allocation estimator.
+			if err := json.Unmarshal([]byte(`{"target_time_estimator":`+tt.estimator+`,"target_time_ms":7999.5}`), p.Sizing); err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			PrintSplitSummary(&buf, p)
+			assertSummary(t, buf.String(), []string{
+				"estimated need 2 nodes before caps (decision basis: " + tt.basis + ")",
+				"Sizing target: 7.9995s (explicit)",
+				"Estimated longest node: 13s (P90 packing with median/default fallbacks); P90 estimate exceeds sizing target",
+			}, []string{"mean estimate exceeds", "target unmet", "forged"})
+		})
+	}
+}
+
+func TestSizingUnusableTimings(t *testing.T) {
+	var p TestPlan
+	if err := json.Unmarshal([]byte(`{"parallelism":2,"settings":{"target_time":8,"max_parallelism":2},"sizing":{"method":"unusable_timings","runnable_units":4,"max_parallelism_binding":true,"runnable_units_binding":false,"estimator":"p90_with_median_fallbacks_v1","estimated_max_task_duration_ms":0}}`), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Sizing.TargetTimeMS != nil || p.Sizing.TargetTimeEstimator != nil || p.Sizing.EstimatedRequiredParallelism != nil || p.Sizing.TargetTimeSource != "" {
+		t.Fatalf("unused target acquired metadata: %+v", p.Sizing)
+	}
+	var buf bytes.Buffer
+	PrintSplitSummary(&buf, p)
+	assertSummary(t, buf.String(), []string{
+		"target time 8s; maximum nodes 2",
+		"Sizing: unusable timing estimates; target time not used.",
+		"Sizing runnable units: 4",
+		"Caps: maximum nodes binding; runnable units not independently binding",
+		"Estimated longest node: 0ms (P90 packing",
+	}, []string{"insufficient timing history", "Sizing target:", "decision basis", "estimated need", "within sizing target", "exceeds sizing target"})
+}
+
 func TestReturnedStrategyAvailability(t *testing.T) {
 	for _, tt := range []struct{ body, want string }{
 		{`{"selection":{"strategy":"random","applied":true}}`, "Applied strategy: random"},

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -378,7 +378,9 @@ func TestPrintSelectionSummary(t *testing.T) {
 		{"fallback reason", `{"selection":{"applied":false,"candidate_count":5,"selected_count":5,"skipped_reason":"no_model"}}`, "Not applied.\n  Reason: \"no_model\"\n  Selected 5 of 5 eligible runnable units (100%)."},
 		{"zero cutoffs", `{"selection":{"score_cutoff":0,"count_cutoff":0,"proportion_cutoff":0,"duration_proportion_cutoff":0,"effective_count":0}}`, "Returned parameters: score_cutoff=0, count_cutoff=0, proportion_cutoff=0, duration_proportion_cutoff=0, effective_count=0"},
 		{"null cutoffs", `{"selection":{"score_cutoff":null,"count_cutoff":null}}`, "Selected: unknown; eligible runnable units: unknown."},
-		{"local fallback", `{"Fallback":true}`, "Not applied: local fallback uses the full locally discovered suite."},
+		{"local fallback", `{"Fallback":true,"tasks":{"0":{"tests":[{"path":"a"}]}}}`, "Not applied: local fallback uses the full locally discovered suite."},
+		{"taskless placeholder", `{"Fallback":true}`, "Not determined: taskless fallback placeholder."},
+		{"empty task map placeholder", `{"Fallback":true,"tasks":{}}`, "Not determined: taskless fallback placeholder."},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var p TestPlan
@@ -394,6 +396,19 @@ func TestPrintSelectionSummary(t *testing.T) {
 				t.Errorf("redundant group or blank line: %q", buf.String())
 			}
 		})
+	}
+}
+
+func TestPrintSplitSummary_Placeholder(t *testing.T) {
+	for _, tasks := range []map[string]*Task{nil, {}} {
+		p := TestPlan{Fallback: true, Parallelism: 3, Tasks: tasks}
+		var buf bytes.Buffer
+		PrintSelectionSummary(&buf, p)
+		PrintSplitSummary(&buf, p)
+		assertSummary(t, buf.String(), []string{
+			"Not determined: taskless fallback placeholder.",
+			"Placeholder only: 3 nodes; no test allocation computed.",
+		}, []string{"full locally discovered suite", "Local non-intelligent split", "0 nodes"})
 	}
 }
 

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 )
@@ -449,5 +450,174 @@ func TestPercentOf(t *testing.T) {
 				t.Errorf("percentOf(%d, %d) = %q, want %q", tt.n, tt.total, got, tt.want)
 			}
 		})
+	}
+}
+
+// These are the exact response fragments from the verified TE-7042 backend
+// handoff. In particular, the top-level mean estimate must not replace P90.
+func planningMetadataFixture(t *testing.T, name string) TestPlan {
+	t.Helper()
+	body, err := os.ReadFile("testdata/planning_metadata.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plans map[string]TestPlan
+	if err := json.Unmarshal(body, &plans); err != nil {
+		t.Fatal(err)
+	}
+	p, ok := plans[name]
+	if !ok {
+		t.Fatalf("missing fixture %s", name)
+	}
+	return p
+}
+
+func TestPlanningMetadataBackendExamples(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		want, absent []string
+	}{
+		{"reached_cap", []string{"At maximum nodes.", "estimated need 2 nodes before caps", "Sizing runnable units: 4", "maximum nodes not independently binding; runnable units not independently binding", "Sizing target: 13s (explicit)", "Estimated longest node: 13s (P90 packing", "within sizing target", "not a runtime guarantee"}, []string{"Estimated longest node: 7s", "exceeds sizing target"}},
+		{"insufficient_history", []string{"target time 13s", "insufficient timing history; target time not used", "maximum nodes not independently binding; runnable units binding", "Estimated longest node: 1s (P90 packing"}, []string{"within sizing target", "exceeds sizing target", "Sizing target:", "estimated need"}},
+		{"selected_share", []string{"Applied strategy: manual", "Selected 1 of 4 eligible runnable units (25%)", "selected 5s of 14s eligible candidate total (mean with candidate median/default fallbacks)", "Estimated duration share: 35.7%; candidate timing coverage: 100%", "Compute, not wall time or the requested cutoff"}, []string{"Estimated duration share: 25%", "P90"}},
+		{"skipped_strategy", []string{"Attempted strategy: xgboost (skipped; not applied)", "Reason: \"no_model\"", "Selected 9 of 9", "Estimated duration share: unavailable"}, []string{"Applied strategy:"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planningMetadataFixture(t, tt.name)
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, p)
+			PrintSplitSummary(&buf, p)
+			assertSummary(t, buf.String(), tt.want, tt.absent)
+		})
+	}
+}
+
+func TestSelectionDurationAvailability(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		change func(*SelectionMetadata)
+		want   string
+	}{
+		{"zero selected", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 0 }, "Estimated duration share: 0%;"},
+		{"full selection", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 14000 }, "Estimated duration share: 100%;"},
+		{"zero denominator", func(s *SelectionMetadata) {
+			*s.DurationEstimates.CandidateTotalDurationMS = 0
+			*s.DurationEstimates.SelectedTotalDurationMS = 0
+		}, "selected 0ms of 0ms eligible candidate total"},
+		{"coverage threshold", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.5 }, "Estimated duration share: 35.7%; candidate timing coverage: 50%"},
+		{"coverage rounding", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.57 }, "Estimated duration share: 35.7%; candidate timing coverage: 57%"},
+		{"sparse coverage", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.49 }, "Estimated duration share: unavailable."},
+		{"missing coverage", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTimingCoverage = nil }, "Estimated duration share: unavailable."},
+		{"missing selected", func(s *SelectionMetadata) { s.DurationEstimates.SelectedTotalDurationMS = nil }, "Estimated duration share: unavailable."},
+		{"missing candidate", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTotalDurationMS = nil }, "Estimated duration share: unavailable."},
+		{"unknown estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "future" }, "Estimated duration share: unavailable."},
+		{"selected pool estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "mean_with_fallbacks_v1" }, "Estimated duration share: unavailable."},
+		{"absent estimates", func(s *SelectionMetadata) { s.DurationEstimates = nil }, "Estimated duration share: unavailable."},
+		{"skipped", func(s *SelectionMetadata) { *s.Applied = false }, "Estimated duration share: unavailable."},
+		{"unknown applied", func(s *SelectionMetadata) { s.Applied = nil }, "Estimated duration share: unavailable."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planningMetadataFixture(t, "selected_share")
+			tt.change(p.Selection)
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, p)
+			absent := []string{}
+			if strings.HasSuffix(tt.want, "unavailable.") {
+				absent = append(absent, "Estimated cumulative compute:")
+			}
+			if tt.name == "zero denominator" {
+				absent = append(absent, "Estimated duration share: 0%")
+				assertSummary(t, buf.String(), []string{"Estimated duration share: unavailable (zero candidate total)"}, nil)
+			}
+			assertSummary(t, buf.String(), []string{tt.want}, absent)
+		})
+	}
+}
+
+func TestSizingMetadataOutcomes(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		change       func(*TestPlan)
+		want, absent []string
+	}{
+		{"binding cap misses target", func(p *TestPlan) {
+			*p.Sizing.MaxParallelismBinding = true
+			*p.Sizing.TargetTimeMS = 8000
+			*p.Sizing.EstimatedRequiredParallelism = 4
+		}, []string{"maximum nodes binding;", "estimated need 4 nodes before caps", "exceeds sizing target"}, []string{"within sizing target"}},
+		{"binding does not prove miss", func(p *TestPlan) { *p.Sizing.MaxParallelismBinding = true }, []string{"maximum nodes binding;", "within sizing target"}, []string{"exceeds sizing target"}},
+		{"tied caps", func(p *TestPlan) {
+			p.Parallelism = 4
+			*p.Settings.MaxParallelism = 4
+			*p.Sizing.EstimatedRequiredParallelism = 8
+		}, []string{"At maximum nodes.", "estimated need 8 nodes before caps", "maximum nodes not independently binding; runnable units not independently binding"}, nil},
+		{"uncapped miss", func(p *TestPlan) {
+			p.Parallelism = 4
+			*p.Settings.MaxParallelism = 10
+			*p.Sizing.TargetTimeMS = 7000
+			*p.Sizing.EstimatedMaxTaskDurationMS = 8000
+		}, []string{"maximum nodes not independently binding", "Estimated longest node: 8s", "exceeds sizing target"}, []string{"At maximum nodes"}},
+		{"automatic target", func(p *TestPlan) {
+			p.Settings.TargetTime = nil
+			p.Sizing.TargetTimeSource = "longest_test"
+			*p.Sizing.TargetTimeMS = 8000
+		}, []string{"Sizing target: 8s (automatic: longest test P90 estimate)"}, nil},
+		{"fractional target", func(p *TestPlan) { *p.Sizing.TargetTimeMS = 12999.5 }, []string{"Sizing target: 12.9995s", "exceeds sizing target"}, nil},
+		{"absent flags", func(p *TestPlan) { p.Sizing.MaxParallelismBinding = nil; p.Sizing.RunnableUnitsBinding = nil }, []string{"maximum nodes binding unknown; runnable units binding unknown"}, []string{"not independently binding"}},
+		{"missing target", func(p *TestPlan) { p.Sizing.TargetTimeMS = nil }, []string{"Sizing target: unavailable"}, []string{"within sizing target", "exceeds sizing target"}},
+		{"unknown target source", func(p *TestPlan) { p.Sizing.TargetTimeSource = "future" }, []string{"Sizing target: unavailable"}, []string{"within sizing target", "exceeds sizing target"}},
+		{"unknown estimator", func(p *TestPlan) { p.Sizing.Estimator = "future" }, []string{"Estimated longest node: unavailable"}, []string{"within sizing target", "exceeds sizing target", "Estimated longest node: 7s"}},
+		{"missing estimate", func(p *TestPlan) { p.Sizing.EstimatedMaxTaskDurationMS = nil }, []string{"Estimated longest node: unavailable"}, []string{"within sizing target", "Estimated longest node: 7s"}},
+		{"old plan", func(p *TestPlan) { p.Sizing = nil }, []string{"does not establish that the cap limited sizing"}, []string{"Sizing:", "Estimated longest node:", "within sizing target"}},
+		{"unknown method", func(p *TestPlan) { p.Sizing.Method = "future" }, []string{"Sizing: unavailable (unknown method)"}, []string{"timing-based", "within sizing target"}},
+		{"fixed one", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "fixed"} }, []string{"Sizing: fixed parallelism; no timing target used", "Estimated longest node: unavailable"}, []string{"Caps:", "within sizing target"}},
+		{"single node", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "single_node"} }, []string{"Sizing: single-node maximum; no timing target used"}, []string{"Caps:", "within sizing target"}},
+		{"empty sparse plan", func(p *TestPlan) {
+			p.Parallelism = 0
+			p.Tasks = map[string]*Task{}
+			p.Sizing.Method = "insufficient_history"
+			*p.Sizing.RunnableUnits = 0
+			*p.Sizing.EstimatedMaxTaskDurationMS = 0
+		}, []string{"0 runnable units across 0 nodes", "Sizing runnable units: 0", "Estimated longest node: 0ms"}, []string{"within sizing target", "exceeds sizing target"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := planningMetadataFixture(t, "reached_cap")
+			tt.change(&p)
+			var buf bytes.Buffer
+			PrintSplitSummary(&buf, p)
+			assertSummary(t, buf.String(), tt.want, tt.absent)
+		})
+	}
+}
+
+func TestReturnedStrategyAvailability(t *testing.T) {
+	for _, tt := range []struct{ body, want string }{
+		{`{"selection":{"strategy":"random","applied":true}}`, "Applied strategy: random"},
+		{`{"selection":{"strategy":"rspec_changed_files","applied":false}}`, "Attempted strategy: rspec_changed_files"},
+		{`{"selection":{"strategy":"austral","applied":null}}`, "Returned strategy: austral (applied status unavailable)"},
+		{`{"selection":{"strategy":"future\n+++ forged","applied":true}}`, "Returned strategy: unavailable (unsupported)"},
+		{`{"selection":{"strategy":null,"applied":true}}`, "Applied."},
+	} {
+		var p TestPlan
+		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		PrintSelectionSummary(&buf, p)
+		assertSummary(t, buf.String(), []string{tt.want}, []string{"forged"})
+	}
+}
+
+func assertSummary(t *testing.T, got string, want, absent []string) {
+	t.Helper()
+	for _, s := range want {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing %q:\n%s", s, got)
+		}
+	}
+	for _, s := range append(absent, "+++", "\n\n") {
+		if strings.Contains(got, s) {
+			t.Errorf("unexpected %q:\n%s", s, got)
+		}
 	}
 }

--- a/internal/plan/summary_test.go
+++ b/internal/plan/summary_test.go
@@ -35,8 +35,8 @@ func TestPrintSplitSummary_MixedHistory(t *testing.T) {
 
 	for _, want := range []string{
 		"Split summary\n  5 files across 2 nodes",
-		"3 files (60%) estimated from past historical durations",
-		"2 files (40%) had no history — assumed median (4.2s)",
+		"Historical timings: 3 of 5 files (60%)",
+		"No history: 2 files (40%); median duration 4.2s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -62,7 +62,8 @@ func TestPrintSplitSummary_NoHistory(t *testing.T) {
 
 	for _, want := range []string{
 		"Split summary\n  3 files across 2 nodes",
-		"3 files (100%) had no history and used the default duration (1.0s)",
+		"Historical timings: 0 of 3 files (0%)",
+		"No history: 3 files (100%); default duration 1.0s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -91,10 +92,10 @@ func TestPrintSplitSummary_NullMedianWithUnknowns(t *testing.T) {
 	PrintSplitSummary(&buf, p)
 	got := buf.String()
 
-	if strings.Contains(got, "assumed median") {
+	if strings.Contains(got, "median duration") {
 		t.Errorf("expected no median when MedianDuration is nil, got:\n%s", got)
 	}
-	if !strings.Contains(got, "had no history\n") {
+	if !strings.Contains(got, "No history: 1 file (50%)\n") {
 		t.Errorf("expected bare \"had no history\" line, got:\n%s", got)
 	}
 }
@@ -108,7 +109,7 @@ func TestPrintSplitSummary_NoMetadata(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
-	if !strings.Contains(buf.String(), "1 file across 1 node") || !strings.Contains(buf.String(), "Timing history unavailable.") {
+	if !strings.Contains(buf.String(), "1 file across 1 node") || !strings.Contains(buf.String(), "Historical timings: unavailable") {
 		t.Errorf("expected count and unknown history, got: %s", buf.String())
 	}
 }
@@ -132,7 +133,7 @@ func TestPrintSplitSummary_ParallelismOneNoBreakdown(t *testing.T) {
 	if !strings.Contains(got, "4 files across 1 node") {
 		t.Errorf("output missing count line\nfull output:\n%s", got)
 	}
-	if strings.Contains(got, "estimated from past") || strings.Contains(got, "had no history") {
+	if strings.Contains(got, "Historical timings:") || strings.Contains(got, "No history:") {
 		t.Errorf("unexpected breakdown at parallelism 1:\n%s", got)
 	}
 }
@@ -158,8 +159,8 @@ func TestPrintSplitSummary_ExampleMode(t *testing.T) {
 
 	for _, want := range []string{
 		"Split summary\n  2 examples across 2 nodes",
-		"1 example (50%) estimated from past historical durations",
-		"1 example (50%) had no history",
+		"Historical timings: 1 of 2 examples (50%)",
+		"No history: 1 example (50%)",
 		"2.0s",
 	} {
 		if !strings.Contains(got, want) {
@@ -192,8 +193,8 @@ func TestPrintSplitSummary_SelectorMode(t *testing.T) {
 
 	for _, want := range []string{
 		"Split summary\n  2 selectors across 2 nodes",
-		"1 selector (50%) estimated from past historical durations",
-		"1 selector (50%) had no history — assumed median (1.8s)",
+		"Historical timings: 1 of 2 selectors (50%)",
+		"No history: 1 selector (50%); median duration 1.8s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -228,7 +229,8 @@ func TestPrintSplitSummary_SelectorModeNoHistoryUsesDefaultDuration(t *testing.T
 	got := buf.String()
 
 	for _, want := range []string{
-		"2 selectors (100%) had no history and used the default duration (1.0s)",
+		"Historical timings: 0 of 2 selectors (0%)",
+		"No history: 2 selectors (100%); default duration 1.0s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -286,13 +288,13 @@ func TestPrintSplitSummary_MixedFormats(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"4 runnable units across 2 nodes",
+		"4 test selectors across 2 nodes",
 		"  2 files\n",
-		"    1 (50%) estimated from past historical durations",
-		"    1 (50%) had no history — assumed median (4.2s)",
+		"    Historical timings: 1 of 2 files (50%)",
+		"    No history: 1 file (50%); median duration 4.2s",
 		"  2 examples\n",
-		"    1 (50%) estimated from past historical durations",
-		"    1 (50%) had no history — assumed median (150ms)",
+		"    Historical timings: 1 of 2 examples (50%)",
+		"    No history: 1 example (50%); median duration 150ms",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -325,14 +327,14 @@ func TestPrintSplitSummary_MixedFormatsWithSelectors(t *testing.T) {
 	got := buf.String()
 
 	for _, want := range []string{
-		"4 runnable units across 2 nodes",
+		"4 test selectors across 2 nodes",
 		"  1 file\n",
-		"    1 (100%) estimated from past historical durations",
+		"    Historical timings: 1 of 1 file (100%)",
 		"  1 example\n",
-		"    1 (100%) had no history and used the default duration (500ms)",
+		"    No history: 1 example (100%); default duration 500ms",
 		"  2 selectors\n",
-		"    1 (50%) estimated from past historical durations",
-		"    1 (50%) had no history — assumed median (1.8s)",
+		"    Historical timings: 1 of 2 selectors (50%)",
+		"    No history: 1 selector (50%); median duration 1.8s",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q\nfull output:\n%s", want, got)
@@ -356,10 +358,10 @@ func TestPrintSplitSummary_Fallback(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
-	if !strings.Contains(buf.String(), "1 runnable unit across 1 node") || !strings.Contains(buf.String(), "Local non-intelligent split") {
+	if !strings.Contains(buf.String(), "1 test selector across 1 node") || !strings.Contains(buf.String(), "Local non-intelligent split") {
 		t.Errorf("expected local fallback summary, got: %s", buf.String())
 	}
-	if strings.Contains(buf.String(), "had no history") {
+	if strings.Contains(buf.String(), "No history:") {
 		t.Errorf("unexpected server timing breakdown for fallback: %s", buf.String())
 	}
 }
@@ -368,16 +370,16 @@ func TestPrintSelectionSummary(t *testing.T) {
 	for _, tt := range []struct {
 		name, body, want string
 	}{
-		{"old plan", `{}`, "Outcome unknown (selection metadata unavailable)."},
-		{"null", `{"selection":null}`, "Outcome unknown (selection metadata unavailable)."},
-		{"missing applied", `{"selection":{"applied":null,"selected_count":0}}`, "Outcome unknown (applied status unavailable).\n  Selected: 0; eligible runnable units: unknown."},
-		{"zero selected", `{"selection":{"applied":true,"candidate_count":5,"selected_count":0}}`, "Applied.\n  Selected 0 of 5 eligible runnable units (0%)."},
-		{"zero eligible", `{"selection":{"applied":true,"candidate_count":0,"selected_count":0}}`, "Selected 0 of 0 eligible runnable units (percentage unavailable: no eligible units)."},
-		{"full selection", `{"selection":{"applied":true,"candidate_count":5,"selected_count":5}}`, "Selected 5 of 5 eligible runnable units (100%)."},
-		{"mixed denominator", `{"selection":{"applied":true,"candidate_count":6,"selected_count":2},"tasks":{"0":{"tests":[{"format":"file"},{"format":"example"}]}}}`, "Selected 2 of 6 eligible runnable units (33.3%)."},
-		{"fallback reason", `{"selection":{"applied":false,"candidate_count":5,"selected_count":5,"skipped_reason":"no_model"}}`, "Not applied.\n  Reason: \"no_model\"\n  Selected 5 of 5 eligible runnable units (100%)."},
-		{"zero cutoffs", `{"selection":{"score_cutoff":0,"count_cutoff":0,"proportion_cutoff":0,"duration_proportion_cutoff":0,"effective_count":0}}`, "Returned parameters: score_cutoff=0, count_cutoff=0, proportion_cutoff=0, duration_proportion_cutoff=0, effective_count=0"},
-		{"null cutoffs", `{"selection":{"score_cutoff":null,"count_cutoff":null}}`, "Selected: unknown; eligible runnable units: unknown."},
+		{"old plan", `{}`, "No selection metadata returned"},
+		{"null", `{"selection":null}`, "No selection metadata returned"},
+		{"missing applied", `{"selection":{"applied":null,"selected_count":0}}`, "Applied status: unavailable\n  Selected: 0 of unknown test selectors"},
+		{"zero selected", `{"selection":{"applied":true,"candidate_count":5,"selected_count":0}}`, "Applied (strategy unavailable)\n  Selected: 0 of 5 test selectors (0%)"},
+		{"zero eligible", `{"selection":{"applied":true,"candidate_count":0,"selected_count":0}}`, "Selected: 0 of 0 test selectors (percentage unavailable)"},
+		{"full selection", `{"selection":{"applied":true,"candidate_count":5,"selected_count":5}}`, "Selected: 5 of 5 test selectors (100%)"},
+		{"mixed denominator", `{"selection":{"applied":true,"candidate_count":6,"selected_count":2},"tasks":{"0":{"tests":[{"format":"file"},{"format":"example"}]}}}`, "Selected: 2 of 6 test selectors (33.3%)"},
+		{"fallback reason", `{"selection":{"applied":false,"candidate_count":5,"selected_count":5,"skipped_reason":"no_model"}}`, "Not applied (strategy unavailable)\n  Reason: no_model\n  Selected: 5 of 5 test selectors (100%)"},
+		{"zero cutoffs", `{"selection":{"score_cutoff":0,"count_cutoff":0,"proportion_cutoff":0,"duration_proportion_cutoff":0,"effective_count":0}}`, "Returned parameter: score_cutoff = 0\n  Returned parameter: count_cutoff = 0\n  Returned parameter: proportion_cutoff = 0\n  Returned parameter: duration_proportion_cutoff = 0\n  Effective count: 0"},
+		{"null cutoffs", `{"selection":{"score_cutoff":null,"count_cutoff":null}}`, "Selected: unknown of unknown test selectors"},
 		{"local fallback", `{"Fallback":true,"tasks":{"0":{"tests":[{"path":"a"}]}}}`, "Not applied: local fallback uses the full locally discovered suite."},
 		{"taskless placeholder", `{"Fallback":true}`, "Not determined: taskless fallback placeholder."},
 		{"empty task map placeholder", `{"Fallback":true,"tasks":{}}`, "Not determined: taskless fallback placeholder."},
@@ -388,11 +390,11 @@ func TestPrintSelectionSummary(t *testing.T) {
 				t.Fatal(err)
 			}
 			var buf bytes.Buffer
-			PrintSelectionSummary(&buf, p)
+			PrintSelectionSummary(&buf, p, nil)
 			if !strings.Contains(buf.String(), tt.want) {
 				t.Errorf("want %q, got:\n%s", tt.want, &buf)
 			}
-			if strings.Contains(buf.String(), "+++") || strings.Contains(buf.String(), "\n\n") {
+			if strings.Contains(buf.String(), "+++") || strings.Contains(buf.String(), "\n\n\n") {
 				t.Errorf("redundant group or blank line: %q", buf.String())
 			}
 		})
@@ -403,7 +405,7 @@ func TestPrintSplitSummary_Placeholder(t *testing.T) {
 	for _, tasks := range []map[string]*Task{nil, {}} {
 		p := TestPlan{Fallback: true, Parallelism: 3, Tasks: tasks}
 		var buf bytes.Buffer
-		PrintSelectionSummary(&buf, p)
+		PrintSelectionSummary(&buf, p, nil)
 		PrintSplitSummary(&buf, p)
 		assertSummary(t, buf.String(), []string{
 			"Not determined: taskless fallback placeholder.",
@@ -416,7 +418,7 @@ func TestSelectionReasonBoundedAndEscaped(t *testing.T) {
 	reason := "no_model\n+++ forged\x1b" + strings.Repeat("x", 1000)
 	p := TestPlan{Selection: &SelectionMetadata{SkippedReason: &reason}}
 	var buf bytes.Buffer
-	PrintSelectionSummary(&buf, p)
+	PrintSelectionSummary(&buf, p, nil)
 	if !strings.Contains(buf.String(), `no_model\n+++ forged\x1b`) || len(buf.String()) > 400 {
 		t.Fatalf("reason not safely bounded: %q", buf.String())
 	}
@@ -425,12 +427,11 @@ func TestSelectionReasonBoundedAndEscaped(t *testing.T) {
 func TestPrintSplitSummary_ReturnedConstraints(t *testing.T) {
 	for _, tt := range []struct {
 		body, want string
-		atCap      bool
 	}{
-		{`{"parallelism":2,"settings":{"target_time":120.5,"max_parallelism":2}}`, "target time 120.5s; maximum nodes 2", true},
-		{`{"parallelism":2,"settings":{"max_parallelism":5}}`, "target time unknown; maximum nodes 5", false},
-		{`{"parallelism":0,"tasks":{},"settings":{"target_time":0,"max_parallelism":0}}`, "target time 0s; maximum nodes 0", false},
-		{`{"parallelism":1,"settings":{"target_time":null,"max_parallelism":null}}`, "target time unknown; maximum nodes unknown", false},
+		{`{"parallelism":2,"settings":{"target_time":120.5,"max_parallelism":2}}`, "Target time: 120.5s (usage unknown)\n  Node limit: 2 (binding unknown)"},
+		{`{"parallelism":2,"settings":{"max_parallelism":5}}`, "Node limit: 5 (binding unknown)"},
+		{`{"parallelism":0,"tasks":{},"settings":{"target_time":0,"max_parallelism":0}}`, "Target time: 0s (usage unknown)\n  Node limit: 0 (binding unknown)"},
+		{`{"parallelism":1,"settings":{"target_time":null,"max_parallelism":null}}`, "Node limit: unavailable (binding unknown)"},
 	} {
 		var p TestPlan
 		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
@@ -438,7 +439,7 @@ func TestPrintSplitSummary_ReturnedConstraints(t *testing.T) {
 		}
 		var buf bytes.Buffer
 		PrintSplitSummary(&buf, p)
-		if !strings.Contains(buf.String(), tt.want) || strings.Contains(buf.String(), "At maximum nodes") != tt.atCap {
+		if !strings.Contains(buf.String(), tt.want) || strings.Contains(buf.String(), "capped at") {
 			t.Errorf("unexpected constraints for %s:\n%s", tt.body, &buf)
 		}
 	}
@@ -492,15 +493,15 @@ func TestPlanningMetadataBackendExamples(t *testing.T) {
 		name         string
 		want, absent []string
 	}{
-		{"reached_cap", []string{"At maximum nodes.", "estimated need 2 nodes before caps", "Sizing runnable units: 4", "maximum nodes not independently binding; runnable units not independently binding", "Sizing target: 13s (explicit)", "Estimated longest node: 13s (P90 packing", "within sizing target", "not a runtime guarantee"}, []string{"Estimated longest node: 7s", "exceeds sizing target"}},
-		{"insufficient_history", []string{"target time 13s", "insufficient timing history; target time not used", "maximum nodes not independently binding; runnable units binding", "Estimated longest node: 1s (P90 packing"}, []string{"within sizing target", "exceeds sizing target", "Sizing target:", "estimated need"}},
-		{"selected_share", []string{"Applied strategy: manual", "Selected 1 of 4 eligible runnable units (25%)", "selected 5s of 14s eligible candidate total (mean with candidate median/default fallbacks)", "Estimated duration share: 35.7%; candidate timing coverage: 100%", "Compute, not wall time or the requested cutoff"}, []string{"Estimated duration share: 25%", "P90"}},
-		{"skipped_strategy", []string{"Attempted strategy: xgboost (skipped; not applied)", "Reason: \"no_model\"", "Selected 9 of 9", "Estimated duration share: unavailable"}, []string{"Applied strategy:"}},
+		{"reached_cap", []string{"Estimated nodes needed: 2", "Node limit: 2 (not independently binding)", "Target time: 13s", "Estimated longest node: 13s (P90 durations; within target)"}, []string{"capped at", "Estimated longest node: 7s", "target exceeded"}},
+		{"insufficient_history", []string{"insufficient timing history; target not used", "Node limit: 10 (not independently binding)", "Test selector limit: capped at 4", "Estimated longest node: 1s (P90 durations)"}, []string{"within target", "target exceeded", "Target time:", "Estimated nodes needed:"}},
+		{"selected_share", []string{"Applied strategy: manual", "Selected: 1 of 4 test selectors (25%)", "Estimated compute: 5s of 14s (35.7%)", "Candidate timing coverage: 100%"}, []string{"Estimated compute: 5s of 14s (25%)", "P90"}},
+		{"skipped_strategy", []string{"Attempted strategy: xgboost (skipped)", "Reason: no_model", "Selected: 9 of 9", "Estimated compute: unavailable"}, []string{"Applied strategy:"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			p := planningMetadataFixture(t, tt.name)
 			var buf bytes.Buffer
-			PrintSelectionSummary(&buf, p)
+			PrintSelectionSummary(&buf, p, nil)
 			PrintSplitSummary(&buf, p)
 			assertSummary(t, buf.String(), tt.want, tt.absent)
 		})
@@ -513,36 +514,35 @@ func TestSelectionDurationAvailability(t *testing.T) {
 		change func(*SelectionMetadata)
 		want   string
 	}{
-		{"zero selected", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 0 }, "Estimated duration share: 0%;"},
-		{"full selection", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 14000 }, "Estimated duration share: 100%;"},
+		{"zero selected", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 0 }, "Estimated compute: 0ms of 14s (0%)"},
+		{"full selection", func(s *SelectionMetadata) { *s.DurationEstimates.SelectedTotalDurationMS = 14000 }, "Estimated compute: 14s of 14s (100%)"},
 		{"zero denominator", func(s *SelectionMetadata) {
 			*s.DurationEstimates.CandidateTotalDurationMS = 0
 			*s.DurationEstimates.SelectedTotalDurationMS = 0
-		}, "selected 0ms of 0ms eligible candidate total"},
-		{"coverage threshold", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.5 }, "Estimated duration share: 35.7%; candidate timing coverage: 50%"},
-		{"coverage rounding", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.57 }, "Estimated duration share: 35.7%; candidate timing coverage: 57%"},
-		{"sparse coverage", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.49 }, "Estimated duration share: unavailable."},
-		{"missing coverage", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTimingCoverage = nil }, "Estimated duration share: unavailable."},
-		{"missing selected", func(s *SelectionMetadata) { s.DurationEstimates.SelectedTotalDurationMS = nil }, "Estimated duration share: unavailable."},
-		{"missing candidate", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTotalDurationMS = nil }, "Estimated duration share: unavailable."},
-		{"unknown estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "future" }, "Estimated duration share: unavailable."},
-		{"selected pool estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "mean_with_fallbacks_v1" }, "Estimated duration share: unavailable."},
-		{"absent estimates", func(s *SelectionMetadata) { s.DurationEstimates = nil }, "Estimated duration share: unavailable."},
-		{"skipped", func(s *SelectionMetadata) { *s.Applied = false }, "Estimated duration share: unavailable."},
-		{"unknown applied", func(s *SelectionMetadata) { s.Applied = nil }, "Estimated duration share: unavailable."},
+		}, "Estimated compute: 0ms of 0ms (share unavailable)"},
+		{"coverage threshold", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.5 }, "Estimated compute: 5s of 14s (35.7%)\n  Candidate timing coverage: 50%"},
+		{"coverage rounding", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.57 }, "Estimated compute: 5s of 14s (35.7%)\n  Candidate timing coverage: 57%"},
+		{"sparse coverage", func(s *SelectionMetadata) { *s.DurationEstimates.CandidateTimingCoverage = 0.49 }, "Estimated compute: unavailable"},
+		{"missing coverage", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTimingCoverage = nil }, "Estimated compute: unavailable"},
+		{"missing selected", func(s *SelectionMetadata) { s.DurationEstimates.SelectedTotalDurationMS = nil }, "Estimated compute: unavailable"},
+		{"missing candidate", func(s *SelectionMetadata) { s.DurationEstimates.CandidateTotalDurationMS = nil }, "Estimated compute: unavailable"},
+		{"unknown estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "future" }, "Estimated compute: unavailable"},
+		{"selected pool estimator", func(s *SelectionMetadata) { s.DurationEstimates.Estimator = "mean_with_fallbacks_v1" }, "Estimated compute: unavailable"},
+		{"absent estimates", func(s *SelectionMetadata) { s.DurationEstimates = nil }, "Estimated compute: unavailable"},
+		{"skipped", func(s *SelectionMetadata) { *s.Applied = false }, "Estimated compute: unavailable"},
+		{"unknown applied", func(s *SelectionMetadata) { s.Applied = nil }, "Estimated compute: unavailable"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			p := planningMetadataFixture(t, "selected_share")
 			tt.change(p.Selection)
 			var buf bytes.Buffer
-			PrintSelectionSummary(&buf, p)
+			PrintSelectionSummary(&buf, p, nil)
 			absent := []string{}
-			if strings.HasSuffix(tt.want, "unavailable.") {
-				absent = append(absent, "Estimated cumulative compute:")
+			if strings.HasSuffix(tt.want, "unavailable") {
+				absent = append(absent, "Estimated compute: 5s")
 			}
 			if tt.name == "zero denominator" {
-				absent = append(absent, "Estimated duration share: 0%")
-				assertSummary(t, buf.String(), []string{"Estimated duration share: unavailable (zero candidate total)"}, nil)
+				absent = append(absent, "of 0ms (0%)")
 			}
 			assertSummary(t, buf.String(), []string{tt.want}, absent)
 		})
@@ -559,41 +559,42 @@ func TestSizingMetadataOutcomes(t *testing.T) {
 			*p.Sizing.MaxParallelismBinding = true
 			*p.Sizing.TargetTimeMS = 8000
 			*p.Sizing.EstimatedRequiredParallelism = 4
-		}, []string{"maximum nodes binding;", "estimated need 4 nodes before caps", "exceeds sizing target"}, []string{"within sizing target"}},
-		{"binding does not prove miss", func(p *TestPlan) { *p.Sizing.MaxParallelismBinding = true }, []string{"maximum nodes binding;", "within sizing target"}, []string{"exceeds sizing target"}},
+		}, []string{"Node limit: capped at 2", "Estimated nodes needed: 4", "target exceeded"}, []string{"within target"}},
+		{"binding does not prove miss", func(p *TestPlan) { *p.Sizing.MaxParallelismBinding = true }, []string{"Node limit: capped at 2", "within target"}, []string{"target exceeded"}},
 		{"tied caps", func(p *TestPlan) {
 			p.Parallelism = 4
 			*p.Settings.MaxParallelism = 4
 			*p.Sizing.EstimatedRequiredParallelism = 8
-		}, []string{"At maximum nodes.", "estimated need 8 nodes before caps", "maximum nodes not independently binding; runnable units not independently binding"}, nil},
+		}, []string{"Estimated nodes needed: 8", "Node limit: 4 (not independently binding)"}, []string{"capped at", "Test selector limit:"}},
 		{"uncapped miss", func(p *TestPlan) {
 			p.Parallelism = 4
 			*p.Settings.MaxParallelism = 10
 			*p.Sizing.TargetTimeMS = 7000
 			*p.Sizing.EstimatedMaxTaskDurationMS = 8000
-		}, []string{"maximum nodes not independently binding", "Estimated longest node: 8s", "exceeds sizing target"}, []string{"At maximum nodes"}},
+		}, []string{"Node limit: 10 (not independently binding)", "Estimated longest node: 8s", "target exceeded"}, []string{"capped at"}},
 		{"automatic target", func(p *TestPlan) {
 			p.Settings.TargetTime = nil
 			p.Sizing.TargetTimeSource = "longest_test"
 			*p.Sizing.TargetTimeMS = 8000
-		}, []string{"Sizing target: 8s (automatic: longest test P90 estimate)"}, nil},
-		{"fractional target", func(p *TestPlan) { *p.Sizing.TargetTimeMS = 12999.5 }, []string{"Sizing target: 12.9995s", "exceeds sizing target"}, nil},
-		{"absent flags", func(p *TestPlan) { p.Sizing.MaxParallelismBinding = nil; p.Sizing.RunnableUnitsBinding = nil }, []string{"maximum nodes binding unknown; runnable units binding unknown"}, []string{"not independently binding"}},
-		{"missing target", func(p *TestPlan) { p.Sizing.TargetTimeMS = nil }, []string{"Sizing target: unavailable"}, []string{"within sizing target", "exceeds sizing target"}},
-		{"unknown target source", func(p *TestPlan) { p.Sizing.TargetTimeSource = "future" }, []string{"Sizing target: unavailable"}, []string{"within sizing target", "exceeds sizing target"}},
-		{"unknown estimator", func(p *TestPlan) { p.Sizing.Estimator = "future" }, []string{"Estimated longest node: unavailable"}, []string{"within sizing target", "exceeds sizing target", "Estimated longest node: 7s"}},
-		{"missing estimate", func(p *TestPlan) { p.Sizing.EstimatedMaxTaskDurationMS = nil }, []string{"Estimated longest node: unavailable"}, []string{"within sizing target", "Estimated longest node: 7s"}},
-		{"old plan", func(p *TestPlan) { p.Sizing = nil }, []string{"does not establish that the cap limited sizing"}, []string{"Sizing:", "Estimated longest node:", "within sizing target"}},
-		{"unknown method", func(p *TestPlan) { p.Sizing.Method = "future" }, []string{"Sizing: unavailable (unknown method)"}, []string{"timing-based", "within sizing target"}},
-		{"fixed one", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "fixed"} }, []string{"Sizing: fixed parallelism; no timing target used", "Estimated longest node: unavailable"}, []string{"Caps:", "within sizing target"}},
-		{"single node", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "single_node"} }, []string{"Sizing: single-node maximum; no timing target used"}, []string{"Caps:", "within sizing target"}},
+		}, []string{"Target time: 8s (automatic, longest P90 test)"}, nil},
+		{"fractional target", func(p *TestPlan) { *p.Sizing.TargetTimeMS = 12999.5 }, []string{"Target time: 12.9995s", "target exceeded"}, nil},
+		{"absent flags", func(p *TestPlan) { p.Sizing.MaxParallelismBinding = nil; p.Sizing.RunnableUnitsBinding = nil }, []string{"Node limit: 2 (binding unknown)", "Test selector limit: binding unknown"}, []string{"not independently binding", "capped at"}},
+		{"binding unknown maximum", func(p *TestPlan) { p.Settings = nil; *p.Sizing.MaxParallelismBinding = true }, []string{"Node limit: binding (maximum unavailable)"}, []string{"capped at"}},
+		{"missing target", func(p *TestPlan) { p.Sizing.TargetTimeMS = nil }, []string{"Target time: unavailable"}, []string{"within target", "target exceeded"}},
+		{"unknown target source", func(p *TestPlan) { p.Sizing.TargetTimeSource = "future" }, []string{"Target time: unavailable"}, []string{"within target", "target exceeded"}},
+		{"unknown estimator", func(p *TestPlan) { p.Sizing.Estimator = "future" }, []string{"Estimated longest node: unavailable"}, []string{"within target", "target exceeded", "Estimated longest node: 7s"}},
+		{"missing estimate", func(p *TestPlan) { p.Sizing.EstimatedMaxTaskDurationMS = nil }, []string{"Estimated longest node: unavailable"}, []string{"within target", "Estimated longest node: 7s"}},
+		{"old plan", func(p *TestPlan) { p.Sizing = nil }, []string{"Sizing: unavailable", "Node limit: 2 (binding unknown)"}, []string{"capped at", "Estimated longest node:", "within target"}},
+		{"unknown method", func(p *TestPlan) { p.Sizing.Method = "future" }, []string{"Sizing: unavailable (unknown method)"}, []string{"Estimated nodes needed:", "within target"}},
+		{"fixed one", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "fixed"} }, []string{"Sizing: fixed parallelism; target not used", "Estimated longest node: unavailable"}, []string{"Node limit:", "within target"}},
+		{"single node", func(p *TestPlan) { p.Sizing = &SizingMetadata{Method: "single_node"} }, []string{"Sizing: single-node maximum; target not used"}, []string{"Node limit:", "within target"}},
 		{"empty sparse plan", func(p *TestPlan) {
 			p.Parallelism = 0
 			p.Tasks = map[string]*Task{}
 			p.Sizing.Method = "insufficient_history"
 			*p.Sizing.RunnableUnits = 0
 			*p.Sizing.EstimatedMaxTaskDurationMS = 0
-		}, []string{"0 runnable units across 0 nodes", "Sizing runnable units: 0", "Estimated longest node: 0ms"}, []string{"within sizing target", "exceeds sizing target"}},
+		}, []string{"0 test selectors across 0 nodes", "Estimated longest node: 0ms"}, []string{"within target", "target exceeded"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			p := planningMetadataFixture(t, "reached_cap")
@@ -609,10 +610,10 @@ func TestSizingDecisionEstimator(t *testing.T) {
 	for _, tt := range []struct {
 		name, estimator, basis string
 	}{
-		{"mean decision", `"mean_with_fallbacks_v1"`, "mean with median/default fallbacks"},
-		{"P90 decision or fallback", `"p90_with_median_fallbacks_v1"`, "P90 with median/default fallbacks"},
-		{"missing decision basis", `null`, "unavailable"},
-		{"unknown decision basis", `"future\n+++ forged"`, "unknown"},
+		{"mean decision", `"mean_with_fallbacks_v1"`, "mean durations"},
+		{"P90 decision or fallback", `"p90_with_median_fallbacks_v1"`, "P90 durations"},
+		{"missing decision basis", `null`, "basis unavailable"},
+		{"unknown decision basis", `"future\n+++ forged"`, "unknown basis"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			p := planningMetadataFixture(t, "reached_cap")
@@ -623,9 +624,9 @@ func TestSizingDecisionEstimator(t *testing.T) {
 			var buf bytes.Buffer
 			PrintSplitSummary(&buf, p)
 			assertSummary(t, buf.String(), []string{
-				"estimated need 2 nodes before caps (decision basis: " + tt.basis + ")",
-				"Sizing target: 7.9995s (explicit)",
-				"Estimated longest node: 13s (P90 packing with median/default fallbacks); P90 estimate exceeds sizing target",
+				"Estimated nodes needed: 2 (" + tt.basis + ")",
+				"Target time: 7.9995s",
+				"Estimated longest node: 13s (P90 durations; target exceeded)",
 			}, []string{"mean estimate exceeds", "target unmet", "forged"})
 		})
 	}
@@ -642,12 +643,10 @@ func TestSizingUnusableTimings(t *testing.T) {
 	var buf bytes.Buffer
 	PrintSplitSummary(&buf, p)
 	assertSummary(t, buf.String(), []string{
-		"target time 8s; maximum nodes 2",
-		"Sizing: unusable timing estimates; target time not used.",
-		"Sizing runnable units: 4",
-		"Caps: maximum nodes binding; runnable units not independently binding",
-		"Estimated longest node: 0ms (P90 packing",
-	}, []string{"insufficient timing history", "Sizing target:", "decision basis", "estimated need", "within sizing target", "exceeds sizing target"})
+		"Sizing: unusable timing estimates; target not used",
+		"Node limit: capped at 2",
+		"Estimated longest node: 0ms (P90 durations)",
+	}, []string{"insufficient timing history", "Target time:", "Estimated nodes needed:", "within target", "target exceeded"})
 }
 
 func TestReturnedStrategyAvailability(t *testing.T) {
@@ -655,16 +654,53 @@ func TestReturnedStrategyAvailability(t *testing.T) {
 		{`{"selection":{"strategy":"random","applied":true}}`, "Applied strategy: random"},
 		{`{"selection":{"strategy":"rspec_changed_files","applied":false}}`, "Attempted strategy: rspec_changed_files"},
 		{`{"selection":{"strategy":"austral","applied":null}}`, "Returned strategy: austral (applied status unavailable)"},
-		{`{"selection":{"strategy":"future\n+++ forged","applied":true}}`, "Returned strategy: unavailable (unsupported)"},
-		{`{"selection":{"strategy":null,"applied":true}}`, "Applied."},
+		{`{"selection":{"strategy":"future\n+++ forged","applied":true}}`, "Applied (strategy unavailable)"},
+		{`{"selection":{"strategy":null,"applied":true}}`, "Applied (strategy unavailable)"},
 	} {
 		var p TestPlan
 		if err := json.Unmarshal([]byte(tt.body), &p); err != nil {
 			t.Fatal(err)
 		}
 		var buf bytes.Buffer
-		PrintSelectionSummary(&buf, p)
+		PrintSelectionSummary(&buf, p, nil)
 		assertSummary(t, buf.String(), []string{tt.want}, []string{"forged"})
+	}
+}
+
+func TestSelectionParameterComparison(t *testing.T) {
+	for _, tt := range []struct {
+		name, body   string
+		requested    map[string]string
+		want, absent []string
+	}{
+		{"equivalent numeric values", `{"score_cutoff":0.5,"count_cutoff":12,"proportion_cutoff":0,"duration_proportion_cutoff":0.5}`, map[string]string{"score_cutoff": "5e-1", "count_cutoff": "12", "proportion_cutoff": "0", "duration_proportion_cutoff": "0.50"}, nil, []string{"Returned parameter:"}},
+		{"different or missing", `{"score_cutoff":0.5,"count_cutoff":12,"proportion_cutoff":0}`, map[string]string{"score_cutoff": "0.6", "count_cutoff": "10"}, []string{"score_cutoff = 0.5", "count_cutoff = 12", "proportion_cutoff = 0"}, nil},
+		{"missing returned", `{}`, map[string]string{"score_cutoff": "0.5", "count_cutoff": "12"}, nil, []string{"Returned parameter:"}},
+		{"invalid request is not a match", `{"score_cutoff":0,"count_cutoff":0}`, map[string]string{"score_cutoff": "invalid", "count_cutoff": "invalid"}, []string{"score_cutoff = 0", "count_cutoff = 0"}, nil},
+		{"large integer stays exact", `{"count_cutoff":9007199254740993}`, map[string]string{"count_cutoff": "9007199254740992"}, []string{"count_cutoff = 9007199254740993"}, nil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var s SelectionMetadata
+			if err := json.Unmarshal([]byte(tt.body), &s); err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			PrintSelectionSummary(&buf, TestPlan{Selection: &s}, tt.requested)
+			assertSummary(t, buf.String(), tt.want, tt.absent)
+		})
+	}
+}
+
+func TestSummaryValue(t *testing.T) {
+	for _, tt := range []struct{ value, want string }{
+		{"xgboost", "xgboost"}, {"0.5", "0.5"}, {"", `""`},
+		{"has space", `"has space"`}, {"line\n\x1b", `"line\n\x1b"`},
+		{"tab\tvalue", `"tab\tvalue"`}, {"quote\"", `"quote\""`},
+		{"bad\xff", `"bad\xff"`}, {"invisible\u202e", `"invisible\u202e"`},
+	} {
+		if got := SummaryValue(tt.value); got != tt.want {
+			t.Errorf("SummaryValue(%q) = %q, want %q", tt.value, got, tt.want)
+		}
 	}
 }
 
@@ -675,7 +711,7 @@ func assertSummary(t *testing.T, got string, want, absent []string) {
 			t.Errorf("missing %q:\n%s", s, got)
 		}
 	}
-	for _, s := range append(absent, "+++", "\n\n") {
+	for _, s := range append(absent, "+++", "\n\n\n", "runnable unit", "At maximum nodes", "Returned constraints") {
 		if strings.Contains(got, s) {
 			t.Errorf("unexpected %q:\n%s", s, got)
 		}

--- a/internal/plan/testdata/planning_metadata.json
+++ b/internal/plan/testdata/planning_metadata.json
@@ -1,0 +1,56 @@
+{
+  "reached_cap": {
+    "parallelism": 2,
+    "settings": {"target_time": 13, "max_parallelism": 2},
+    "sizing": {
+      "method": "timing",
+      "target_time_source": "explicit",
+      "target_time_ms": 13000,
+      "estimated_required_parallelism": 2,
+      "runnable_units": 4,
+      "max_parallelism_binding": false,
+      "runnable_units_binding": false,
+      "estimator": "p90_with_median_fallbacks_v1",
+      "estimated_max_task_duration_ms": 13000
+    },
+    "duration_estimates": {
+      "estimator": "mean_with_fallbacks_v1",
+      "total_duration_ms": 12000,
+      "max_task_duration_ms": 7000,
+      "source_counts": {"mean": 4, "median": 0, "default": 0}
+    }
+  },
+  "insufficient_history": {
+    "parallelism": 4,
+    "settings": {"target_time": 13, "max_parallelism": 10},
+    "sizing": {
+      "method": "insufficient_history",
+      "runnable_units": 4,
+      "max_parallelism_binding": false,
+      "runnable_units_binding": true,
+      "estimator": "p90_with_median_fallbacks_v1",
+      "estimated_max_task_duration_ms": 1000
+    },
+    "duration_estimates": {
+      "estimator": "mean_with_fallbacks_v1",
+      "total_duration_ms": 4000,
+      "max_task_duration_ms": 1000,
+      "source_counts": {"mean": 0, "median": 0, "default": 4}
+    }
+  },
+  "selected_share": {
+    "selection": {
+      "applied": true,
+      "strategy": "manual",
+      "candidate_count": 4,
+      "selected_count": 1,
+      "duration_estimates": {
+        "estimator": "mean_with_candidate_median_fallbacks_v1",
+        "candidate_total_duration_ms": 14000,
+        "selected_total_duration_ms": 5000,
+        "candidate_timing_coverage": 1.0
+      }
+    }
+  },
+  "skipped_strategy": {"selection":{"applied":false,"strategy":"xgboost","candidate_count":9,"selected_count":9,"skipped_reason":"no_model"}}
+}

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -63,6 +63,27 @@ type Task struct {
 	Tests []TestCase `json:"tests"`
 }
 
+// SelectionMetadata contains public selection outcomes. Pointers distinguish
+// missing/null metadata on older plans from real zero counts and false outcomes.
+// Counts are runnable units, not necessarily paths or the cutoff's denominator.
+type SelectionMetadata struct {
+	Applied                  *bool    `json:"applied,omitempty"`
+	CandidateCount           *int     `json:"candidate_count,omitempty"`
+	SelectedCount            *int     `json:"selected_count,omitempty"`
+	ScoreCutoff              *float64 `json:"score_cutoff,omitempty"`
+	CountCutoff              *int     `json:"count_cutoff,omitempty"`
+	ProportionCutoff         *float64 `json:"proportion_cutoff,omitempty"`
+	DurationProportionCutoff *float64 `json:"duration_proportion_cutoff,omitempty"`
+	EffectiveCount           *int     `json:"effective_count,omitempty"`
+	SkippedReason            *string  `json:"skipped_reason,omitempty"`
+}
+
+// Settings describes returned split constraints, not the current invocation.
+type Settings struct {
+	MaxParallelism *int     `json:"max_parallelism,omitempty"`
+	TargetTime     *float64 `json:"target_time,omitempty"` // seconds
+}
+
 // TestPlan represents the entire test plan.
 type TestPlan struct {
 	Identifier   string           `json:"identifier"`
@@ -70,8 +91,10 @@ type TestPlan struct {
 	Experiment   string           `json:"experiment"`
 	Tasks        map[string]*Task `json:"tasks"`
 	Fallback     bool
-	MutedTests   []TestCase `json:"muted_tests,omitempty"`
-	SkippedTests []TestCase `json:"skipped_tests,omitempty"`
+	MutedTests   []TestCase         `json:"muted_tests,omitempty"`
+	SkippedTests []TestCase         `json:"skipped_tests,omitempty"`
+	Selection    *SelectionMetadata `json:"selection,omitempty"`
+	Settings     *Settings          `json:"settings,omitempty"`
 	// TimingMetadata describes the historical timing data the server used to
 	// build this plan. Nil when missing (e.g. error plans, plans cached before
 	// the server began emitting it).

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -67,15 +67,42 @@ type Task struct {
 // missing/null metadata on older plans from real zero counts and false outcomes.
 // Counts are runnable units, not necessarily paths or the cutoff's denominator.
 type SelectionMetadata struct {
-	Applied                  *bool    `json:"applied,omitempty"`
-	CandidateCount           *int     `json:"candidate_count,omitempty"`
-	SelectedCount            *int     `json:"selected_count,omitempty"`
-	ScoreCutoff              *float64 `json:"score_cutoff,omitempty"`
-	CountCutoff              *int     `json:"count_cutoff,omitempty"`
-	ProportionCutoff         *float64 `json:"proportion_cutoff,omitempty"`
-	DurationProportionCutoff *float64 `json:"duration_proportion_cutoff,omitempty"`
-	EffectiveCount           *int     `json:"effective_count,omitempty"`
-	SkippedReason            *string  `json:"skipped_reason,omitempty"`
+	Applied                  *bool                       `json:"applied,omitempty"`
+	Strategy                 *string                     `json:"strategy,omitempty"`
+	CandidateCount           *int                        `json:"candidate_count,omitempty"`
+	SelectedCount            *int                        `json:"selected_count,omitempty"`
+	ScoreCutoff              *float64                    `json:"score_cutoff,omitempty"`
+	CountCutoff              *int                        `json:"count_cutoff,omitempty"`
+	ProportionCutoff         *float64                    `json:"proportion_cutoff,omitempty"`
+	DurationProportionCutoff *float64                    `json:"duration_proportion_cutoff,omitempty"`
+	EffectiveCount           *int                        `json:"effective_count,omitempty"`
+	SkippedReason            *string                     `json:"skipped_reason,omitempty"`
+	DurationEstimates        *SelectionDurationEstimates `json:"duration_estimates,omitempty"`
+}
+
+// SelectionDurationEstimates prices both pools using candidate-pool fallbacks.
+// The top-level duration_estimates uses different, selected-pool fallbacks and
+// must not supply either side of this share. Zero candidate compute has no share.
+type SelectionDurationEstimates struct {
+	Estimator                string   `json:"estimator,omitempty"`
+	CandidateTotalDurationMS *int     `json:"candidate_total_duration_ms,omitempty"`
+	SelectedTotalDurationMS  *int     `json:"selected_total_duration_ms,omitempty"`
+	CandidateTimingCoverage  *float64 `json:"candidate_timing_coverage,omitempty"`
+}
+
+// SizingMetadata records the actual server sizing branch, never reconstructed
+// from settings or tasks. Binding flags are independent: tied constraints are
+// both false. Target/required nodes exist only when timing-based sizing was used.
+type SizingMetadata struct {
+	Method                       string   `json:"method,omitempty"`
+	RunnableUnits                *int     `json:"runnable_units,omitempty"`
+	MaxParallelismBinding        *bool    `json:"max_parallelism_binding,omitempty"`
+	RunnableUnitsBinding         *bool    `json:"runnable_units_binding,omitempty"`
+	TargetTimeSource             string   `json:"target_time_source,omitempty"`
+	TargetTimeMS                 *float64 `json:"target_time_ms,omitempty"`
+	EstimatedRequiredParallelism *int     `json:"estimated_required_parallelism,omitempty"`
+	Estimator                    string   `json:"estimator,omitempty"`
+	EstimatedMaxTaskDurationMS   *int     `json:"estimated_max_task_duration_ms,omitempty"`
 }
 
 // Settings describes returned split constraints, not the current invocation.
@@ -95,6 +122,7 @@ type TestPlan struct {
 	SkippedTests []TestCase         `json:"skipped_tests,omitempty"`
 	Selection    *SelectionMetadata `json:"selection,omitempty"`
 	Settings     *Settings          `json:"settings,omitempty"`
+	Sizing       *SizingMetadata    `json:"sizing,omitempty"`
 	// TimingMetadata describes the historical timing data the server used to
 	// build this plan. Nil when missing (e.g. error plans, plans cached before
 	// the server began emitting it).

--- a/internal/plan/type.go
+++ b/internal/plan/type.go
@@ -93,6 +93,8 @@ type SelectionDurationEstimates struct {
 // SizingMetadata records the actual server sizing branch, never reconstructed
 // from settings or tasks. Binding flags are independent: tied constraints are
 // both false. Target/required nodes exist only when timing-based sizing was used.
+// TargetTimeEstimator prices the sizing decision independently of the P90
+// allocation Estimator; it is absent on older plans or when no target was used.
 type SizingMetadata struct {
 	Method                       string   `json:"method,omitempty"`
 	RunnableUnits                *int     `json:"runnable_units,omitempty"`
@@ -100,6 +102,7 @@ type SizingMetadata struct {
 	RunnableUnitsBinding         *bool    `json:"runnable_units_binding,omitempty"`
 	TargetTimeSource             string   `json:"target_time_source,omitempty"`
 	TargetTimeMS                 *float64 `json:"target_time_ms,omitempty"`
+	TargetTimeEstimator          *string  `json:"target_time_estimator,omitempty"`
 	EstimatedRequiredParallelism *int     `json:"estimated_required_parallelism,omitempty"`
 	Estimator                    string   `json:"estimator,omitempty"`
 	EstimatedMaxTaskDurationMS   *int     `json:"estimated_max_task_duration_ms,omitempty"`

--- a/internal/plan/type_test.go
+++ b/internal/plan/type_test.go
@@ -194,6 +194,36 @@ func TestTestPlan_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestTestPlan_TargetTimeEstimator(t *testing.T) {
+	for _, value := range []string{`null`, `""`, `"mean_with_fallbacks_v1"`, `"p90_with_median_fallbacks_v1"`, `"future"`} {
+		var got TestPlan
+		if err := json.Unmarshal([]byte(`{"sizing":{"method":"timing","target_time_estimator":`+value+`,"target_time_ms":0.5,"estimated_required_parallelism":0}}`), &got); err != nil {
+			t.Fatal(err)
+		}
+		var want *string
+		if err := json.Unmarshal([]byte(value), &want); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(want, got.Sizing.TargetTimeEstimator); diff != "" {
+			t.Fatal(diff)
+		}
+		if got.Sizing.TargetTimeMS == nil || *got.Sizing.TargetTimeMS != 0.5 || got.Sizing.EstimatedRequiredParallelism == nil || *got.Sizing.EstimatedRequiredParallelism != 0 {
+			t.Fatalf("lost fractional/zero values: %+v", got.Sizing)
+		}
+		encoded, err := json.Marshal(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var roundTrip TestPlan
+		if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got, roundTrip); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}
+
 func TestTestPlan_OptionalPlanningMetadata(t *testing.T) {
 	zero, no, strategy := 0, false, "manual"
 	for _, tt := range []struct {

--- a/internal/plan/type_test.go
+++ b/internal/plan/type_test.go
@@ -193,3 +193,38 @@ func TestTestPlan_RoundTrip(t *testing.T) {
 		t.Errorf("round-trip diff (-want +got):\n%s", diff)
 	}
 }
+
+func TestTestPlan_OptionalPlanningMetadata(t *testing.T) {
+	zero, no, strategy := 0, false, "manual"
+	for _, tt := range []struct {
+		body string
+		want TestPlan
+	}{
+		{`{}`, TestPlan{}},
+		{`{"selection":null,"sizing":null}`, TestPlan{}},
+		{`{"selection":{"strategy":null,"duration_estimates":{"candidate_total_duration_ms":null,"selected_total_duration_ms":null,"candidate_timing_coverage":null}},"sizing":{"runnable_units":null,"max_parallelism_binding":null,"runnable_units_binding":null,"target_time_ms":null,"estimated_required_parallelism":null,"estimated_max_task_duration_ms":null}}`, TestPlan{Selection: &SelectionMetadata{DurationEstimates: &SelectionDurationEstimates{}}, Sizing: &SizingMetadata{}}},
+		{`{"selection":{"applied":false,"strategy":"manual","duration_estimates":{"candidate_total_duration_ms":0,"selected_total_duration_ms":0,"candidate_timing_coverage":0}},"sizing":{"runnable_units":0,"max_parallelism_binding":false,"runnable_units_binding":false,"target_time_ms":0.5,"estimated_required_parallelism":0,"estimated_max_task_duration_ms":0}}`, TestPlan{
+			Selection: &SelectionMetadata{Applied: &no, Strategy: &strategy, DurationEstimates: &SelectionDurationEstimates{CandidateTotalDurationMS: &zero, SelectedTotalDurationMS: &zero, CandidateTimingCoverage: fp(0)}},
+			Sizing:    &SizingMetadata{RunnableUnits: &zero, MaxParallelismBinding: &no, RunnableUnitsBinding: &no, TargetTimeMS: fp(0.5), EstimatedRequiredParallelism: &zero, EstimatedMaxTaskDurationMS: &zero},
+		}},
+	} {
+		var got TestPlan
+		if err := json.Unmarshal([]byte(tt.body), &got); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("decode %s (-want +got):\n%s", tt.body, diff)
+		}
+		encoded, err := json.Marshal(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var roundTrip TestPlan
+		if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got, roundTrip); diff != "" {
+			t.Errorf("round trip lost presence (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Make `bktec plan` and `run` explain both the selection requested by a CI script and what the returned plan actually did. Keep planning output in one compact stderr group, with the version on a normal line and JSON stdout unchanged.

For example, a cached plan can now report `Applied strategy: manual` and `Selected: 1 of 4 test selectors (25%)` even when this invocation requests another strategy. With the new backend metadata, it can also distinguish reaching the maximum nodes from a binding cap, and report a 13s P90 longest-node estimate exceeding an 8s sizing target without claiming a mean-based sizing decision missed its target.

### Context

- Parent plan: [TE-7040](https://linear.app/buildkite/issue/TE-7040).
- Overlaps the selection-summary work in [#637](https://github.com/buildkite/test-engine-client/pull/637); coordinate before landing either. This PR also adds requested settings, cached-plan provenance, sizing/duration explanations, and log grouping changes.
- Richer returned metadata is supplied by [backend PR buildkite/buildkite#33949](https://github.com/buildkite/buildkite/pull/33949) for [TE-7042](https://linear.app/buildkite/issue/TE-7042), including compatibility with opt-in mean target sizing. Older responses remain supported; selection duration estimates remain feature/coverage gated.

### Changes

- Show requested strategy, bounded parameters, and fixed/dynamic split settings with short existing-plan/fallback notices. Keep ordinary values unquoted and omit matching returned selection parameters.
- Show returned selection counts, applied versus attempted strategy, and comparable estimated duration share when available. Display any nonempty returned strategy name as bounded, escaped text, including future server names; applied status stays authoritative. Truncate long returned names/reasons without splitting UTF-8.
- Label the returned sizing-decision basis (mean/P90, or unavailable/unknown) separately from P90 allocation estimates. Explain applicable targets and independently binding limits; distinguish unusable estimates from insufficient history when the target was not used. Estimates are not runtime guarantees.
- Distinguish taskless planning fallback placeholders (no allocation computed) from populated run fallbacks; preserve raw plan output and execution behavior.

### Testing

Both affected Go packages, focused race tests, and `go vet ./...` passed again for the mean-sizing compatibility follow-up, along with five built-CLI raw-output scenarios covering mean/P90 decision bases, absent/unknown bases, and unusable timings. Initial validation also passed ten built-CLI scenarios; the four original metadata fixtures preserve the initial backend handoff examples. Full-suite runner failures (Cypress/Jest fixtures and a skipped-test panic) also reproduce on unchanged baseline. Review follow-up: placeholder regressions cover JSON/pipeline/raw modes; both affected packages, focused race tests, vet/build, CI-version golangci-lint v2.5.0 (0 issues), and three built-CLI fallback checks pass. Concise-format follow-up: both affected packages, focused race tests, vet/build, formatting/diff checks and exact CI lint v2.5.0 pass; eleven built-CLI scenarios cover cached differing parameters, legacy metadata, taskless/populated fallback, bounded values, binding/reached limits, automatic/sparse/unusable timing and unknown estimators. Normal stderr byte-equals the approved golden. Forward-compatible strategy follow-up: future-name/status, missing/empty-name, unsafe-text and UTF-8 boundary regressions pass, along with both affected packages, focused race, vet/build and CI lint. Eight built-CLI fixtures preserve the approved golden and raw JSON content. No live client/backend integration was run.

Additive metadata only; client can roll out before the backend and leave unavailable details unknown. Rollback is a client revert; no migration or execution-policy change.

### Synthesized output example

Hypothetical data in the current formatter style, verified locally with a synthesized response. This is not captured production output or proof of live client/backend integration. It requires this client and the backend metadata in #33949, plus the applicable feature and timing-coverage availability; `dev` is a placeholder version.

```text
+++ Buildkite Test Engine Client: Planning
bktec dev

Requested
  Selection strategy: xgboost
    duration_proportion_cutoff = 0.5
  Target time: 10s
  Maximum nodes: 4

Selection summary
  Applied strategy: xgboost
  Selected: 40 of 100 test selectors (40%)
  Estimated compute: 60s of 120s (50%)
  Candidate timing coverage: 100%

Split summary
  40 selectors across 4 nodes
  Target time: 10s
  Estimated nodes needed: 6 (mean durations)
  Node limit: capped at 4
  Estimated longest node: 18s (P90 durations; target exceeded)
  Historical timings: 40 of 40 selectors (100%)
```

### Related

- Resolves TE-7041
- Resolves TE-7043

